### PR TITLE
add pypi metadata

### DIFF
--- a/aws-opentelemetry-distro/pyproject.toml
+++ b/aws-opentelemetry-distro/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
   { name = "Amazon Web Services" },
 ]
 classifiers = [
-  "Development Status :: 5 - Production/Stable",
+  "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python",


### PR DESCRIPTION
Noticed that [our recently published PyPI project](https://pypi.org/project/aws-opentelemetry-distro/) is missing some metadata that [Otel Python](https://pypi.org/project/opentelemetry-sdk/) has.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

