### PR TITLE
Update release_build.yml to reorder image releases

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -90,8 +90,27 @@ jobs:
         run: |
           twine upload --repository testpypi --skip-existing --verbose dist/aws_opentelemetry_distro-${{ github.event.inputs.version }}-py3-none-any.whl
 
-      # The following step publish to ECR
-      - name: Build and push images
+      # Publish to prod PyPI
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: '__token__'
+          TWINE_PASSWORD: ${{ env.PROD_PYPI_TOKEN_API_TOKEN }}
+        run: |
+          twine upload --skip-existing --verbose dist/aws_opentelemetry_distro-${{ github.event.inputs.version }}-py3-none-any.whl
+
+      # Publish to public ECR
+      - name: Build and push public ECR image
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ${{ env.RELEASE_PUBLIC_REPOSITORY }}:v${{ github.event.inputs.version }}
+
+      # Publish to private ECR
+      - name: Build and push private ECR image
         uses: docker/build-push-action@v5
         with:
           push: true
@@ -100,15 +119,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: |
             ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }}
-            ${{ env.RELEASE_PUBLIC_REPOSITORY }}:v${{ github.event.inputs.version }}
-
-      # Publish to prod PyPI
-      - name: Publish to PyPI
-        env:
-          TWINE_USERNAME: '__token__'
-          TWINE_PASSWORD: ${{ env.PROD_PYPI_TOKEN_API_TOKEN }}
-        run: |
-          twine upload --skip-existing --verbose dist/aws_opentelemetry_distro-${{ github.event.inputs.version }}-py3-none-any.whl
 
       - name: Create GH release
         id: create_release

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -109,6 +109,17 @@ jobs:
           tags: |
             ${{ env.RELEASE_PUBLIC_REPOSITORY }}:v${{ github.event.inputs.version }}
 
+      # Publish to private ECR
+      - name: Build and push private ECR image
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }}
+
       # Publish to GitHub releases
       - name: Create GH release
         id: create_release
@@ -120,14 +131,3 @@ jobs:
              --draft \
              "v${{ github.event.inputs.version }}" \
              dist/aws_opentelemetry_distro-${{ github.event.inputs.version }}-py3-none-any.whl
-
-      # Publish to private ECR
-      - name: Build and push private ECR image
-        uses: docker/build-push-action@v5
-        with:
-          push: true
-          context: .
-          file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
-          tags: |
-            ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }}

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -109,17 +109,7 @@ jobs:
           tags: |
             ${{ env.RELEASE_PUBLIC_REPOSITORY }}:v${{ github.event.inputs.version }}
 
-      # Publish to private ECR
-      - name: Build and push private ECR image
-        uses: docker/build-push-action@v5
-        with:
-          push: true
-          context: .
-          file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
-          tags: |
-            ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }}
-
+      # Publish to GitHub releases
       - name: Create GH release
         id: create_release
         env:
@@ -130,3 +120,14 @@ jobs:
              --draft \
              "v${{ github.event.inputs.version }}" \
              dist/aws_opentelemetry_distro-${{ github.event.inputs.version }}-py3-none-any.whl
+
+      # Publish to private ECR
+      - name: Build and push private ECR image
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Reordering the release steps in release_build.yml. 
- The old order is Public and Private ECR -> PyPI -> GitHub
- The new order is PyPI -> Public ECR -> GitHub -> Private ECR.

### Testing
Tested by creating a fork of this repo and running the release workflow. Changed the repos to my own private/public ECR repos and the images were published successfully as well as a draft release was created. One thing to callout, I removed the PyPI step as this step wasn't changed and I didn't see a reason to test publishing there. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

