### PR TITLE
Enable Flake8 line length

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,8 +1,6 @@
 [flake8]
+max-line-length = 120
 ignore =
-  # line too long, defer to black
-  E501
-
   # allow line breaks before binary ops
   W503
 


### PR DESCRIPTION
Prior to this commit, we were only linting code length, as Black linter does not check comments. This lead to inconsistent files, and is resolved by enabling flake8 line length rules, which checks both code and comments

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

