### PR TITLE
Add AwsAttributeKeys

### DIFF
--- a/opentelemetry-distro/src/amazon/opentelemetry/distro/aws_attribute_keys.py
+++ b/opentelemetry-distro/src/amazon/opentelemetry/distro/aws_attribute_keys.py
@@ -1,0 +1,24 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
+class AwsAttributeKeys:
+    """Utility class holding attribute keys with special meaning to AWS components"""
+
+    AWS_SPAN_KIND: str = "aws.span.kind"
+    AWS_LOCAL_SERVICE: str = "aws.local.service"
+    AWS_LOCAL_OPERATION: str = "aws.local.operation"
+    AWS_REMOTE_SERVICE: str = "aws.remote.service"
+    AWS_REMOTE_OPERATION: str = "aws.remote.operation"
+    AWS_REMOTE_TARGET: str = "aws.remote.target"
+    AWS_SDK_DESCENDANT: str = "aws.sdk.descendant"
+    AWS_CONSUMER_PARENT_SPAN_KIND: str = "aws.consumer.parent.span.kind"
+
+    # Use the same AWS Resource attribute name defined by OTel java auto-instr for aws_sdk_v_1_1
+    # TODO: all AWS specific attributes should be defined in semconv package and reused cross all
+    #   otel packages. Related sim - https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8710
+
+    AWS_BUCKET_NAME: str = "aws.bucket.name"
+    AWS_QUEUE_NAME: str = "aws.queue.name"
+    AWS_STREAM_NAME: str = "aws.stream.name"
+    AWS_TABLE_NAME: str = "aws.table.name"


### PR DESCRIPTION
AwsAttributeKeys holds useful attribute keys needed by multiple other classes. This is a roughly-carbon-copy file of https://github.com/aws-observability/aws-otel-java-instrumentation/blob/main/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAttributeKeys.java

Callout: https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8710 has been resolved, and a new issue needs to be opened. The larger problem is that the `AWS_*_NAME` attributes only exist in Java. We will either need to add these to Python or (more likely) move away from these attributes and towards ones accepted in the [AWS service specific attributes semantic conventions](https://opentelemetry.io/docs/specs/semconv/cloud-providers/aws-sdk/#aws-service-specific-attributes). I've cut a backlog item for this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

