### PR TITLE
Add unit tests and fix bug

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,4 @@
 [report]
 include_namespace_packages = true
-fail_under = 93.00
+fail_under = 95.00
 precision = 2

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
@@ -203,19 +203,19 @@ def _custom_import_sampler(sampler_name: str, resource: Resource) -> Sampler:
 
 
 def _customize_sampler(sampler: Sampler) -> Sampler:
-    if not is_app_signals_enabled():
+    if not _is_app_signals_enabled():
         return sampler
     return AlwaysRecordSampler(sampler)
 
 
 def _customize_exporter(span_exporter: SpanExporter, resource: Resource) -> SpanExporter:
-    if not is_app_signals_enabled():
+    if not _is_app_signals_enabled():
         return span_exporter
     return AwsMetricAttributesSpanExporterBuilder(span_exporter, resource).build()
 
 
 def _customize_span_processors(provider: TracerProvider, resource: Resource) -> None:
-    if not is_app_signals_enabled():
+    if not _is_app_signals_enabled():
         return
 
     # Construct and set local and remote attributes span processor
@@ -247,8 +247,8 @@ def _customize_versions(auto_resource: Dict[str, any]) -> Dict[str, any]:
     return auto_resource
 
 
-def is_app_signals_enabled():
-    return os.environ.get(OTEL_AWS_APP_SIGNALS_ENABLED, False)
+def _is_app_signals_enabled():
+    return os.environ.get(OTEL_AWS_APP_SIGNALS_ENABLED, "false").lower() == "true"
 
 
 class AppSignalsExporterProvider:

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py
@@ -3,18 +3,28 @@
 import os
 import time
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
+from amazon.opentelemetry.distro.always_record_sampler import AlwaysRecordSampler
+from amazon.opentelemetry.distro.attribute_propagating_span_processor import AttributePropagatingSpanProcessor
+from amazon.opentelemetry.distro.aws_metric_attributes_span_exporter import AwsMetricAttributesSpanExporter
 from amazon.opentelemetry.distro.aws_opentelemetry_configurator import (
     AwsOpenTelemetryConfigurator,
     _custom_import_sampler,
+    _customize_exporter,
+    _customize_sampler,
+    _customize_span_processors,
+    _is_app_signals_enabled,
 )
 from amazon.opentelemetry.distro.aws_opentelemetry_distro import AwsOpenTelemetryDistro
+from amazon.opentelemetry.distro.aws_span_metrics_processor import AwsSpanMetricsProcessor
 from amazon.opentelemetry.distro.sampler._aws_xray_sampling_client import _AwsXRaySamplingClient
 from amazon.opentelemetry.distro.sampler.aws_xray_remote_sampler import AwsXRayRemoteSampler
 from opentelemetry.environment_variables import OTEL_LOGS_EXPORTER, OTEL_METRICS_EXPORTER, OTEL_TRACES_EXPORTER
 from opentelemetry.sdk.environment_variables import OTEL_TRACES_SAMPLER, OTEL_TRACES_SAMPLER_ARG
-from opentelemetry.sdk.trace import Span, Tracer, TracerProvider
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import Span, SpanProcessor, Tracer, TracerProvider
+from opentelemetry.sdk.trace.export import SpanExporter
 from opentelemetry.sdk.trace.sampling import Sampler
 from opentelemetry.trace import get_tracer_provider
 
@@ -183,3 +193,51 @@ class TestAwsOpenTelemetryConfigurator(TestCase):
         _: Sampler = _custom_import_sampler("traceidratio", resource=None)
         self.assertEqual(os.environ.get("OTEL_PYTHON_REQUESTS_EXCLUDED_URLS", None), ",,,target_A,target_B,,,")
         self.assertEqual(os.environ.get("OTEL_PYTHON_URLLIB3_EXCLUDED_URLS", None), "target_C,target_D")
+
+    def test_is_app_signals_enabled(self):
+        os.environ.setdefault("OTEL_AWS_APP_SIGNALS_ENABLED", "True")
+        self.assertTrue(_is_app_signals_enabled())
+        os.environ.pop("OTEL_AWS_APP_SIGNALS_ENABLED", None)
+
+        os.environ.setdefault("OTEL_AWS_APP_SIGNALS_ENABLED", "False")
+        self.assertFalse(_is_app_signals_enabled())
+        os.environ.pop("OTEL_AWS_APP_SIGNALS_ENABLED", None)
+        self.assertFalse(_is_app_signals_enabled())
+
+    def test_customize_sampler(self):
+        mock_sampler: Sampler = MagicMock()
+        customized_sampler: Sampler = _customize_sampler(mock_sampler)
+        self.assertEqual(mock_sampler, customized_sampler)
+
+        os.environ.setdefault("OTEL_AWS_APP_SIGNALS_ENABLED", "True")
+        customized_sampler = _customize_sampler(mock_sampler)
+        self.assertNotEqual(mock_sampler, customized_sampler)
+        self.assertIsInstance(customized_sampler, AlwaysRecordSampler)
+        self.assertEqual(mock_sampler, customized_sampler._root_sampler)
+        os.environ.pop("OTEL_AWS_APP_SIGNALS_ENABLED", None)
+
+    def test_customize_exporter(self):
+        mock_exporter: SpanExporter = MagicMock()
+        customized_exporter: SpanExporter = _customize_exporter(mock_exporter, Resource.get_empty())
+        self.assertEqual(mock_exporter, customized_exporter)
+
+        os.environ.setdefault("OTEL_AWS_APP_SIGNALS_ENABLED", "True")
+        customized_exporter = _customize_exporter(mock_exporter, Resource.get_empty())
+        self.assertNotEqual(mock_exporter, customized_exporter)
+        self.assertIsInstance(customized_exporter, AwsMetricAttributesSpanExporter)
+        self.assertEqual(mock_exporter, customized_exporter._delegate)
+        os.environ.pop("OTEL_AWS_APP_SIGNALS_ENABLED", None)
+
+    def test_customize_span_processors(self):
+        mock_tracer_provider: TracerProvider = MagicMock()
+        _customize_span_processors(mock_tracer_provider, Resource.get_empty())
+        self.assertEqual(mock_tracer_provider.add_span_processor.call_count, 0)
+
+        os.environ.setdefault("OTEL_AWS_APP_SIGNALS_ENABLED", "True")
+        _customize_span_processors(mock_tracer_provider, Resource.get_empty())
+        self.assertEqual(mock_tracer_provider.add_span_processor.call_count, 2)
+        first_processor: SpanProcessor = mock_tracer_provider.add_span_processor.call_args_list[0].args[0]
+        self.assertIsInstance(first_processor, AttributePropagatingSpanProcessor)
+        second_processor: SpanProcessor = mock_tracer_provider.add_span_processor.call_args_list[1].args[0]
+        self.assertIsInstance(second_processor, AwsSpanMetricsProcessor)
+        os.environ.pop("OTEL_AWS_APP_SIGNALS_ENABLED", None)


### PR DESCRIPTION
When enabling test coverage checks, we observed that `aws_opentelementry_configurator.py` had low (75%) coverage. We decided to add unit test coverage as this class contains simple but critical code. In adding these tests, we identified a bug in `is_app_signals_enabled`, namely that it returned true if any string value is supplied (e.g. "true", "false", "blue"). In [Java](https://github.com/aws-observability/aws-otel-java-instrumentation/blob/main/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/AwsAppSignalsCustomizerProvider.java#L70-L71), we use [`ConfigProperties.getBoolean`](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure-spi/src/main/java/io/opentelemetry/sdk/autoconfigure/spi/ConfigProperties.java#L44), which only returns true if "true" is supplied.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

