### PR TITLE
Instrument the sample application using CWOperator.

### DIFF
--- a/sample-applications/vehicle-dealership-sample-app/eks/backend-deployment.yaml
+++ b/sample-applications/vehicle-dealership-sample-app/eks/backend-deployment.yaml
@@ -46,6 +46,7 @@ spec:
               value: "/vehicle-inventory-app"
             - name: DJANGO_SETTINGS_MODULE
               value: "VehicleInventoryApp.settings"
+#              TODO: Remove OTEL_TRACES_SAMPLER when XRay trace sampler is ready
             - name: OTEL_TRACES_SAMPLER
               value: "always_on"
           imagePullPolicy: Always

--- a/sample-applications/vehicle-dealership-sample-app/eks/image-backend-deployment.yaml
+++ b/sample-applications/vehicle-dealership-sample-app/eks/image-backend-deployment.yaml
@@ -54,6 +54,7 @@ spec:
               value: "/image-service-app"
             - name: DJANGO_SETTINGS_MODULE
               value: "ImageServiceApp.settings"
+#              TODO: Remove OTEL_TRACES_SAMPLER when XRay trace sampler is ready
             - name: OTEL_TRACES_SAMPLER
               value: "always_on"
       restartPolicy: Always

--- a/sample-applications/vehicle-dealership-sample-app/script.sh
+++ b/sample-applications/vehicle-dealership-sample-app/script.sh
@@ -21,11 +21,11 @@ export S3_BUCKET=${s3_bucket}
 
 docker-compose build
 
-#eksctl create cluster --name ${cluster_name} --region ${region} --zones ${region}a,${region}b
-#eksctl create addon --name aws-ebs-csi-driver --cluster ${cluster_name} --service-account-role-arn arn:aws:iam::${account}:role/Admin --region ${region} --force
-#
+eksctl create cluster --name ${cluster_name} --region ${region} --zones ${region}a,${region}b
+eksctl create addon --name aws-ebs-csi-driver --cluster ${cluster_name} --service-account-role-arn arn:aws:iam::${account}:role/Admin --region ${region} --force
+
 ./scripts/push-ecr.sh ${region}
-#
-#./scripts/set-permissions.sh ${cluster_name} ${region}
+
+./scripts/set-permissions.sh ${cluster_name} ${region}
 
 ./scripts/deploy-eks.sh


### PR DESCRIPTION
This PR Instrument the sample application using CWOperator by setting up following:
1. annotation: instrumentation.opentelemetry.io/inject-python: "true"
2. run the server with `--noreload`
3. Add `DJANGO_SETTINGS_MODULE` env variable.
4. Add `PYTHONPATH` env variable, this is required as CWOperator instrumentation when application is mount in a specific directory instead of root.
5. Add `OTEL_TRACES_SAMPLER`, this will be removed when Xray remote sampler is ready.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

