### PR TITLE
Add attribution file to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ RUN mkdir workspace && pip install --target workspace ./aws-opentelemetry-distro
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:minimal
 
+# Required to copy attribute files to distributed docker images
+ADD THIRD-PARTY-LICENSES ./THIRD-PARTY-LICENSES
+
 COPY --from=build /operator-build/workspace /autoinstrumentation
 
 RUN chmod -R go+r /autoinstrumentation


### PR DESCRIPTION
Copying this file is a requirement for attribution purposes.

Testing done:
```
$ docker image build -t adot-python .  
$ docker image save adot-python:latest > adot-python.tar
$ mkdir adot-python
$ tar -xvf adot-python.tar -C  adot-python
$ cd adot-python 
$ cd bd0c3feb8990f55dba5845497597307fe38ba411510a520c6ea4738896db66aa 
$ tar -xvf layer.tar                
$ ls
> json  layer.tar  THIRD-PARTY-LICENSES  VERSION
# Confirmed `THIRD-PARTY-LICENSES` is the same file.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

