### PR TITLE
Sampler to default to parentbased_always_on if OTEL_TRACES_SAMPLER is Unset

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
@@ -111,13 +111,6 @@ def _initialize_components():
     ).merge(Resource.create(auto_resource))
 
     sampler_name = _get_sampler()
-    # _get_sampler() returns None if `OTEL_TRACES_SAMPLER` is not set. This is fine in upstream since TracerProvider
-    # accepts a None sampler, however we require the sampler to not be None to create our `AlwaysRecordSampler`
-    # Default value of `OTEL_TRACES_SAMPLER` should be `parentbased_always_on`.
-    # https://opentelemetry.io/docs/languages/sdk-configuration/general/#otel_traces_sampler
-    # Ideally, _get_sampler() should default to `parentbased_always_on` in upstream.
-    if sampler_name is None:
-        sampler_name = "parentbased_always_on"
     sampler = _custom_import_sampler(sampler_name, resource)
 
     _init_tracing(
@@ -177,6 +170,14 @@ def _exclude_urls_for_instrumentations():
 
 
 def _custom_import_sampler(sampler_name: str, resource: Resource) -> Sampler:
+    # sampler_name from _get_sampler() can be None if `OTEL_TRACES_SAMPLER` is unset. Upstream TracerProvider is able to
+    # accept None as sampler, however we require the sampler to be not None to create `AlwaysRecordSampler` beforehand.
+    # Default value of `OTEL_TRACES_SAMPLER` should be `parentbased_always_on`.
+    # https://opentelemetry.io/docs/languages/sdk-configuration/general/#otel_traces_sampler
+    # Ideally, _get_sampler() should default to `parentbased_always_on` in upstream.
+    if sampler_name is None:
+        sampler_name = "parentbased_always_on"
+
     if sampler_name == "xray":
         # Example env var value
         # OTEL_TRACES_SAMPLER_ARG=endpoint=http://localhost:2000,polling_interval=360

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py
@@ -25,7 +25,7 @@ from opentelemetry.sdk.environment_variables import OTEL_TRACES_SAMPLER, OTEL_TR
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import Span, SpanProcessor, Tracer, TracerProvider
 from opentelemetry.sdk.trace.export import SpanExporter
-from opentelemetry.sdk.trace.sampling import Sampler
+from opentelemetry.sdk.trace.sampling import DEFAULT_ON, Sampler
 from opentelemetry.trace import get_tracer_provider
 
 
@@ -152,6 +152,14 @@ class TestAwsOpenTelemetryConfigurator(TestCase):
         self.assertEqual(
             xray_client._AwsXRaySamplingClient__get_sampling_rules_endpoint, "http://127.0.0.1:2000/GetSamplingRules"
         )
+
+    def test_import_default_sampler_when_env_var_is_not_set(self):
+        os.environ.pop(OTEL_TRACES_SAMPLER, None)
+        default_sampler: Sampler = _custom_import_sampler(None, resource=None)
+
+        self.assertIsNotNone(default_sampler)
+        self.assertEqual(default_sampler.get_description(), DEFAULT_ON.get_description())
+        # DEFAULT_ON is a ParentBased(ALWAYS_ON) sampler
 
     def test_using_xray_sampler_sets_url_exclusion_env_vars(self):
         targets_to_exclude = "SamplingTargets,GetSamplingRules"


### PR DESCRIPTION
*Issue #, if available:*
When `OTEL_TRACES_SAMPLER` is unset, the following error occurs when applying auto-instrumentation:
```
  File "/Users/test/Documents/my_test_venv/lib/python3.12/site-packages/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py", line 136, in _init_tracing
    sampler = _customize_sampler(sampler)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/test/Documents/my_test_venv/lib/python3.12/site-packages/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py", line 210, in _customize_sampler
    return AlwaysRecordSampler(sampler)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/test/Documents/my_test_venv/lib/python3.12/site-packages/amazon/opentelemetry/distro/always_record_sampler.py", line 37, in __init__
    raise ValueError("root_sampler must not be None")
```
If `OTEL_TRACES_SAMPLER` is not set, this error will occur because we don’t fallback to a default sampler

In upstream OTel Python, this is fine, because the following events occur:
```
    OTEL_TRACES_SAMPLER is unset -> _get_sampler returns None
    TracerProvider receives NONE sampler -> TracerProvider defaults to `parentbased_always_on`
```

In this repository, this is not fine because the following events occur:
```
    OTEL_TRACES_SAMPLER is unset -> _get_sampler returns None
    _get_sampler returns None -> _custom_import_sampler returns None
    _customize_sampler receives None sampler -> AlwaysRecordSampler receives NONE sampler and raises error
```

*Description of changes:*
Currently, `_get_sampler()` method returns `environ.get(OTEL_TRACES_SAMPLER, None)`.
However, OTel Docs states that `OTEL_TRACES_SAMPLER` should [default to parentbased_always_on](https://opentelemetry.io/docs/languages/sdk-configuration/general/#otel_traces_sampler). Thus the change is to default to `parentbased_always_on` if _get_sampler() returns None.

This solution was chosen as it requires the least amount of changes from upstream.
- An alternative solution is to replace `_import_sampler()` method with `_get_from_env_or_default()`, which would read from `OTEL_TRACES_SAMPLER` env var a second time.

Ideally, upstream's `_get_sampler()` should default to `parentbased_always_on`

*Testing:*
1. Before change, `unset OTEL_TRACES_SAMPLER`, see ValueError when instrumenting `server_automatic_s3client.py`
2. After change, `unset OTEL_TRACES_SAMPLER`, no more error occurred. Traces from `server_automatic_s3client.py` were recorded in XRay console. Also tested with `OTEL_TRACES_SAMPLER=xray` to ensure xray sampler still works.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

