### PR TITLE
Fix pr_build

### DIFF
--- a/.github/actions/artifacts_build/action.yml
+++ b/.github/actions/artifacts_build/action.yml
@@ -4,17 +4,17 @@ description: |
 
 inputs:
   aws-region:
-    required: true
-    description: "AWS Region"
+    required: false
+    description: "AWS Region, required only if push_image is true"
   image_uri_with_tag:
     required: true
     description: "Image URI with Tag"
   image_registry:
-    required: true
-    description: "Image Registry"
+    required: false
+    description: "Image Registry, required only if push_image is true"
   snapshot-ecr-role:
-    required: true
-    description: "IAM Role used for pushing to snapshot ecr"
+    required: false
+    description: "IAM Role used for pushing to snapshot ecr, required only if push_image is true"
   push_image:
     required: true
     description: "Whether push image to ECR"

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -5,10 +5,6 @@ on:
       - main
       - "release/v*"
 
-env:
-  AWS_DEFAULT_REGION: us-east-1
-  TEST_TAG: 637423224110.dkr.ecr.us-east-1.amazonaws.com/eks/observability/adot-autoinstrumentation-python:test
-
 permissions:
   id-token: write
   contents: read
@@ -27,10 +23,7 @@ jobs:
       - name: Build Wheel and Image Files
         uses: ./.github/actions/artifacts_build
         with:
-          aws-region: ${{ env.AWS_DEFAULT_REGION }}
-          image_uri_with_tag: ${{ env.TEST_TAG }}
-          image_registry: 637423224110.dkr.ecr.us-east-1.amazonaws.com
-          snapshot-ecr-role: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          image_uri_with_tag: pr_build
           push_image: false
           load_image: true
           python_version: ${{ matrix.python-version }}


### PR DESCRIPTION
pr_build had a dependency on a repo secret, which would have made it fail for forked repos. In this commit we are removing that dependency, as well as a few other non-required fields.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

