### PR TITLE
Add AwsAlwaysRecordSampler.

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/always_record_sampler.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/always_record_sampler.py
@@ -13,7 +13,7 @@ from opentelemetry.util.types import Attributes
 
 _logger: Logger = getLogger(__name__)
 
-_OTEL_SAMPLER_ENTRY_POINT_GROUP = "opentelemetry_traces_sampler"
+_OTEL_SAMPLER_ENTRY_POINT_GROUP: str = "opentelemetry_traces_sampler"
 
 
 class AlwaysRecordSampler(Sampler):
@@ -33,6 +33,8 @@ class AlwaysRecordSampler(Sampler):
     _root_sampler: Sampler
 
     def __init__(self, root_sampler: Sampler):
+        if not root_sampler:
+            raise ValueError("root_sampler must not be None")
         self._root_sampler = root_sampler
 
     @override
@@ -55,8 +57,6 @@ class AlwaysRecordSampler(Sampler):
 
     @override
     def get_description(self) -> str:
-        if not self._root_sampler:
-            raise ValueError("root_sampler must not be None")
         return "AlwaysRecordSampler{" + self._root_sampler.get_description() + "}"
 
 

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
@@ -1,8 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-from amazon.opentelemetry.distro.attribute_propagating_span_processor_builder import (
-    AttributePropagatingSpanProcessorBuilder,
-)
 from opentelemetry.sdk._configuration import _BaseConfigurator
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
@@ -11,15 +8,14 @@ from opentelemetry.trace import set_tracer_provider
 
 class AwsTracerProvider(TracerProvider):
     def __init__(self):
-        # Add this if you want to see metrics in testing
         super(AwsTracerProvider, self).__init__()
         self.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
-        self.add_span_processor(AttributePropagatingSpanProcessorBuilder().build())
         # TODO:
         # 1. Remove BatchSpanProcessor(ConsoleSpanExporter())) and update testing instructions
         # 2. Add SpanMetricsProcessor to generate AppSignal metrics from spans and exports them
         # 3. Add AwsMetricAttributesSpanExporter to add more attributes to all spans.
         # 4. Add AlwaysRecordSampler to record all spans.
+        # 5. Add AttributePropagatingSpanProcessor to propagate span attributes from parent to child.
 
 
 class AwsOpenTelemetryConfigurator(_BaseConfigurator):

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_always_record_sampler.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_always_record_sampler.py
@@ -3,11 +3,11 @@
 from unittest import TestCase
 
 from amazon.opentelemetry.distro.always_record_sampler import AlwaysRecordSampler
-from opentelemetry.sdk.trace.sampling import Sampler
+from opentelemetry.sdk.trace.sampling import Decision, Sampler, StaticSampler
 
 
 class TestAlwaysRecordSampler(TestCase):
     def test_basic(self):
-        sampler: Sampler = AlwaysRecordSampler(None)
-        with self.assertRaises(ValueError):
-            sampler.get_description()
+        root_sampler: Sampler = StaticSampler(Decision.DROP)
+        sampler: Sampler = AlwaysRecordSampler(root_sampler)
+        self.assertIn("AlwaysRecordSampler", sampler.get_description())


### PR DESCRIPTION
This commit add `AwsAlwaysRecordSampler` along with basic unit test. 

The `AwsAlwaysRecordSampler` initialize the basic sampler by reading environment variable. If no sampler related environment variable provided, it initialize the default sampler. The sampler initialization works similar as opentelemetry default distro configuration: https://github.com/open-telemetry/opentelemetry-python/blob/da48e0b131ff34ff382b7d1206f71b2e31929cab/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py#L304

Then `AwsAlwaysRecordSampler` wrap the basic sampler decision to be `RECORD_ONLY`.  As much as possible, we are attempting to mirror the implementation of these class found in https://github.com/aws-observability/aws-otel-java-instrumentation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

