### PR TITLE
Make build script more robust

### DIFF
--- a/scripts/build_and_install_distro.sh
+++ b/scripts/build_and_install_distro.sh
@@ -14,7 +14,7 @@ if [ "$current_dir" != "aws-otel-python-instrumentation" ]; then
 fi
 
 # Setup - update dependencies and create/empty dist dir
-pip install --upgrade pip setuptools wheel packaging build
+python3 -m pip install --upgrade pip setuptools wheel packaging build
 mkdir -p dist
 rm -rf dist/aws_opentelemetry_distro*
 
@@ -25,5 +25,5 @@ python3 -m build --outdir ../dist
 # Install distro
 cd ../dist
 DISTRO=(aws_opentelemetry_distro-*-py3-none-any.whl)
-pip install $DISTRO --force-reinstall
+python3 -m pip install $DISTRO --force-reinstall
 cd ..


### PR DESCRIPTION
No guarantee that `pip` alias is set up correctly. Rely on `python3 -m` command.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

