### PR TITLE
Use public image for CW operator canary tests and expand the test to all regions.

### DIFF
--- a/.github/workflows/appsignals-python-e2e-eks-canary-test.yml
+++ b/.github/workflows/appsignals-python-e2e-eks-canary-test.yml
@@ -7,10 +7,9 @@
 ## including logs, metrics, and traces.
 name: App Signals Enablement - Python E2E EKS Canary Testing
 on:
-#  schedule:
-#    - cron: '*/15 * * * *' # run the workflow every 15 minutes
+  schedule:
+    - cron: '*/15 * * * *' # run the workflow every 15 minutes
   workflow_dispatch: # be able to run the workflow on demand
-  push:
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/appsignals-python-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-python-e2e-eks-test.yml
@@ -137,8 +137,6 @@ jobs:
             echo "appsignals-adot-image-tag is empty"
             sed -i 's/tag: 0.43b0/tag: latest/g' values.yaml
           fi
-          echo "Modified values.yaml:"
-          cat values.yaml
 
       # TODO: This step is used for custom pre-release instrumentation
       # It is a temporary measure until the cw add-on is released with python support

--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - "release/v*"
-      - cw_agent_public
 env:
   AWS_DEFAULT_REGION: us-east-1
   STAGING_ECR_REGISTRY: 637423224110.dkr.ecr.us-east-1.amazonaws.com


### PR DESCRIPTION
This PR changed to use public image for CW operator in python EKS canary tests and expand the test to all regions.

Example workflow run: https://github.com/aws-observability/aws-otel-python-instrumentation/actions/runs/8302598860

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

