### PR TITLE
Fix staging wheel file name

### DIFF
--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -58,10 +58,12 @@ jobs:
           package_name: aws-opentelemetry-distro
           os: ubuntu-latest
 
+        # workaround: prefixing the short-sha with a 0 to create a valid
+        # wheel file name as per https://peps.python.org/pep-0427/#file-name-convention
       - name: Output Wheel File Name
         id: staging_wheel_output
         run: |
-          staging_wheel="aws_opentelemetry_distro-${{ steps.python_output.outputs.ADOT_PYTHON_VERSION}}-${{ env.SHORT_SHA }}-py3-none-any.whl"
+          staging_wheel="aws_opentelemetry_distro-${{ steps.python_output.outputs.ADOT_PYTHON_VERSION}}-0${{ env.SHORT_SHA }}-py3-none-any.whl"
           echo "STAGING_WHEEL=$staging_wheel" >> $GITHUB_OUTPUT
           cd ./dist
           cp aws_opentelemetry_distro-${{ steps.python_output.outputs.ADOT_PYTHON_VERSION}}-py3-none-any.whl $staging_wheel
@@ -73,7 +75,7 @@ jobs:
       - name: Upload Wheel to GitHub Actions
         uses: actions/upload-artifact@v3
         with:
-          name: aws_opentelemetry_distro-${{ steps.python_output.outputs.ADOT_PYTHON_VERSION}}-py3-none-any.whl
+          name: ${{ steps.staging_wheel_output.outputs.STAGING_WHEEL}}
           path: dist/${{ steps.staging_wheel_output.outputs.STAGING_WHEEL}}
 
       - name: Set up and run contract tests with pytest


### PR DESCRIPTION
*Issue #, if available:*
when using the GH short sha, we may generate a wheel file with name as `aws_opentelemetry_distro-0.0.1-fc3f57f-py3-none-any.whl`. This is an invalid wheel file name because as per [convention](https://peps.python.org/pep-0427/#file-name-convention) the "build tag" must start with a digit.
Some times the build may pass or it may fail depending on the value of short-sha. For example:
- Failing build: https://github.com/aws-observability/aws-otel-python-instrumentation/actions/runs/8056055206/job/22004307620
- Passing build: https://github.com/aws-observability/aws-otel-python-instrumentation/actions/runs/8056193097/job/22004775201

*Description of changes:*
- as a workaround, prefix the short sha with a `0` to make it a valid filename.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

