### PR TITLE
fix condition in custom action

### DIFF
--- a/.github/actions/artifacts_build/action.yml
+++ b/.github/actions/artifacts_build/action.yml
@@ -44,7 +44,7 @@ runs:
         run_unit_tests: true
 
     - name: Configure AWS Credentials
-      if: ${{ inputs.push_image == true || inputs.push_image == 'true'}}
+      if: ${{ inputs.push_image == true || inputs.push_image == 'true' }}
       uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.snapshot-ecr-role }}
@@ -66,7 +66,7 @@ runs:
       uses: docker/setup-buildx-action@v3
 
     - name: Login to AWS ECR
-      if: ${{ inputs.push_image == true || inputs.push_image == 'true'}}
+      if: ${{ inputs.push_image == true || inputs.push_image == 'true' }}
       uses: docker/login-action@v3
       with:
         registry: ${{ inputs.image_registry }}


### PR DESCRIPTION
The [previous change did not work](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/85) as expected (failed [run](https://github.com/aws-observability/aws-otel-python-instrumentation/actions/runs/8086789976/job/22097309271) as evidence) since the inputs [are not actually boolean](https://github.com/actions/runner/issues/1483). So we should be comparing against the string `'true'` or `'false'` to make the conditions work correctly.
Unfortunately, GH doesn't yet support input type for custom actions: https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#inputs


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

