### PR TITLE
Remove `set_http_status` logic from AwsMetricAttributeGenerator

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_aws_metric_attribute_generator.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_aws_metric_attribute_generator.py
@@ -43,7 +43,6 @@ _FAAS_INVOKED_NAME: str = SpanAttributes.FAAS_INVOKED_NAME
 _FAAS_TRIGGER: str = SpanAttributes.FAAS_TRIGGER
 _GRAPHQL_OPERATION_TYPE: str = SpanAttributes.GRAPHQL_OPERATION_TYPE
 _HTTP_METHOD: str = SpanAttributes.HTTP_METHOD
-_HTTP_STATUS_CODE: str = SpanAttributes.HTTP_STATUS_CODE
 _HTTP_URL: str = SpanAttributes.HTTP_URL
 _MESSAGING_OPERATION: str = SpanAttributes.MESSAGING_OPERATION
 _MESSAGING_SYSTEM: str = SpanAttributes.MESSAGING_SYSTEM
@@ -92,7 +91,6 @@ def _generate_service_metric_attributes(span: ReadableSpan, resource: Resource) 
     _set_service(resource, span, attributes)
     _set_ingress_operation(span, attributes)
     _set_span_kind_for_service(span, attributes)
-    _set_http_status(span, attributes)
     return attributes
 
 
@@ -103,7 +101,6 @@ def _generate_dependency_metric_attributes(span: ReadableSpan, resource: Resourc
     _set_remote_service_and_operation(span, attributes)
     _set_remote_target(span, attributes)
     _set_span_kind_for_dependency(span, attributes)
-    _set_http_status(span, attributes)
     return attributes
 
 
@@ -138,22 +135,6 @@ def _set_span_kind_for_service(span: ReadableSpan, attributes: BoundedAttributes
         span_kind = LOCAL_ROOT
 
     attributes[AWS_SPAN_KIND] = span_kind
-
-
-def _set_http_status(span: ReadableSpan, attributes: BoundedAttributes) -> None:
-    if is_key_present(span, _HTTP_STATUS_CODE):
-        return
-
-    status_code: Optional[int] = _get_aws_status_code(span)
-    if status_code is not None:
-        attributes[_HTTP_STATUS_CODE] = status_code
-
-
-def _get_aws_status_code(span: ReadableSpan) -> Optional[int]:
-    """
-    TODO: We need to determine if the same status code issue in Java AWS SDK instrumentation is present in Python.
-    """
-    return None
 
 
 def _set_egress_operation(span: ReadableSpan, attributes: BoundedAttributes) -> None:

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_span_metrics_processor.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_span_metrics_processor.py
@@ -94,9 +94,6 @@ class AwsSpanMetricsProcessor(SpanProcessor):
         http_status_code: int = span.attributes.get(_HTTP_STATUS_CODE)
         status_code: StatusCode = span.status.status_code
 
-        if http_status_code is None:
-            http_status_code = attributes.get(_HTTP_STATUS_CODE)
-
         if _is_not_error_or_fault(http_status_code):
             if StatusCode.ERROR == status_code:
                 self._error_histogram.record(0, attributes)

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_metric_attribute_generator.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_metric_attribute_generator.py
@@ -500,8 +500,6 @@ class TestAwsMetricAttributeGenerator(TestCase):
         ).get(DEPENDENCY_METRIC)
         self.assertEqual(actual_attributes.get(AWS_REMOTE_SERVICE), "TestString")
 
-    # TODO: add HTTP_STATUS_CODE based test when http-status-code related implementation ready
-
     def test_no_metric_when_consumer_process_with_consumer_parent(self):
         self._mock_attribute(
             [AWS_CONSUMER_PARENT_SPAN_KIND, SpanAttributes.MESSAGING_OPERATION],


### PR DESCRIPTION
In this commit, we are removing the `set_http_status` logic from AwsMetricAttributeGenerator. This logic was originally in place for parity with Java. In Java, the OTEL instrumentation for AWS SDK does not populate the `http.status_code` attribute for spans, so we had to add logic to extract status code from the exception embedded within the events of the span. However, in Python, we have verified that this is not a problem; `http.status_code` is reliably set and so we do not need this logic. `set_http_status` logic is no longer needed, so this commit seeks to clean up the code by removing it and all code depending on it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

