### PR TITLE
Move shareable constants to module level

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_aws_attribute_keys.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_aws_attribute_keys.py
@@ -1,24 +1,12 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+"""Utility module holding attribute keys with special meaning to AWS components"""
 
-
-class _AwsAttributeKeys:
-    """Utility class holding attribute keys with special meaning to AWS components"""
-
-    AWS_SPAN_KIND: str = "aws.span.kind"
-    AWS_LOCAL_SERVICE: str = "aws.local.service"
-    AWS_LOCAL_OPERATION: str = "aws.local.operation"
-    AWS_REMOTE_SERVICE: str = "aws.remote.service"
-    AWS_REMOTE_OPERATION: str = "aws.remote.operation"
-    AWS_REMOTE_TARGET: str = "aws.remote.target"
-    AWS_SDK_DESCENDANT: str = "aws.sdk.descendant"
-    AWS_CONSUMER_PARENT_SPAN_KIND: str = "aws.consumer.parent.span.kind"
-
-    # Use the same AWS Resource attribute name defined by OTel java auto-instr for aws_sdk_v_1_1
-    # TODO: all AWS specific attributes should be defined in semconv package and reused cross all
-    #   otel packages. Related sim - https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/8710
-
-    AWS_BUCKET_NAME: str = "aws.bucket.name"
-    AWS_QUEUE_NAME: str = "aws.queue.name"
-    AWS_STREAM_NAME: str = "aws.stream.name"
-    AWS_TABLE_NAME: str = "aws.table.name"
+AWS_SPAN_KIND: str = "aws.span.kind"
+AWS_LOCAL_SERVICE: str = "aws.local.service"
+AWS_LOCAL_OPERATION: str = "aws.local.operation"
+AWS_REMOTE_SERVICE: str = "aws.remote.service"
+AWS_REMOTE_OPERATION: str = "aws.remote.operation"
+AWS_REMOTE_TARGET: str = "aws.remote.target"
+AWS_SDK_DESCENDANT: str = "aws.sdk.descendant"
+AWS_CONSUMER_PARENT_SPAN_KIND: str = "aws.consumer.parent.span.kind"

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_aws_span_processing_util.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_aws_span_processing_util.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Utility module designed to support shared logic across AWS Span Processors."""
-from amazon.opentelemetry.distro._aws_attribute_keys import _AwsAttributeKeys
+from amazon.opentelemetry.distro._aws_attribute_keys import AWS_CONSUMER_PARENT_SPAN_KIND, AWS_LOCAL_OPERATION
 from opentelemetry.sdk.trace import InstrumentationScope, ReadableSpan
 from opentelemetry.semconv.trace import MessagingOperationValues, SpanAttributes
 from opentelemetry.trace import SpanKind
@@ -35,7 +35,7 @@ def get_ingress_operation(__, span: ReadableSpan) -> str:
 def get_egress_operation(span: ReadableSpan) -> str:
     if should_use_internal_operation(span):
         return INTERNAL_OPERATION
-    return span.attributes.get(_AwsAttributeKeys.AWS_LOCAL_OPERATION)
+    return span.attributes.get(AWS_LOCAL_OPERATION)
 
 
 def extract_api_path_value(http_target: str) -> str:
@@ -117,7 +117,7 @@ def _is_dependency_consumer_span(span: ReadableSpan) -> bool:
     if is_consumer_process_span(span):
         if is_local_root(span):
             return True
-        parent_span_kind: str = span.attributes.get(_AwsAttributeKeys.AWS_CONSUMER_PARENT_SPAN_KIND)
+        parent_span_kind: str = span.attributes.get(AWS_CONSUMER_PARENT_SPAN_KIND)
         return SpanKind.CONSUMER != parent_span_kind
 
     return True

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/attribute_propagating_span_processor.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/attribute_propagating_span_processor.py
@@ -4,7 +4,7 @@ from typing import Callable, Optional, Tuple
 
 from typing_extensions import override
 
-from amazon.opentelemetry.distro._aws_attribute_keys import _AwsAttributeKeys
+from amazon.opentelemetry.distro._aws_attribute_keys import AWS_CONSUMER_PARENT_SPAN_KIND, AWS_SDK_DESCENDANT
 from amazon.opentelemetry.distro._aws_span_processing_util import is_aws_sdk_span, is_local_root
 from opentelemetry.context import Context
 from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
@@ -48,7 +48,7 @@ class AttributePropagatingSpanProcessor(SpanProcessor):
             # It's assumed that the HTTP spans are immediate children of the AWS SDK span
             # TODO: we should have a contract test to check the immediate children are HTTP span
             if is_aws_sdk_span(parent_span):
-                span.set_attribute(_AwsAttributeKeys.AWS_SDK_DESCENDANT, "true")
+                span.set_attribute(AWS_SDK_DESCENDANT, "true")
 
             if SpanKind.INTERNAL == parent_span.kind:
                 for key_to_propagate in self._attribute_keys_to_propagate:
@@ -60,7 +60,7 @@ class AttributePropagatingSpanProcessor(SpanProcessor):
             # To work around this, add the AWS_CONSUMER_PARENT_SPAN_KIND attribute if parent and child are both CONSUMER
             # then check later if a metric should be generated.
             if _is_consumer_kind(span) and _is_consumer_kind(parent_span):
-                span.set_attribute(_AwsAttributeKeys.AWS_CONSUMER_PARENT_SPAN_KIND, parent_span.kind.name)
+                span.set_attribute(AWS_CONSUMER_PARENT_SPAN_KIND, parent_span.kind.name)
 
         propagation_data: str = None
         if is_local_root(span):

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/attribute_propagating_span_processor_builder.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/attribute_propagating_span_processor_builder.py
@@ -2,7 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 from typing import Callable, List, Tuple
 
-from amazon.opentelemetry.distro._aws_attribute_keys import _AwsAttributeKeys
+from amazon.opentelemetry.distro._aws_attribute_keys import (
+    AWS_LOCAL_OPERATION,
+    AWS_REMOTE_OPERATION,
+    AWS_REMOTE_SERVICE,
+)
 from amazon.opentelemetry.distro._aws_span_processing_util import get_ingress_operation
 from amazon.opentelemetry.distro.attribute_propagating_span_processor import AttributePropagatingSpanProcessor
 from opentelemetry.sdk.trace import ReadableSpan
@@ -16,10 +20,10 @@ class AttributePropagatingSpanProcessorBuilder:
     """
 
     _propagation_data_extractor: str = get_ingress_operation
