### PR TITLE
Fix 100 TPS test

### DIFF
--- a/performance-tests/src/test/java/io/opentelemetry/config/Configs.java
+++ b/performance-tests/src/test/java/io/opentelemetry/config/Configs.java
@@ -14,7 +14,7 @@ import java.util.stream.Stream;
 public enum Configs {
   ALL_100_TPS(
       TestConfig.builder()
-          .name("all-800-tps")
+          .name("all-100-tps")
           .description("Compares all DistroConfigs (100TPS test)")
           .withDistroConfigs(DistroConfig.values())
           .warmupSeconds(60)


### PR DESCRIPTION
Both were named `all-800-tps` so test results were being overwritten.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

