### PR TITLE
Support AppSignals metrics transport protocol configuration.

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
@@ -31,6 +31,7 @@ from opentelemetry.sdk._configuration import (
 from opentelemetry.sdk.environment_variables import (
     _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED,
     OTEL_EXPORTER_OTLP_METRICS_PROTOCOL,
+    OTEL_EXPORTER_OTLP_PROTOCOL,
     OTEL_TRACES_SAMPLER_ARG,
 )
 from opentelemetry.sdk.extension.aws.resource.ec2 import AwsEc2ResourceDetector
@@ -226,7 +227,9 @@ class AppSignalsExporterProvider:
 
     # pylint: disable=no-self-use
     def create_exporter(self):
-        protocol = os.environ.get(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL, "grpc")
+        protocol = os.environ.get(
+            OTEL_EXPORTER_OTLP_PROTOCOL, os.environ.get(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL, "grpc")
+        )
         _logger.debug("AppSignals export protocol: %s", protocol)
 
         app_signals_endpoint = os.environ.get(


### PR DESCRIPTION
*Issue #, if available:*

This PR is matching the [aws-otel-java-instrumentation PR ](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/752) to support both http and grpc protocol according the environment variables. 

Testing:
I test the change on EC2 instance using the CWAgent receiving the metrics and traces by running on two sets of environment variables:
1. http:
```
export OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/protobuf
export OTEL_EXPORTER_OTLP_METRICS_PROTOCOL=http/protobuf
export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4316/v1/traces
export OTEL_AWS_APP_SIGNALS_EXPORTER_ENDPOINT=http://localhost:4316/v1/metrics
```
2. grpc:
```
export OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=grpc
export OTEL_EXPORTER_OTLP_METRICS_PROTOCOL=grpc
export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4315
export OTEL_AWS_APP_SIGNALS_EXPORTER_ENDPOINT=http://localhost:4315
```

I has been confirmed that both the traces and metrics are received successfully,  logs and service map shows up in the console:
![Screenshot 2024-02-23 at 11 35 39 AM](https://github.com/aws-observability/aws-otel-python-instrumentation/assets/146124015/200af747-772a-46de-931e-dee96d5f6f57)

![Screenshot 2024-02-23 at 11 36 11 AM](https://github.com/aws-observability/aws-otel-python-instrumentation/assets/146124015/287575b4-6bb1-453a-a54a-9bd3b74e6e9d)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

