### PR TITLE
Add AwsMetricAttributeGenerator

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_aws_metric_attribute_generator.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_aws_metric_attribute_generator.py
@@ -1,8 +1,68 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-from amazon.opentelemetry.distro.metric_attribute_generator import MetricAttributeGenerator
-from opentelemetry.sdk.resources import Resource
+from logging import DEBUG, Logger, getLogger
+from typing import Optional
+from urllib.parse import ParseResult, urlparse
+
+from amazon.opentelemetry.distro._aws_attribute_keys import (
+    AWS_LOCAL_OPERATION,
+    AWS_LOCAL_SERVICE,
+    AWS_REMOTE_OPERATION,
+    AWS_REMOTE_SERVICE,
+    AWS_REMOTE_TARGET,
+    AWS_SPAN_KIND,
+)
+from amazon.opentelemetry.distro._aws_span_processing_util import (
+    LOCAL_ROOT,
+    UNKNOWN_OPERATION,
+    UNKNOWN_REMOTE_OPERATION,
+    UNKNOWN_REMOTE_SERVICE,
+    UNKNOWN_SERVICE,
+    extract_api_path_value,
+    get_egress_operation,
+    get_ingress_operation,
+    is_key_present,
+    is_local_root,
+    should_generate_dependency_metric_attributes,
+    should_generate_service_metric_attributes,
+)
+from amazon.opentelemetry.distro.metric_attribute_generator import (
+    DEPENDENCY_METRIC,
+    SERVICE_METRIC,
+    MetricAttributeGenerator,
+)
+from opentelemetry.sdk.resources import Resource, ResourceAttributes
 from opentelemetry.sdk.trace import BoundedAttributes, ReadableSpan
+from opentelemetry.semconv.trace import SpanAttributes
+
+# Pertinent OTEL attribute keys
+_SERVICE_NAME: str = ResourceAttributes.SERVICE_NAME
+_DB_OPERATION: str = SpanAttributes.DB_OPERATION
+_DB_SYSTEM: str = SpanAttributes.DB_SYSTEM
+_FAAS_INVOKED_NAME: str = SpanAttributes.FAAS_INVOKED_NAME
+_FAAS_TRIGGER: str = SpanAttributes.FAAS_TRIGGER
+_GRAPHQL_OPERATION_TYPE: str = SpanAttributes.GRAPHQL_OPERATION_TYPE
+_HTTP_METHOD: str = SpanAttributes.HTTP_METHOD
+_HTTP_STATUS_CODE: str = SpanAttributes.HTTP_STATUS_CODE
+_HTTP_URL: str = SpanAttributes.HTTP_URL
+_MESSAGING_OPERATION: str = SpanAttributes.MESSAGING_OPERATION
+_MESSAGING_SYSTEM: str = SpanAttributes.MESSAGING_SYSTEM
+_NET_PEER_NAME: str = SpanAttributes.NET_PEER_NAME
+_NET_PEER_PORT: str = SpanAttributes.NET_PEER_PORT
+_NET_SOCK_PEER_ADDR: str = SpanAttributes.NET_SOCK_PEER_ADDR
+_NET_SOCK_PEER_PORT: str = SpanAttributes.NET_SOCK_PEER_PORT
+_PEER_SERVICE: str = SpanAttributes.PEER_SERVICE
+_RPC_METHOD: str = SpanAttributes.RPC_METHOD
+_RPC_SERVICE: str = SpanAttributes.RPC_SERVICE
+
+# Special DEPENDENCY attribute value if GRAPHQL_OPERATION_TYPE attribute key is present.
+_GRAPHQL: str = "graphql"
+
+# As per https://opentelemetry.io/docs/specs/semconv/resource/#service, if service name is not specified, SDK defaults
+# the service name to unknown_service:<process name> or just unknown_service.
+_OTEL_UNKNOWN_SERVICE_PREFIX: str = "unknown_service"
+
+_logger: Logger = getLogger(__name__)
 
 
 class _AwsMetricAttributeGenerator(MetricAttributeGenerator):
@@ -19,5 +79,244 @@ class _AwsMetricAttributeGenerator(MetricAttributeGenerator):
     @staticmethod
     def generate_metric_attributes_dict_from_span(span: ReadableSpan, resource: Resource) -> [str, BoundedAttributes]:
         """This method is used by the AwsSpanMetricsProcessor to generate service and dependency metrics"""
