### PR TITLE
Update line length limit to 120 characters

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,7 +2,7 @@
 include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
-line_length=79
+line_length=120
 profile=black
 
 ; 3 stands for Vertical Hanging Indent, e.g.

--- a/.pylintrc
+++ b/.pylintrc
@@ -264,7 +264,7 @@ indent-after-paren=4
 indent-string='    '
 
 # Maximum number of characters on a single line.
-max-line-length=79
+max-line-length=120
 
 # Maximum number of lines in a module.
 max-module-lines=1000

--- a/checkers/file_header_checker.py
+++ b/checkers/file_header_checker.py
@@ -3,9 +3,7 @@
 
 from pylint.checkers import BaseRawFileChecker
 
-COPYWRITE_STRING = (
-    "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\n"
-)
+COPYWRITE_STRING = "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\n"
 COPYWRITE_BYTES = bytes(COPYWRITE_STRING, "utf-8")
 LICENSE_STRING = "# SPDX-License-Identifier: Apache-2.0"
 LICENSE_BYTES = bytes(LICENSE_STRING, "utf-8")
@@ -17,9 +15,7 @@ class FileHeaderChecker(BaseRawFileChecker):
         "E1234": (
             "File has missing or malformed header",
             "missing-header",
-            "All files must have required header: \n"
-            + COPYWRITE_STRING
-            + LICENSE_STRING,
+            "All files must have required header: \n" + COPYWRITE_STRING + LICENSE_STRING,
         ),
     }
     options = ()

--- a/opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py
+++ b/opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py
@@ -3,10 +3,7 @@
 
 from unittest import TestCase
 
-from opentelemetry.distro.aws_opentelemetry_configurator import (
-    AwsOpenTelemetryConfigurator,
-    AwsTracerProvider,
-)
+from opentelemetry.distro.aws_opentelemetry_configurator import AwsOpenTelemetryConfigurator, AwsTracerProvider
 
 
 class TestAwsOpenTelemetryConfigurator(TestCase):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-line-length = 79
+line-length = 120
 exclude = '''
 (
   \.git

--- a/scripts/check_for_valid_readme.py
+++ b/scripts/check_for_valid_readme.py
@@ -16,12 +16,8 @@ def is_valid_rst(path):
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(
-        description="Checks README.rst file in path for syntax errors."
-    )
-    parser.add_argument(
-        "paths", nargs="+", help="paths containing a README.rst to test"
-    )
+    parser = argparse.ArgumentParser(description="Checks README.rst file in path for syntax errors.")
+    parser.add_argument("paths", nargs="+", help="paths containing a README.rst to test")
     parser.add_argument("-v", "--verbose", action="store_true")
     return parser.parse_args()
 


### PR DESCRIPTION
79 characters was very agressive and decreased readability. Increase to 120 for a more modern limit. Also applied the linter with  python scripts/eachdist.py lint.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

