### PR TITLE
Remove TODO regarding IMDS endpoint override

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
@@ -15,10 +15,7 @@ class AwsOpenTelemetryDistro(OpenTelemetryDistro):
             apply_patches: bool - apply patches to upstream instrumentation. Default is True.
 
         TODO:
-         1. Unlike opentelemetry Java, "otel.aws.imds.endpointOverride" is not configured on python. Need to figure out
-            if we rely on ec2 and eks resource to get context about the platform for python and if we need endpoint
-            override support.
-         2. OTLPMetricExporterMixin is using hard coded histogram_aggregation_type, which reads
+         1. OTLPMetricExporterMixin is using hard coded histogram_aggregation_type, which reads
             OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION environment variable. Need to work with upstream to
             make it to be configurable.
         """


### PR DESCRIPTION
The TODO said:

>Unlike opentelemetry Java, "otel.aws.imds.endpointOverride" is not configured on python. Need to figure out
            if we rely on ec2 and eks resource to get context about the platform for python and if we need endpoint
            override support.

[In java](https://github.com/open-telemetry/opentelemetry-java-contrib/blob/6a44e04a76bbe6b9844555f9b37e777c2a23103f/aws-resources/src/main/java/io/opentelemetry/contrib/aws/resource/Ec2Resource.java#L46-L51), the property is solely for testing purposes and not to be used in production. We don't need this for Python.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