-        # TODO
-        return {}
+        attributes_dict: [str, BoundedAttributes] = {}
+        if should_generate_service_metric_attributes(span):
+            attributes_dict[SERVICE_METRIC] = _generate_service_metric_attributes(span, resource)
+        if should_generate_dependency_metric_attributes(span):
+            attributes_dict[DEPENDENCY_METRIC] = _generate_dependency_metric_attributes(span, resource)
+        return attributes_dict
+
+
+def _generate_service_metric_attributes(span: ReadableSpan, resource: Resource) -> BoundedAttributes:
+    attributes: BoundedAttributes = BoundedAttributes(immutable=False)
+    _set_service(resource, span, attributes)
+    _set_ingress_operation(span, attributes)
+    _set_span_kind_for_service(span, attributes)
+    _set_http_status(span, attributes)
+    return attributes
+
+
+def _generate_dependency_metric_attributes(span: ReadableSpan, resource: Resource) -> BoundedAttributes:
+    attributes: BoundedAttributes = BoundedAttributes(immutable=False)
+    _set_service(resource, span, attributes)
+    _set_egress_operation(span, attributes)
+    _set_remote_service_and_operation(span, attributes)
+    _set_remote_target(span, attributes)
+    _set_span_kind_for_dependency(span, attributes)
+    _set_http_status(span, attributes)
+    return attributes
+
+
+def _set_service(resource: Resource, span: ReadableSpan, attributes: BoundedAttributes) -> None:
+    """Service is always derived from SERVICE_NAME"""
+    service: str = resource.attributes.get(_SERVICE_NAME)
+
+    # In practice the service name is never None, but we can be defensive here.
+    if service is None or service.startswith(_OTEL_UNKNOWN_SERVICE_PREFIX):
+        _log_unknown_attribute(AWS_LOCAL_SERVICE, span)
+        service = UNKNOWN_SERVICE
+
+    attributes[AWS_LOCAL_SERVICE] = service
+
+
+def _set_ingress_operation(span: ReadableSpan, attributes: BoundedAttributes) -> None:
+    """
+    Ingress operation (i.e. operation for Server and Consumer spans) will be generated from "http.method + http.target/
+    with the first API path parameter" if the default span name is None, UnknownOperation or http.method value.
+    """
+    operation: str = get_ingress_operation(None, span)
+    if operation == UNKNOWN_OPERATION:
+        _log_unknown_attribute(AWS_LOCAL_OPERATION, span)
+
+    attributes[AWS_LOCAL_OPERATION] = operation
+
+
+def _set_span_kind_for_service(span: ReadableSpan, attributes: BoundedAttributes) -> None:
+    """Span kind is needed for differentiating metrics in the EMF exporter"""
+    span_kind: str = span.kind.name
+    if is_local_root(span):
+        span_kind = LOCAL_ROOT
+
+    attributes[AWS_SPAN_KIND] = span_kind
+
+
+def _set_http_status(span: ReadableSpan, attributes: BoundedAttributes) -> None:
+    if is_key_present(span, _HTTP_STATUS_CODE):
+        return
+
+    status_code: Optional[int] = _get_aws_status_code(span)
+    if status_code is not None:
+        attributes[_HTTP_STATUS_CODE] = status_code
+
+
+def _get_aws_status_code(span: ReadableSpan) -> Optional[int]:
+    """
+    TODO: We need to determine if the same status code issue in Java AWS SDK instrumentation is present in Python.
+    """
+    return None
+
+
+def _set_egress_operation(span: ReadableSpan, attributes: BoundedAttributes) -> None:
+    """
+    Egress operation (i.e. operation for Client and Producer spans) is always derived from a special span attribute,
+    AwsAttributeKeys.AWS_LOCAL_OPERATION. This attribute is generated with a separate SpanProcessor,
+    AttributePropagatingSpanProcessor
+    """
+    operation: str = get_egress_operation(span)
+    if operation is None:
+        _log_unknown_attribute(AWS_LOCAL_OPERATION, span)
+        operation = UNKNOWN_OPERATION
+
+    attributes[AWS_LOCAL_OPERATION] = operation
+
+
+def _set_remote_service_and_operation(span: ReadableSpan, attributes: BoundedAttributes) -> None:
+    """
+    Remote attributes (only for Client and Producer spans) are generated based on low-cardinality span attributes, in
+    priority order.
+
+    The first priority is the AWS Remote attributes, which are generated from manually instrumented span attributes, and
+     are clear indications of customer intent. If AWS Remote attributes are not present, the next highest priority span
+     attribute is Peer Service, which is also a reliable indicator of customer intent. If this is set, it will override
+     AWS_REMOTE_SERVICE identified from any other span attribute, other than AWS Remote attributes.
+
+    After this, we look for the following low-cardinality span attributes that can be used to determine the remote
+    metric attributes:
+    * RPC
+    * DB
+    * FAAS
+    * Messaging
+    * GraphQL - Special case, if GRAPHQL_OPERATION_TYPE is present, we use it for RemoteOperation and set RemoteService
+      to GRAPHQL.
+
+    In each case, these span attributes were selected from the OpenTelemetry trace semantic convention specifications as
+     they adhere to the three following criteria:
+
+    * Attributes are meaningfully indicative of remote service/operation names.
+    * Attributes are defined in the specification to be low cardinality, usually with a low-cardinality list of values.
+    * Attributes are confirmed to have low-cardinality values, based on code analysis.
+
+    if the selected attributes are still producing the UnknownRemoteService or UnknownRemoteOperation, `net.peer.name`,
+    `net.peer.port`, `net.peer.sock.addr` and `net.peer.sock.port` will be used to derive the RemoteService. And
+    `http.method` and `http.url` will be used to derive the RemoteOperation.
+    """
+    remote_service: str = UNKNOWN_REMOTE_SERVICE
+    remote_operation: str = UNKNOWN_REMOTE_OPERATION
+    if is_key_present(span, AWS_REMOTE_SERVICE) or is_key_present(span, AWS_REMOTE_OPERATION):
+        remote_service = _get_remote_service(span, AWS_REMOTE_SERVICE)
+        remote_operation = _get_remote_operation(span, AWS_REMOTE_OPERATION)
+    elif is_key_present(span, _RPC_SERVICE) or is_key_present(span, _RPC_METHOD):
+        remote_service = _normalize_service_name(span, _get_remote_service(span, _RPC_SERVICE))
+        remote_operation = _get_remote_operation(span, _RPC_METHOD)
+    elif is_key_present(span, _DB_SYSTEM) or is_key_present(span, _DB_OPERATION):
+        remote_service = _get_remote_service(span, _DB_SYSTEM)
+        remote_operation = _get_remote_operation(span, _DB_OPERATION)
+    elif is_key_present(span, _FAAS_INVOKED_NAME) or is_key_present(span, _FAAS_TRIGGER):
+        remote_service = _get_remote_service(span, _FAAS_INVOKED_NAME)
+        remote_operation = _get_remote_operation(span, _FAAS_TRIGGER)
+    elif is_key_present(span, _MESSAGING_SYSTEM) or is_key_present(span, _MESSAGING_OPERATION):
+        remote_service = _get_remote_service(span, _MESSAGING_SYSTEM)
+        remote_operation = _get_remote_operation(span, _MESSAGING_OPERATION)
+    elif is_key_present(span, _GRAPHQL_OPERATION_TYPE):
+        remote_service = _GRAPHQL
+        remote_operation = _get_remote_operation(span, _GRAPHQL_OPERATION_TYPE)
+
+    # Peer service takes priority as RemoteService over everything but AWS Remote.
+    if is_key_present(span, _PEER_SERVICE) and not is_key_present(span, AWS_REMOTE_SERVICE):
+        remote_service = _get_remote_service(span, _PEER_SERVICE)
+
+    # Try to derive RemoteService and RemoteOperation from the other related attributes.
+    if remote_service == UNKNOWN_REMOTE_SERVICE:
+        remote_service = _generate_remote_service(span)
+    if remote_operation == UNKNOWN_REMOTE_OPERATION:
+        remote_operation = _generate_remote_operation(span)
+
+    attributes[AWS_REMOTE_SERVICE] = remote_service
+    attributes[AWS_REMOTE_OPERATION] = remote_operation
+
+
+def _get_remote_service(span: ReadableSpan, remote_service_key: str) -> str:
+    remote_service: str = span.attributes.get(remote_service_key)
+    if remote_service is None:
+        remote_service = UNKNOWN_REMOTE_SERVICE
+
+    return remote_service
+
+
+def _get_remote_operation(span: ReadableSpan, remote_operation_key: str) -> str:
+    remote_operation: str = span.attributes.get(remote_operation_key)
+    if remote_operation is None:
+        remote_operation = UNKNOWN_REMOTE_OPERATION
+
+    return remote_operation
+
+
+def _normalize_service_name(span: ReadableSpan, service_name: str) -> str:
+    """
+    TODO: Determine if problems in Java instrumentation are relevant here. Do we need normalization? If so, probably we
+     are looking for boto, not aws-sdk
+    """
+    return service_name
+
+
+def _generate_remote_service(span: ReadableSpan) -> str:
+    remote_service: str = UNKNOWN_REMOTE_SERVICE
+    if is_key_present(span, _NET_PEER_NAME):
+        remote_service = _get_remote_service(span, _NET_PEER_NAME)
+        if is_key_present(span, _NET_PEER_PORT):
+            port: str = str(span.attributes.get(_NET_PEER_PORT))
+            remote_service += ":" + port
+    elif is_key_present(span, _NET_SOCK_PEER_ADDR):
+        remote_service = _get_remote_service(span, _NET_SOCK_PEER_ADDR)
+        if is_key_present(span, _NET_SOCK_PEER_PORT):
+            port: str = str(span.attributes.get(_NET_SOCK_PEER_PORT))
+            remote_service += ":" + port
+    else:
+        _log_unknown_attribute(AWS_REMOTE_SERVICE, span)
+
+    return remote_service
+
+
+def _generate_remote_operation(span: ReadableSpan) -> str:
+    """
+    When the remote call operation is undetermined for http use cases, will try to extract the remote operation name
+    from http url string
+    """
+    remote_operation: str = UNKNOWN_REMOTE_OPERATION
+    if is_key_present(span, _HTTP_URL):
+        http_url: str = span.attributes.get(_HTTP_URL)
+        url: ParseResult = urlparse(http_url)
+        remote_operation = extract_api_path_value(url.path)
+
+    if is_key_present(span, _HTTP_METHOD):
+        http_method: str = span.attributes.get(_HTTP_METHOD)
+        remote_operation = http_method + " " + remote_operation
+
+    if remote_operation == UNKNOWN_REMOTE_OPERATION:
+        _log_unknown_attribute(AWS_REMOTE_OPERATION, span)
+
+    return remote_operation
+
+
+def _set_remote_target(span: ReadableSpan, attributes: BoundedAttributes) -> None:
+    remote_target: Optional[str] = _get_remote_target(span)
+    if remote_target is not None:
+        attributes[AWS_REMOTE_TARGET] = remote_target
+
+
+def _get_remote_target(span: ReadableSpan) -> Optional[str]:
+    """
+    TODO: Keys we depended on in Java for RemoteTarget are not present in Python, we need to determine the path forward
+     here.
+    """
+    return None
+
+
+def _set_span_kind_for_dependency(span: ReadableSpan, attributes: BoundedAttributes) -> None:
+    span_kind: str = span.kind.name
+    attributes[AWS_SPAN_KIND] = span_kind
+
+
+def _log_unknown_attribute(attribute_key: str, span: ReadableSpan) -> None:
+    message: str = "No valid %s value found for %s span %s"
+    _logger.log(DEBUG, message, attribute_key, span.kind.name, str(span.context.span_id))

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_metric_attribute_generator.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_metric_attribute_generator.py
@@ -3,9 +3,15 @@
 from unittest import TestCase
 
 from amazon.opentelemetry.distro._aws_metric_attribute_generator import _AwsMetricAttributeGenerator
