### PR TITLE
Update version.py to 0.0.1.dev0

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/version.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/version.py
@@ -1,4 +1,4 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "0.0.0.dev"
+__version__ = "0.0.1.dev0"


### PR DESCRIPTION
Update post the 0.0.1 release

Note: for some reason the a `0` is being appended to `dev` when building the wheel file causing the subsequent steps to fail in the build like this one: https://github.com/aws-observability/aws-otel-python-instrumentation/actions/runs/8180307683/job/22368072893#step:5:24

So explicitly adding `dev0` to version to make the builds work.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

