### PR TITLE
Run contract tests in pr- and main- build workflows

### DIFF
--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -76,4 +76,10 @@ jobs:
           name: aws_opentelemetry_distro-${{ steps.python_output.outputs.ADOT_PYTHON_VERSION}}-py3-none-any.whl
           path: dist/${{ steps.staging_wheel_output.outputs.STAGING_WHEEL}}
 
-#  TODO: Add Contract test and E2E test
+      - name: Set up and run contract tests with pytest
+        run: |
+          bash contract-tests/set-up-contract-tests.sh
+          pip install pytest
+          pytest contract-tests/tests
+
+#  TODO: Add E2E tests

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -44,4 +44,8 @@ jobs:
       - name: run spell check tox
         run: tox -e ${{ matrix.tox-environment }}
 
-#     TODO: Add Contract test.
+      - name: Set up and run contract tests with pytest
+        run: |
+          bash contract-tests/set-up-contract-tests.sh
+          pip install pytest
+          pytest contract-tests/tests


### PR DESCRIPTION
In this PR, we are adding contract test runs to the pr-build and main-build, following suit with ADOT Java's [pr-build](https://github.com/aws-observability/aws-otel-java-instrumentation/blob/61460af22255d5963df17c77a37ef71ff6f652d8/.github/workflows/pr-build.yml#L90) and [main-build](https://github.com/aws-observability/aws-otel-java-instrumentation/blob/61460af22255d5963df17c77a37ef71ff6f652d8/.github/workflows/main-build.yml#L184). Like in Java, we are running these steps after building and pushing artifacts so we can debug more effectively, if needed. Unlike Java, we are not separating into separate jobs, as there is no clear benefit to doing this, as it just incurs overhead of checking out and building code.

Testing was done by forcing runs on pushes to `contract-tests-workflow`:
* PR: https://github.com/aws-observability/aws-otel-python-instrumentation/actions/runs/7892494255
* Main: https://github.com/aws-observability/aws-otel-python-instrumentation/actions/runs/7892494256

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