-    _propagation_data_key: str = _AwsAttributeKeys.AWS_LOCAL_OPERATION
+    _propagation_data_key: str = AWS_LOCAL_OPERATION
     _attributes_keys_to_propagate: Tuple[str, ...] = (
-        _AwsAttributeKeys.AWS_REMOTE_SERVICE,
-        _AwsAttributeKeys.AWS_REMOTE_OPERATION,
+        AWS_REMOTE_SERVICE,
+        AWS_REMOTE_OPERATION,
     )
 
     def set_propagation_data_extractor(

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/metric_attribute_generator.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/metric_attribute_generator.py
@@ -3,6 +3,9 @@
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import BoundedAttributes, ReadableSpan
 
+SERVICE_METRIC: str = "Service"
+DEPENDENCY_METRIC: str = "Dependency"
+
 
 class MetricAttributeGenerator:
     """MetricAttributeGenerator is an interface for generating metric attributes from a span.
@@ -10,9 +13,6 @@ class MetricAttributeGenerator:
     Metric attribute generator defines an interface for classes that can generate specific attributes to be used by an
     AwsSpanMetricsProcessor to produce metrics and by AwsMetricAttributesSpanExporter to wrap the original span.
     """
-
-    SERVICE_METRIC: str = "Service"
-    DEPENDENCY_METRIC: str = "Dependency"
 
     @staticmethod
     def generate_metric_attributes_dict_from_span(span: ReadableSpan, resource: Resource) -> [str, BoundedAttributes]:


### PR DESCRIPTION
In this commit we are moving constants out of classes and into modules, to make it easier to reference them in code. Also, we are removing AWS_*_NAME attributes fomr AwsAttributeKeys, since these attributes are not present in Python implementation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

