### PR TITLE
Add release_build workflow to Release environment

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -21,6 +21,7 @@ permissions:
 
 jobs:
   build:
+    environment: Release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Contrib Repo @ SHA - ${{ github.sha }}


### PR DESCRIPTION
In this PR, we are changing the release_build workflow to run in the Release environment. The Release environment has been configured to require approval from another member of the team for workflow runs (called deployments), reducing the chance of accidental releases from going out etc.

For more details, see https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment

Testing: Created a dummy workflow and added to the release env, then performed a deployment with another member of the team: https://github.com/aws-observability/aws-otel-python-instrumentation/actions/workflows/env-test.yml

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

