### PR TITLE
Fix Main Build - Remove undefined job dependency, Rename image repo parameter

### DIFF
--- a/.github/workflows/appsignals-python-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-python-e2e-eks-test.yml
@@ -14,7 +14,7 @@ on:
       test-cluster-name:
         required: true
         type: string
-      appsignals-adot-image:
+      appsignals-adot-image-registry:
         required: false
         type: string
       appsignals-adot-image-tag:
@@ -125,9 +125,9 @@ jobs:
           sed -i 's/repository: cloudwatch-agent-operator/repository: cwagent-operator-pre-release/g' values.yaml
           sed -i 's/tag: 1.0.2/tag: latest/g' values.yaml
           sed -i '0,/public: public.ecr.aws\/cloudwatch-agent/s//public: ${{ secrets.TEST_CW_AGENT_REPO }}/' values.yaml
-          if [ ${{ inputs.appsignals-adot-image }} != "" ]; then
+          if [ ${{ inputs.appsignals-adot-image-registry }} != "" ]; then
             echo "Using provided AppSignals ADOT image"
-            sed -i 's~repository: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-python~repository: ${{ inputs.appsignals-adot-image }}/aws-observability/adot-autoinstrumentation-python-staging~g' values.yaml
+            sed -i 's~repository: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-python~repository: ${{ inputs.appsignals-adot-image-registry }}/aws-observability/adot-autoinstrumentation-python-staging~g' values.yaml
           else
             echo "AppSignals ADOT image is not provided"
             sed -i 's~repository: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-python~repository: ${{ secrets.TEMP_TEST_ADOT_PYTHON_IMAGE }}~g' values.yaml

--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -95,12 +95,12 @@ jobs:
       aws-region: ${{ needs.build.outputs.aws_default_region }}
       test-cluster-name: e2e-python-adot-test
       caller-workflow-name: 'main-build'
-      appsignals-adot-image: ${{ needs.build.outputs.staging_registry }}
+      appsignals-adot-image-registry: ${{ needs.build.outputs.staging_registry }}
       appsignals-adot-image-tag: ${{ needs.build.outputs.python_image_tag }}
 
   # AppSignals specific e2e tests for ec2
   appsignals-python-e2e-ec2-test:
-    needs: [ build, default-region-output ]
+    needs: [ build ]
     uses: ./.github/workflows/appsignals-python-e2e-ec2-test.yml
     secrets: inherit
     with:


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws-observability/aws-otel-python-instrumentation/actions/runs/8209428104
Caused from merge conflict resolution in https://github.com/aws-observability/aws-otel-python-instrumentation/pull/102

*Description of changes:*
- Rename `appsignals-adot-image` -> `appsignals-adot-image-registry`
- Remove dependency of `default-region-output` which was previously removed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

