### PR TITLE
XRay Sampler Enhancements - Use Request 'session', 'with' locks, add jitter for initial Targets Poll

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/sampler/_aws_xray_sampling_client.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/sampler/_aws_xray_sampling_client.py
@@ -22,12 +22,14 @@ class _AwsXRaySamplingClient:
         self.__get_sampling_rules_endpoint = endpoint + "/GetSamplingRules"
         self.__get_sampling_targets_endpoint = endpoint + "/SamplingTargets"
 
+        self.__session = requests.Session()
+
     def get_sampling_rules(self) -> [_SamplingRule]:
         sampling_rules = []
         headers = {"content-type": "application/json"}
 
         try:
-            xray_response = requests.post(url=self.__get_sampling_rules_endpoint, headers=headers, timeout=20)
+            xray_response = self.__session.post(url=self.__get_sampling_rules_endpoint, headers=headers, timeout=20)
             if xray_response is None:
                 _logger.error("GetSamplingRules response is None")
                 return []
@@ -60,7 +62,7 @@ class _AwsXRaySamplingClient:
         )
         headers = {"content-type": "application/json"}
         try:
-            xray_response = requests.post(
+            xray_response = self.__session.post(
                 url=self.__get_sampling_targets_endpoint,
                 headers=headers,
                 timeout=20,

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/sampler/_rule_cache.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/sampler/_rule_cache.py
@@ -75,25 +75,22 @@ class _RuleCache:
                 continue
             temp_rule_appliers.append(_SamplingRuleApplier(sampling_rule, self.__client_id, self._clock))
 
-        self.__cache_lock.acquire()
+        with self.__cache_lock:
+            # map list of rule appliers by each applier's sampling_rule name
+            rule_applier_map: Dict[str, _SamplingRuleApplier] = {
+                applier.sampling_rule.RuleName: applier for applier in self.__rule_appliers
+            }
 
-        # map list of rule appliers by each applier's sampling_rule name
-        rule_applier_map: Dict[str, _SamplingRuleApplier] = {
-            applier.sampling_rule.RuleName: applier for applier in self.__rule_appliers
-        }
-
-        # If a sampling rule has not changed, keep its respective applier in the cache.
-        new_applier: _SamplingRuleApplier
-        for index, new_applier in enumerate(temp_rule_appliers):
-            rule_name_to_check = new_applier.sampling_rule.RuleName
-            if rule_name_to_check in rule_applier_map:
-                old_applier = rule_applier_map[rule_name_to_check]
-                if new_applier.sampling_rule == old_applier.sampling_rule:
-                    temp_rule_appliers[index] = old_applier
-        self.__rule_appliers = temp_rule_appliers
-        self._last_modified = self._clock.now()
-
-        self.__cache_lock.release()
+            # If a sampling rule has not changed, keep its respective applier in the cache.
+            new_applier: _SamplingRuleApplier
+            for index, new_applier in enumerate(temp_rule_appliers):
+                rule_name_to_check = new_applier.sampling_rule.RuleName
+                if rule_name_to_check in rule_applier_map:
+                    old_applier = rule_applier_map[rule_name_to_check]
+                    if new_applier.sampling_rule == old_applier.sampling_rule:
+                        temp_rule_appliers[index] = old_applier
+            self.__rule_appliers = temp_rule_appliers
+            self._last_modified = self._clock.now()
 
     def update_sampling_targets(self, sampling_targets_response: _SamplingTargetResponse) -> (bool, int):
         targets: [_SamplingTarget] = sampling_targets_response.SamplingTargetDocuments
@@ -135,8 +132,5 @@ class _RuleCache:
         return all_statistics
 
     def expired(self) -> bool:
-        self.__cache_lock.acquire()
-        try:
+        with self.__cache_lock:
             return self._clock.now() > self._last_modified + self._clock.time_delta(seconds=CACHE_TTL_SECONDS)
-        finally:
-            self.__cache_lock.release()

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/sampler/aws_xray_remote_sampler.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/sampler/aws_xray_remote_sampler.py
@@ -83,7 +83,9 @@ class AwsXRayRemoteSampler(Sampler):
         self._rules_timer.start()
 
         # set up the target poller to go off once after the default interval. Subsequent polls may use new intervals.
-        self._targets_timer = Timer(DEFAULT_TARGET_POLLING_INTERVAL_SECONDS, self.__start_sampling_target_poller)
+        self._targets_timer = Timer(
+            self.__target_polling_interval + self.__target_polling_jitter, self.__start_sampling_target_poller
+        )
         self._targets_timer.daemon = True  # Ensures that when the main thread exits, the Timer threads are killed
         self._targets_timer.start()
 

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/sampler/test_aws_xray_remote_sampler.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/sampler/test_aws_xray_remote_sampler.py
@@ -86,7 +86,7 @@ class TestAwsXRayRemoteSampler(TestCase):
         self.assertEqual(rs._AwsXRayRemoteSampler__resource.attributes["service.name"], "test-service-name")
         self.assertEqual(rs._AwsXRayRemoteSampler__resource.attributes["cloud.platform"], "test-cloud-platform")
 
-    @patch("requests.post", side_effect=mocked_requests_get)
+    @patch("requests.Session.post", side_effect=mocked_requests_get)
     @patch("amazon.opentelemetry.distro.sampler.aws_xray_remote_sampler.DEFAULT_TARGET_POLLING_INTERVAL_SECONDS", 2)
     def test_update_sampling_rules_and_targets_with_pollers_and_should_sample(self, mock_post=None):
         rs = AwsXRayRemoteSampler(
@@ -113,7 +113,7 @@ class TestAwsXRayRemoteSampler(TestCase):
             rs.should_sample(None, 0, "name", attributes={"abc": "1234"}).decision, Decision.RECORD_AND_SAMPLE
         )
 
-    @patch("requests.post", side_effect=mocked_requests_get)
+    @patch("requests.Session.post", side_effect=mocked_requests_get)
     @patch("amazon.opentelemetry.distro.sampler.aws_xray_remote_sampler.DEFAULT_TARGET_POLLING_INTERVAL_SECONDS", 3)
     def test_multithreading_with_large_reservoir_with_otel_sdk(self, mock_post=None):
         rs = AwsXRayRemoteSampler(
@@ -157,7 +157,7 @@ class TestAwsXRayRemoteSampler(TestCase):
         self.assertEqual(sum_sampled, 100000)
 
     # pylint: disable=no-member
-    @patch("requests.post", side_effect=mocked_requests_get)
+    @patch("requests.Session.post", side_effect=mocked_requests_get)
     @patch("amazon.opentelemetry.distro.sampler.aws_xray_remote_sampler.DEFAULT_TARGET_POLLING_INTERVAL_SECONDS", 2)
     @patch("amazon.opentelemetry.distro.sampler.aws_xray_remote_sampler._Clock", MockClock)
     def test_multithreading_with_some_reservoir_with_otel_sdk(self, mock_post=None):

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/sampler/test_aws_xray_sampling_client.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/sampler/test_aws_xray_sampling_client.py
@@ -16,14 +16,14 @@ DATA_DIR = os.path.join(TEST_DIR, "data")
 
 
 class TestAwsXRaySamplingClient(TestCase):
-    @patch("requests.post")
+    @patch("requests.Session.post")
     def test_get_no_sampling_rules(self, mock_post=None):
         mock_post.return_value.configure_mock(**{"json.return_value": {"SamplingRuleRecords": []}})
         client = _AwsXRaySamplingClient("http://127.0.0.1:2000")
         sampling_rules = client.get_sampling_rules()
         self.assertTrue(len(sampling_rules) == 0)
 
-    @patch("requests.post")
+    @patch("requests.Session.post")
     def test_get_invalid_responses(self, mock_post=None):
         mock_post.return_value.configure_mock(**{"json.return_value": {}})
         client = _AwsXRaySamplingClient("http://127.0.0.1:2000")
@@ -31,7 +31,7 @@ class TestAwsXRaySamplingClient(TestCase):
             sampling_rules = client.get_sampling_rules()
             self.assertTrue(len(sampling_rules) == 0)
 
-    @patch("requests.post")
+    @patch("requests.Session.post")
     def test_get_sampling_rule_missing_in_records(self, mock_post=None):
         mock_post.return_value.configure_mock(**{"json.return_value": {"SamplingRuleRecords": [{}]}})
         client = _AwsXRaySamplingClient("http://127.0.0.1:2000")
@@ -39,7 +39,7 @@ class TestAwsXRaySamplingClient(TestCase):
             sampling_rules = client.get_sampling_rules()
             self.assertTrue(len(sampling_rules) == 0)
 
-    @patch("requests.post")
+    @patch("requests.Session.post")
     def test_default_values_used_when_missing_properties_in_sampling_rule(self, mock_post=None):
         mock_post.return_value.configure_mock(**{"json.return_value": {"SamplingRuleRecords": [{"SamplingRule": {}}]}})
         client = _AwsXRaySamplingClient("http://127.0.0.1:2000")
@@ -61,7 +61,7 @@ class TestAwsXRaySamplingClient(TestCase):
         self.assertEqual(sampling_rule.URLPath, "")
         self.assertEqual(sampling_rule.Version, 0)
 
-    @patch("requests.post")
+    @patch("requests.Session.post")
     def test_get_correct_number_of_sampling_rules(self, mock_post=None):
         sampling_records = []
         with open(f"{DATA_DIR}/get-sampling-rules-response-sample.json", encoding="UTF-8") as file:
@@ -104,7 +104,7 @@ class TestAwsXRaySamplingClient(TestCase):
             self.assertIsNotNone(sampling_rule.Version)
             self.assertEqual(sampling_rule.Version, sampling_record["SamplingRule"]["Version"])
 
-    @patch("requests.post")
+    @patch("requests.Session.post")
     def test_get_sampling_targets(self, mock_post=None):
         with open(f"{DATA_DIR}/get-sampling-targets-response-sample.json", encoding="UTF-8") as file:
             sample_response = json.load(file)
@@ -116,7 +116,7 @@ class TestAwsXRaySamplingClient(TestCase):
         self.assertEqual(len(sampling_targets_response.UnprocessedStatistics), 0)
         self.assertEqual(sampling_targets_response.LastRuleModification, 1707551387.0)
 
-    @patch("requests.post")
+    @patch("requests.Session.post")
     def test_get_invalid_sampling_targets(self, mock_post=None):
         mock_post.return_value.configure_mock(
             **{


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
- Use request Session object to be reused for getting sampling rules/targets
- Use `with` locks to be consistent with lock usage
- Add jitter for initial Targets Poll

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

