### PR TITLE
Temporary EKS canary tests.

### DIFF
--- a/.github/workflows/appsignals-python-e2e-eks-canary-test.yml
+++ b/.github/workflows/appsignals-python-e2e-eks-canary-test.yml
@@ -7,8 +7,8 @@
 ## including logs, metrics, and traces.
 name: App Signals Enablement - Python E2E EKS Canary Testing
 on:
-  schedule:
-    - cron: '*/15 * * * *' # run the workflow every 15 minutes
+#  schedule:
+#    - cron: '*/15 * * * *' # run the workflow every 15 minutes
   workflow_dispatch: # be able to run the workflow on demand
 
 concurrency:


### PR DESCRIPTION
Temporary EKS canary tests to prepare switching to CW add-on.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

