### PR TITLE
Fix a behaviour for wrap span with attributes

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_metric_attributes_span_exporter.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_metric_attributes_span_exporter.py
@@ -112,10 +112,9 @@ def wrap_span_with_attributes(span: ReadableSpan, attributes: BoundedAttributes)
     # Copy all attribute in span into update_attributes
     for key, value in original_attributes.items():
         update_attributes[key] = value
-    # Append all attribute in attributes that is not in original_attributes into update_attributes
+    # Replace existing span-attributes if there is same key in Attributes
     for key, value in attributes.items():
-        if key not in update_attributes:
-            update_attributes[key] = value
+        update_attributes[key] = value
 
     if isinstance(original_attributes, BoundedAttributes):
         span._attributes = BoundedAttributes(


### PR DESCRIPTION
*Issue #, if available:*
Fix a behaviour for wrap span with attributes, to match behaviour in Java
*Description of changes:*
Now attributes inputed will replace existing attributes in span attributes with same key in wrap_span_with_attributes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

