### PR TITLE
Make scripts fail fast

### DIFF
--- a/scripts/build_and_install_distro.sh
+++ b/scripts/build_and_install_distro.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Fail fast
+set -e
+
 # Check script is running in contract-tests
 current_path=`pwd`
 current_dir="${current_path##*/}"
@@ -9,7 +15,7 @@ fi
 
 # Setup - update dependencies and create/empty dist dir
 pip install --upgrade pip setuptools wheel packaging build
-mkdir dist
+mkdir -p dist
 rm -rf dist/aws_opentelemetry_distro*
 
 # Build distro

--- a/scripts/set-up-contract-tests.sh
+++ b/scripts/set-up-contract-tests.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Fail fast
+set -e
+
 # Check script is running in contract-tests
 current_path=`pwd`
 current_dir="${current_path##*/}"


### PR DESCRIPTION
In this commit we are using `set -e` to make our bash scripts for building the distro and setting up contract tests fail fast in the case of errors. Without this change, scripts can fail one command, then run the next, obscuring failures and wasting developer time.

Also, fix `mkdir` to succeed even if the dir already exists with `-p` and add copyright notices.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