+from opentelemetry.sdk.trace import ReadableSpan, Resource
+from opentelemetry.trace import SpanContext
 
 
 class TestAwsMetricAttributeGenerator(TestCase):
     def test_basic(self):
         generator: _AwsMetricAttributeGenerator = _AwsMetricAttributeGenerator()
-        self.assertEqual(generator.generate_metric_attributes_dict_from_span(None, None), {})
+        context: SpanContext = SpanContext(1, 1, False)
+        parent_context: SpanContext = SpanContext(1, 1, False)
+        span: ReadableSpan = ReadableSpan("test", context, parent_context)
+        resource: Resource = Resource({})
+        self.assertEqual(generator.generate_metric_attributes_dict_from_span(span, resource), {})


### PR DESCRIPTION
AwsMetricAttributeGeneratorjava generates the key metrics used by the AwsSpanMetric Processor and Exporter. With some exceptions, this is a roughly-carbon-copy file of https://github.com/aws-observability/aws-otel-java-instrumentation/blob/main/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsMetricAttributeGenerator.java

Exceptions:
* The following classes are not implemented as they solve problems that are specific to Java and we need to pathfind their solutions in Python:
   * _get_aws_status_code
   * _normalize_service_name
   * _get_remote_target
* _generate_remote_operation URL parsing logic is slighly different compared to Java's generateRemoteOperation:
   * In Java. we will not parse the http url if a Malformed exception is thrown. In Python no such exception is thrown, so we always parse.
   * Per documentation [1] Malformed exception is only thrown if the protocol (http/https) is malformed or not recognized. I confirmed with @xiami that this is just a quirk of Java and has no real bearing on the funcitonality, since per OTEL spec, http_url must be well formed

[1] https://docs.oracle.com/javase/8/docs/api/java/net/URL.html#URL-java.lang.String-

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

