### PR TITLE
Update python EC2 canary tests to match with cw agent rpm latest version. 

### DIFF
--- a/.github/workflows/appsignals-python-e2e-ec2-test.yml
+++ b/.github/workflows/appsignals-python-e2e-ec2-test.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: aws-observability/aws-application-signals-test-framework
-          ref: python-ec2
+          ref: main
 
       - name: Set CW Agent RPM environment variable
         run: echo GET_CW_AGENT_RPM_COMMAND="wget -O cw-agent.rpm https://amazoncloudwatch-agent-${{ inputs.aws-region }}.s3.${{ inputs.aws-region }}.amazonaws.com/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm" >> $GITHUB_ENV


### PR DESCRIPTION
Update python EC2 canary tests to match with cw agent rpm latest version. 
Matching with Java EC2 canary change: https://github.com/aws-observability/aws-application-signals-test-framework/pull/28

An example of workflow test passed:
https://github.com/aws-observability/aws-otel-python-instrumentation/actions/runs/8527133186

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

