### PR TITLE
Run warmup phase and allow concurrency configuration

### DIFF
--- a/performance-tests/README.md
+++ b/performance-tests/README.md
@@ -80,6 +80,7 @@ Pre-requirements:
 * Have `docker` installed and running - verify by running the `docker` command.
 * Export `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, and `S3_BUCKET` environment variables.
 * By default, each distroConfig runs for 10 seconds. To change this, export `DURATION` environment variable (e.g. `60m`).
+* By default, each distroConfig runs with a concurrency (VUs) of 5. To change this, export `CONCURRENCY` environment variable (e.g. `10`).
 
 Steps:
 * From `aws-otel-python-instrumentation` dir, execute:
@@ -87,9 +88,9 @@ Steps:
 ./scripts/build_and_install_distro.sh
 ./scripts/set-up-performance-tests.sh
 cd performance-tests
-./gradlew test
+./gradlew clean test
 ```
 
 The last step can be run or you can run from IDE (after setting environment variables appropriately).
 
-To diagnose test failures with `./gradlew -i test` or use `-d` for very fine details.
+To diagnose test failures with `./gradlew -i clean test` or use `-d` for very fine details.

--- a/performance-tests/src/test/java/io/opentelemetry/config/Configs.java
+++ b/performance-tests/src/test/java/io/opentelemetry/config/Configs.java
@@ -17,18 +17,20 @@ public enum Configs {
           .name("all-100-tps")
           .description("Compares all DistroConfigs (100TPS test)")
           .withDistroConfigs(DistroConfig.values())
-          .warmupSeconds(60)
+          .warmupSeconds(10)
           .maxRequestRate(100)
           .duration(System.getenv("DURATION"))
+          .concurrentConnections(System.getenv("CONCURRENCY"))
           .build()),
   ALL_800_TPS(
       TestConfig.builder()
           .name("all-800-tps")
           .description("Compares all DistroConfigs (800TPS test)")
           .withDistroConfigs(DistroConfig.values())
-          .warmupSeconds(60)
+          .warmupSeconds(10)
           .maxRequestRate(800)
           .duration(System.getenv("DURATION"))
+          .concurrentConnections(System.getenv("CONCURRENCY"))
           .build());
 
   public final TestConfig config;

--- a/performance-tests/src/test/java/io/opentelemetry/config/TestConfig.java
+++ b/performance-tests/src/test/java/io/opentelemetry/config/TestConfig.java
@@ -98,8 +98,10 @@ public class TestConfig {
       return this;
     }
 
-    Builder concurrentConnections(int concurrentConnections) {
-      this.concurrentConnections = concurrentConnections;
+    Builder concurrentConnections(String concurrentConnections) {
+      if (concurrentConnections != null && !concurrentConnections.isEmpty()) {
+        this.concurrentConnections = Integer.parseInt(concurrentConnections);
+      }
       return this;
     }
 


### PR DESCRIPTION
In this commit we are enabling the warmup phase and allowing runs to have configurable concurrency. Also improved the commands provided in the README.

Testing:
```
OverheadTests > runAllTestConfigurations() > all-800-tps STANDARD_OUT
    ----------------------------------------------------------
     Run at Mon Mar 04 20:42:29 UTC 2024
     all-800-tps : Compares all DistroConfigs (800TPS test)
     100 users, 1s duration
    ----------------------------------------------------------
    DistroConfig                  :                      none     app_signals_disabled    app_signals_no_traces       app_signals_traces
    Run duration                  :                  00:00:13                 00:00:11                 00:00:13                 00:00:11
    Avg. CPU (user) %             :                       0.0                      0.0                      0.0                      0.0
    Max. CPU (user) %             :                       0.0                      0.0                      0.0                      0.0
    Avg. mch tot cpu %            :                       0.0                      0.0                      0.0                      0.0
    Startup time (ms)             :                      4010                     5013                     5014                     5013
    Total allocated MB            :                      0.00                     0.00                     0.00                     0.00
    Thread switch rate            :                       0.0                      0.0                      0.0                      0.0
    GC time (ms)                  :                         0                        0                        0                        0
    GC pause time (ms)            :                         0                        0                        0                        0
    Req. Count                    :                   1400.00                  1400.00                  1400.00                  1400.00
    Req. Rate                     :                    124.01                   144.99                   119.48                   146.53
    Req. Lat. mean (ms)           :                    481.05                   462.39                   509.49                   504.60
    Req. Lat. p0 (ms)             :                      2.06                     2.85                     2.08                     4.23
    Req. Lat. p50 (ms)            :                    159.19                   190.15                   175.91                   200.18
    Req. Lat. p90 (ms)            :                   1143.15                  1303.96                  1391.22                  1427.85
    Req. Lat. p99 (ms)            :                   5058.14                  3840.13                  4229.97                  4261.41
    Req. Lat. p100 (ms)           :                   8397.74                  5530.18                  8578.33                  5468.59
    Net read avg (bps)            :                      0.00                     0.00                     0.00                     0.00
    Net write avg (bps)           :                      0.00                     0.00                     0.00                     0.00
    Peak threads                  :                         0                        0                        0                        0

Gradle Test Executor 41 finished executing tests.

> Task :test
Finished generating test XML results (0.145 secs) into: /workplace/thp/python-sdk/aws-otel-python-instrumentation/performance-tests/build/test-results/test
Generating HTML test report...
Finished generating test html results (0.106 secs) into: /workplace/thp/python-sdk/aws-otel-python-instrumentation/performance-tests/build/reports/tests/test

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.6/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 6m 49s
4 actionable tasks: 4 executed
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

