### PR TITLE
Removed unrequired dependency grpcio

### DIFF
--- a/aws-opentelemetry-distro/pyproject.toml
+++ b/aws-opentelemetry-distro/pyproject.toml
@@ -11,7 +11,6 @@ license = "Apache-2.0"
 requires-python = ">=3.8"
 
 dependencies = [
-  "grpcio == 1.60.1",
   "opentelemetry-api == 1.22.0",
   "opentelemetry-instrumentation == 0.43b0",
   "opentelemetry-sdk == 1.22.0",


### PR DESCRIPTION
*Description of changes:*
Removed unrequired dependency grpcio since if it's not installed on the customer's environment, `opentelemetry-exporter-otlp-proto-grpc` will install it as part of it's dependencies. If it is and it's between version 1.xx and 2.xx, `opentelemetry-exporter-otlp-proto-grpc` will use it. In this case, we don't need to force a certain version in our dependencies since we don't directly use it. 

### Testing:
Tested by deploying a sample app with the updated dependencies list for the distro and it instrumented as expected. 

Installed by `opentelemetry-exporter-otlp-proto-grpc` when building the distro without explicitly adding grpcio in the dependencies list. It installed the latest version. Note the `Required-by` field.
```
(testEnv) [ec2-user@ip-172-31-29-9 VehicleInventoryApp]$ pip show grpcio
Name: grpcio
Version: 1.62.1
Summary: HTTP/2-based RPC framework
Home-page: https://grpc.io
Author: The gRPC Authors
Author-email: grpc-io@googlegroups.com
License: Apache License 2.0
Location: /home/ec2-user/vehicle/aws-otel-python-instrumentation/testEnv/lib64/python3.11/site-packages
Requires: 
Required-by: opentelemetry-exporter-otlp-proto-grpc
```

When explicitly having grpcio in the dependencies, notice the `Required-by` field:
```
[ec2-user@ip-172-31-29-9 VehicleInventoryApp]$ pip3.11 show grpcio
Name: grpcio
Version: 1.60.1
Summary: HTTP/2-based RPC framework
Home-page: https://grpc.io
Author: The gRPC Authors
Author-email: grpc-io@googlegroups.com
License: Apache License 2.0
Location: /home/ec2-user/.local/lib/python3.11/site-packages
Requires: 
Required-by: aws-opentelemetry-distro, opentelemetry-exporter-otlp-proto-grpc
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

