### PR TITLE
Fix lint and py3.8 compatibility issues

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_span_metrics_processor.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_span_metrics_processor.py
@@ -1,6 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-from typing import Optional
+from typing import Dict, Optional
 
 from typing_extensions import override
 
@@ -66,7 +66,7 @@ class AwsSpanMetricsProcessor(SpanProcessor):
 
     @override
     def on_end(self, span: ReadableSpan) -> None:
-        attribute_dict: dict[str, BoundedAttributes] = self._generator.generate_metric_attributes_dict_from_span(
+        attribute_dict: Dict[str, BoundedAttributes] = self._generator.generate_metric_attributes_dict_from_span(
             span, self._resource
         )
         for attributes in attribute_dict.values():

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_metric_attribute_generator.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_metric_attribute_generator.py
@@ -1,6 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-from typing import List, Optional
+from typing import Dict, List, Optional
 from unittest import TestCase
 from unittest.mock import MagicMock
 
@@ -117,7 +117,7 @@ class TestAwsMetricAttributeGenerator(TestCase):
         self.parent_span_context.is_valid = False
         self.span_mock.name = _SPAN_NAME_VALUE
 
-        expected_attributes_map: dict[str, BoundedAttributes] = {
+        expected_attributes_map: Dict[str, BoundedAttributes] = {
             SERVICE_METRIC: {
                 AWS_SPAN_KIND: _LOCAL_ROOT,
                 AWS_LOCAL_SERVICE: _SERVICE_NAME_VALUE,
@@ -126,7 +126,7 @@ class TestAwsMetricAttributeGenerator(TestCase):
         }
 
         self.span_mock.kind = SpanKind.SERVER
-        actual_attributes_map: dict[str, BoundedAttributes] = _GENERATOR.generate_metric_attributes_dict_from_span(
+        actual_attributes_map: Dict[str, BoundedAttributes] = _GENERATOR.generate_metric_attributes_dict_from_span(
             self.span_mock, self.resource
         )
         self.assertEqual(actual_attributes_map, expected_attributes_map)
@@ -136,7 +136,7 @@ class TestAwsMetricAttributeGenerator(TestCase):
         self.parent_span_context.is_valid = False
         self.span_mock.name = _SPAN_NAME_VALUE
 
-        expected_attributes_map: dict[str, BoundedAttributes] = {
+        expected_attributes_map: Dict[str, BoundedAttributes] = {
             SERVICE_METRIC: {
                 AWS_SPAN_KIND: _LOCAL_ROOT,
                 AWS_LOCAL_SERVICE: _SERVICE_NAME_VALUE,
@@ -145,7 +145,7 @@ class TestAwsMetricAttributeGenerator(TestCase):
         }
 
         self.span_mock.kind = SpanKind.INTERNAL
-        actual_attributes_map: dict[str, BoundedAttributes] = _GENERATOR.generate_metric_attributes_dict_from_span(
+        actual_attributes_map: Dict[str, BoundedAttributes] = _GENERATOR.generate_metric_attributes_dict_from_span(
             self.span_mock, self.resource
         )
         self.assertEqual(actual_attributes_map, expected_attributes_map)
@@ -158,7 +158,7 @@ class TestAwsMetricAttributeGenerator(TestCase):
             [AWS_REMOTE_SERVICE, AWS_REMOTE_OPERATION], [_AWS_REMOTE_SERVICE_VALUE, _AWS_REMOTE_OPERATION_VALUE]
         )
 
-        expected_attributes_map: dict[str, BoundedAttributes] = {
+        expected_attributes_map: Dict[str, BoundedAttributes] = {
             SERVICE_METRIC: {
                 AWS_SPAN_KIND: _LOCAL_ROOT,
                 AWS_LOCAL_SERVICE: _SERVICE_NAME_VALUE,
@@ -174,7 +174,7 @@ class TestAwsMetricAttributeGenerator(TestCase):
         }
 
         self.span_mock.kind = SpanKind.CLIENT
-        actual_attributes_map: dict[str, BoundedAttributes] = _GENERATOR.generate_metric_attributes_dict_from_span(
+        actual_attributes_map: Dict[str, BoundedAttributes] = _GENERATOR.generate_metric_attributes_dict_from_span(
             self.span_mock, self.resource
         )
         self.assertEqual(actual_attributes_map, expected_attributes_map)
@@ -187,7 +187,7 @@ class TestAwsMetricAttributeGenerator(TestCase):
             [AWS_REMOTE_SERVICE, AWS_REMOTE_OPERATION], [_AWS_REMOTE_SERVICE_VALUE, _AWS_REMOTE_OPERATION_VALUE]
         )
 
-        expected_attributes_map: dict[str, BoundedAttributes] = {
+        expected_attributes_map: Dict[str, BoundedAttributes] = {
             SERVICE_METRIC: {
                 AWS_SPAN_KIND: _LOCAL_ROOT,
                 AWS_LOCAL_SERVICE: _SERVICE_NAME_VALUE,
@@ -203,7 +203,7 @@ class TestAwsMetricAttributeGenerator(TestCase):
         }
 
         self.span_mock.kind = SpanKind.CONSUMER
-        actual_attributes_map: dict[str, BoundedAttributes] = _GENERATOR.generate_metric_attributes_dict_from_span(
+        actual_attributes_map: Dict[str, BoundedAttributes] = _GENERATOR.generate_metric_attributes_dict_from_span(
             self.span_mock, self.resource
         )
         self.assertEqual(actual_attributes_map, expected_attributes_map)
@@ -216,7 +216,7 @@ class TestAwsMetricAttributeGenerator(TestCase):
             [AWS_REMOTE_SERVICE, AWS_REMOTE_OPERATION], [_AWS_REMOTE_SERVICE_VALUE, _AWS_REMOTE_OPERATION_VALUE]
         )
 
-        expected_attributes_map: dict[str, BoundedAttributes] = {
+        expected_attributes_map: Dict[str, BoundedAttributes] = {
             SERVICE_METRIC: {
                 AWS_SPAN_KIND: _LOCAL_ROOT,
                 AWS_LOCAL_SERVICE: _SERVICE_NAME_VALUE,
@@ -232,7 +232,7 @@ class TestAwsMetricAttributeGenerator(TestCase):
         }
 
         self.span_mock.kind = SpanKind.PRODUCER
-        actual_attributes_map: dict[str, BoundedAttributes] = _GENERATOR.generate_metric_attributes_dict_from_span(
+        actual_attributes_map: Dict[str, BoundedAttributes] = _GENERATOR.generate_metric_attributes_dict_from_span(
             self.span_mock, self.resource
         )
         self.assertEqual(actual_attributes_map, expected_attributes_map)

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_metric_attributes_span_exporter.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_metric_attributes_span_exporter.py
@@ -174,8 +174,8 @@ class TestAwsMetricAttributesSpanExporter(TestCase):
             DEPENDENCY_METRIC: dependency_metric,
         }
 
-        self.generator_mock.generate_metric_attributes_dict_from_span.side_effect = (
-            lambda span, resource: attribute_map if span == span_data_mock and resource == self.test_resource else {}
+        self.generator_mock.generate_metric_attributes_dict_from_span.side_effect = lambda span, resource: (
+            attribute_map if span == span_data_mock and resource == self.test_resource else {}
         )
 
         self.aws_metric_attributes_span_exporter.export([span_data_mock])


### PR DESCRIPTION
Fix lint and [py3.8 compatibility issues](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/49#issue-2125663532)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

