### PR TITLE
Fix main_build.yml

### DIFF
--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -54,7 +54,7 @@ jobs:
           snapshot-ecr-role: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
           push_image: true
           load_image: false
-          python_version: 3.10
+          python_version: "3.10"
           package_name: aws-opentelemetry-distro
           os: ubuntu-latest
 


### PR DESCRIPTION
Main build is failing with: `Error: The version '3.1' with architecture 'x64' was not found for Ubuntu 22.04.` - I suspect this is because it's treating 3.10 as a number (3.1) rather than a string ("3.10").

Failure: https://github.com/aws-observability/aws-otel-python-instrumentation/actions/runs/7911600232/job/21596008343

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

