### PR TITLE
Renaming python EKS E2E test in main build.

### DIFF
--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -87,7 +87,7 @@ jobs:
           pytest contract-tests/tests
 
   # AppSignals specific e2e eks tests
-  appsignals-e2e-eks-test:
+  appsignals-python-e2e-eks-test:
     needs: [build]
     uses: ./.github/workflows/appsignals-python-e2e-eks-test.yml
     secrets: inherit


### PR DESCRIPTION
*Issue #, if available:*

Renaming python EKS E2E test in main build.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

