### PR TITLE
disable aws related steps if pr run

### DIFF
--- a/.github/actions/artifacts_build/action.yml
+++ b/.github/actions/artifacts_build/action.yml
@@ -44,7 +44,7 @@ runs:
         run_unit_tests: true
 
     - name: Configure AWS Credentials
-      if: github.event_name != 'pull_request'
+      if: inputs.push_image == true
       uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.snapshot-ecr-role }}
@@ -66,7 +66,7 @@ runs:
       uses: docker/setup-buildx-action@v3
 
     - name: Login to AWS ECR
-      if: github.event_name != 'pull_request'
+      if: inputs.push_image == true
       uses: docker/login-action@v3
       with:
         registry: ${{ inputs.image_registry }}


### PR DESCRIPTION
If a PR is created from a fork, then GitHub secrets are not available to the fork (for security reasons). This will cause the AWS related steps to fail.
So we should skip such steps that rely on the GH secret for PR workflow runs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

