### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,18 +9,17 @@ jobs:
   build:
     env:
       # We use these variables to convert between tox and GHA version literals
-      py37: 3.7
       py38: 3.8
       py39: 3.9
       py310: "3.10"
       py311: "3.11"
-      pypy3: "pypy3.7"
+      pypy3: "pypy3.8"
       RUN_MATRIX_COMBINATION: ${{ matrix.python-version }}-${{ matrix.package }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false  # ensures the entire test matrix is run, even if one permutation fails
       matrix:
-        python-version: [ py37, py38, py39, py310, py311, pypy3 ]
+        python-version: [ py38, py39, py310, py311, pypy3 ]
         package: [ "aws-opentelemetry-distro" ]
         os: [ ubuntu-20.04 ]
     steps:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ preconfigured for use with AWS services. Please check out that project too to ge
 understanding of the underlying internals.
 
 ## Python Version Support
-This project ensures compatibility with the following supported Python versions: 3.7, 3.8, 3.9, 3.10, 3.11
+This project ensures compatibility with the following supported Python versions: 3.8, 3.9, 3.10, 3.11
 
 ## Code Style Check
 

--- a/aws-opentelemetry-distro/pyproject.toml
+++ b/aws-opentelemetry-distro/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "AWS OpenTelemetry Python Distro"
 readme = "README.rst"
 license = "Apache-2.0"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 
 dependencies = [
   "opentelemetry-api ~= 1.12",


### PR DESCRIPTION
In this commmit we are removing support for Python 3.7, to align with upstream: https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2152


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

