### PR TITLE
Fix Black linter

### DIFF
--- a/opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
+++ b/opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
@@ -7,9 +7,7 @@ from opentelemetry.trace import set_tracer_provider
 
 
 class AwsTracerProvider(TracerProvider):
-    def __init__(
-            self
-    ):
+    def __init__(self):
         pass
         # TODO:
         # 1. Add SpanMetricsProcessor to generate AppSignal metrics from spans and exports them

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,2 @@
 [tool.black]
 line-length = 120
-exclude = '''
-(
-  \.git
-  | \.tox
-  | venv
-  | build
-  | dist
-)
-'''

--- a/scripts/eachdist.py
+++ b/scripts/eachdist.py
@@ -185,15 +185,11 @@ def parse_args(args=None):
         ),
     )
 
-    instparser = subparsers.add_parser(
-        "install", help="Install all distributions."
-    )
+    instparser = subparsers.add_parser("install", help="Install all distributions.")
 
     def setup_instparser(instparser):
         instparser.set_defaults(func=install_args)
-        instparser.add_argument(
-            "pipargs", nargs=argparse.REMAINDER, help=extraargs_help("pip")
-        )
+        instparser.add_argument("pipargs", nargs=argparse.REMAINDER, help=extraargs_help("pip"))
 
     setup_instparser(instparser)
     instparser.add_argument("--editable", "-e", action="store_true")
@@ -213,9 +209,7 @@ def parse_args(args=None):
         with_test_deps=True,
     )
 
-    lintparser = subparsers.add_parser(
-        "lint", help="Lint everything, autofixing if possible."
-    )
+    lintparser = subparsers.add_parser("lint", help="Lint everything, autofixing if possible.")
     lintparser.add_argument("--check-only", action="store_true")
     lintparser.set_defaults(func=lint_args)
 
@@ -224,9 +218,7 @@ def parse_args(args=None):
         help="Test everything (run pytest yourself for more complex operations).",
     )
     testparser.set_defaults(func=test_args)
-    testparser.add_argument(
-        "pytestargs", nargs=argparse.REMAINDER, help=extraargs_help("pytest")
-    )
+    testparser.add_argument("pytestargs", nargs=argparse.REMAINDER, help=extraargs_help("pytest"))
 
     fmtparser = subparsers.add_parser(
         "format",
@@ -263,12 +255,7 @@ def find_targets_unordered(rootpath):
 
 
 def getlistcfg(strval):
-    return [
-        val.strip()
-        for line in strval.split("\n")
-        for val in line.split(",")
-        if val.strip()
-    ]
+    return [val.strip() for line in strval.split("\n") for val in line.split(",") if val.strip()]
 
 
 def find_targets(mode, rootpath):
@@ -281,11 +268,7 @@ def find_targets(mode, rootpath):
 
     targets = list(find_targets_unordered(rootpath))
     if "extraroots" in mcfg:
-        targets += [
-            path
-            for extraglob in getlistcfg(mcfg["extraroots"])
-            for path in rootpath.glob(extraglob)
-        ]
+        targets += [path for extraglob in getlistcfg(mcfg["extraroots"]) for path in rootpath.glob(extraglob)]
     if "sortfirst" in mcfg:
         sortfirst = getlistcfg(mcfg["sortfirst"])
 
@@ -319,9 +302,7 @@ def find_targets(mode, rootpath):
                 for target in targets
                 for subglob in subglobs
                 # We need to special-case the dot, because glob fails to parse that with an IndexError.
-                for subdir in (
-                    (target,) if subglob == "." else target.glob(subglob)
-                )
+                for subdir in ((target,) if subglob == "." else target.glob(subglob))
             )
             if ".egg-info" not in str(newentry) and newentry.exists()
         ]
@@ -361,9 +342,7 @@ def runsubprocess(dry_run, params, *args, **kwargs):
     try:
         return subprocess_run(params, *args, check=check, **kwargs)
     except OSError as exc:
-        raise ValueError(
-            "Failed executing " + repr(params) + ": " + str(exc)
-        ) from exc
+        raise ValueError("Failed executing " + repr(params) + ": " + str(exc)) from exc
 
 
 def execute_args(args):
@@ -388,9 +367,7 @@ def execute_args(args):
         )
 
     def _runcmd(cmd):
-        result = runsubprocess(
-            args.dry_run, shlex.split(cmd), cwd=rootpath, check=False
-        )
+        result = runsubprocess(args.dry_run, shlex.split(cmd), cwd=rootpath, check=False)
         if result is not None and result.returncode not in args.allowexitcode:
             print(
                 f"'{cmd}' failed with code {result.returncode}",
@@ -399,9 +376,7 @@ def execute_args(args):
             sys.exit(result.returncode)
 
     if args.all:
-        allstr = args.allsep.join(
-            fmt_for_path(args.all, path) for path in targets
-        )
+        allstr = args.allsep.join(fmt_for_path(args.all, path) for path in targets)
         cmd = args.format.format(allstr)
         _runcmd(cmd)
     else:
@@ -492,8 +467,7 @@ def lint_args(args):
 
     runsubprocess(
         args.dry_run,
-        ("black", "--config", f"{rootdir}/pyproject.toml", ".")
-        + (("--diff", "--check") if args.check_only else ()),
+        ("black", "--config", f"{rootdir}/pyproject.toml", ".") + (("--diff", "--check") if args.check_only else ()),
         cwd=rootdir,
         check=True,
     )
@@ -509,11 +483,7 @@ def lint_args(args):
         ("flake8", "--config", f"{rootdir}/.flake8", rootdir),
         check=True,
     )
-    execute_args(
-        parse_subargs(
-            args, ("exec", "pylint {}", "--all", "--mode", "lintroots")
-        )
-    )
+    execute_args(parse_subargs(args, ("exec", "pylint {}", "--all", "--mode", "lintroots")))
     execute_args(
         parse_subargs(
             args,


### PR DESCRIPTION
The Black linter was configured with an "exclude" file that was not correctly made - it was excluding anything with "dist" in the path, which included eachdist.py and the opentelemetry-distro directory. By default[1], Black uses the .gitignore file, which is a superset of what was specified in the exclude file, so just use that. Also ran and applied the linter.

[1] https://black.readthedocs.io/en/stable/usage_and_configuration/file_collection_and_discovery.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

