### PR TITLE
Add 100/800 TPS tests and Duration functionality

### DIFF
--- a/performance-tests/README.md
+++ b/performance-tests/README.md
@@ -78,7 +78,8 @@ An distroConfig is defined in code as a name, description, flag for instrumentat
 
 Pre-requirements:
 * Have `docker` installed and running - verify by running the `docker` command.
-* Export AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN, and S3_BUCKET environment variables.
+* Export `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, and `S3_BUCKET` environment variables.
+* By default, each distroConfig runs for 10 seconds. To change this, export `DURATION` environment variable (e.g. `60m`).
 
 Steps:
 * From `aws-otel-python-instrumentation` dir, execute:
@@ -90,3 +91,5 @@ cd performance-tests
 ```
 
 The last step can be run or you can run from IDE (after setting environment variables appropriately).
+
+To diagnose test failures with `./gradlew -i test` or use `-d` for very fine details.

--- a/performance-tests/src/test/java/io/opentelemetry/OverheadTests.java
+++ b/performance-tests/src/test/java/io/opentelemetry/OverheadTests.java
@@ -34,6 +34,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
@@ -42,6 +44,7 @@ import org.testcontainers.utility.MountableFile;
 
 public class OverheadTests {
 
+  private static final Logger logger = LoggerFactory.getLogger(OverheadTests.class);
   private static final Network NETWORK = Network.newNetwork();
   private static GenericContainer<?> collector;
   private final NamingConventions namingConventions = new NamingConventions();
@@ -68,11 +71,17 @@ public class OverheadTests {
   }
 
   void runTestConfig(TestConfig config) {
+    logger.warn(
+        String.format("Running test config %s: %s", config.getName(), config.getDescription()));
     runDurations.clear();
     config
         .getDistroConfigs()
         .forEach(
             distroConfig -> {
+              logger.warn(
+                  String.format(
+                      "Running distro config %s: %s (%s)",
+                      distroConfig.getName(), distroConfig.getDescription(), config.getName()));
               try {
                 runAppOnce(config, distroConfig);
               } catch (Exception e) {

--- a/performance-tests/src/test/java/io/opentelemetry/config/Configs.java
+++ b/performance-tests/src/test/java/io/opentelemetry/config/Configs.java
@@ -12,12 +12,23 @@ import java.util.stream.Stream;
 
 /** Defines all test configurations */
 public enum Configs {
-  ALL(
+  ALL_100_TPS(
       TestConfig.builder()
-          .name("all")
-          .description("Compares all DistroConfigs")
+          .name("all-800-tps")
+          .description("Compares all DistroConfigs (100TPS test)")
           .withDistroConfigs(DistroConfig.values())
           .warmupSeconds(60)
+          .maxRequestRate(100)
+          .duration(System.getenv("DURATION"))
+          .build()),
+  ALL_800_TPS(
+      TestConfig.builder()
+          .name("all-800-tps")
+          .description("Compares all DistroConfigs (800TPS test)")
+          .withDistroConfigs(DistroConfig.values())
+          .warmupSeconds(60)
+          .maxRequestRate(800)
+          .duration(System.getenv("DURATION"))
           .build());
 
   public final TestConfig config;

--- a/performance-tests/src/test/java/io/opentelemetry/config/TestConfig.java
+++ b/performance-tests/src/test/java/io/opentelemetry/config/TestConfig.java
@@ -17,14 +17,14 @@ public class TestConfig {
 
   private static final int DEFAULT_MAX_REQUEST_RATE = 0; // none
   private static final int DEFAULT_CONCURRENT_CONNECTIONS = 5;
-  private static final int DEFAULT_TOTAL_ITERATIONS = 5000;
+  private static final String DEFAULT_DURATION = "10s";
 
   private final String name;
   private final String description;
   private final List<DistroConfig> distroConfigs;
   private final int maxRequestRate;
   private final int concurrentConnections;
-  private final int totalIterations;
+  private final String duration;
   private final int warmupSeconds;
 
   public TestConfig(Builder builder) {
@@ -33,7 +33,7 @@ public class TestConfig {
     this.distroConfigs = Collections.unmodifiableList(builder.distroConfigs);
     this.maxRequestRate = builder.maxRequestRate;
     this.concurrentConnections = builder.concurrentConnections;
-    this.totalIterations = builder.totalIterations;
+    this.duration = builder.duration;
     this.warmupSeconds = builder.warmupSeconds;
   }
 
@@ -57,8 +57,8 @@ public class TestConfig {
     return concurrentConnections;
   }
 
-  public int getTotalIterations() {
-    return totalIterations;
+  public String getDuration() {
+    return duration;
   }
 
   public int getWarmupSeconds() {
@@ -75,7 +75,7 @@ public class TestConfig {
     private List<DistroConfig> distroConfigs = new ArrayList<>();
     private int maxRequestRate = DEFAULT_MAX_REQUEST_RATE;
     private int concurrentConnections = DEFAULT_CONCURRENT_CONNECTIONS;
-    private int totalIterations = DEFAULT_TOTAL_ITERATIONS;
+    private String duration = DEFAULT_DURATION;
     public int warmupSeconds = 0;
 
     Builder name(String name) {
@@ -103,8 +103,10 @@ public class TestConfig {
       return this;
     }
 
-    Builder totalIterations(int totalIterations) {
-      this.totalIterations = totalIterations;
+    Builder duration(String duration) {
+      if (duration != null) {
+        this.duration = duration;
+      }
       return this;
     }
 

--- a/performance-tests/src/test/java/io/opentelemetry/containers/K6Container.java
+++ b/performance-tests/src/test/java/io/opentelemetry/containers/K6Container.java
@@ -49,10 +49,10 @@ public class K6Container {
         .withCreateContainerCmdModifier(cmd -> cmd.withUser("root"))
         .withCommand(
             "run",
-            "-u",
+            "--vus",
             String.valueOf(config.getConcurrentConnections()),
-            "-i",
-            String.valueOf(config.getTotalIterations()),
+            "--duration",
+            String.valueOf(config.getDuration()),
             "--rps",
             String.valueOf(config.getMaxRequestRate()),
             "--summary-export",

--- a/performance-tests/src/test/java/io/opentelemetry/results/PrintStreamPersister.java
+++ b/performance-tests/src/test/java/io/opentelemetry/results/PrintStreamPersister.java
@@ -29,9 +29,7 @@ class PrintStreamPersister implements ResultsPersister {
     out.println("----------------------------------------------------------");
     out.println(" Run at " + new Date());
     out.printf(" %s : %s\n", config.getName(), config.getDescription());
-    out.printf(
-        " %d users, %d iterations\n",
-        config.getConcurrentConnections(), config.getTotalIterations());
+    out.printf(" %d users, %s duration\n", config.getConcurrentConnections(), config.getDuration());
     out.println("----------------------------------------------------------");
 
     display(results, "DistroConfig", appPerfResults -> appPerfResults.distroConfig.getName());
@@ -68,10 +66,10 @@ class PrintStreamPersister implements ResultsPersister {
 
   private void display(
       List<AppPerfResults> results, String pref, Function<AppPerfResults, String> vs) {
-    out.printf("%-20s: ", pref);
+    out.printf("%-30s: ", pref);
     results.forEach(
         result -> {
-          out.printf("%17s", vs.apply(result));
+          out.printf("%25s", vs.apply(result));
         });
     out.println();
   }


### PR DESCRIPTION
In this commit, we making the tests run with two throughputs (100 and 800 TPS) for improved test coverage. Also we add the ability to run tests for a given duration rather than an iteration count. This makes it simple to run tests on a given timeline, which is a more common usecase.

Testing:

```
(24-03-01 1:33:36) <0> [~/workplace/python-sdk/aws-otel-python-instrumentation/performance-tests]  
dev-dsk-thp-2a-bd3a87ed % ./gradlew test   

> Task :compileTestJava
Note: /workplace/thp/python-sdk/aws-otel-python-instrumentation/performance-tests/src/test/java/io/opentelemetry/containers/K6Container.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: /workplace/thp/python-sdk/aws-otel-python-instrumentation/performance-tests/src/test/java/io/opentelemetry/distros/DistroConfig.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.6/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 2m 12s
3 actionable tasks: 3 executed
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

