### PR TITLE
Attempt to fix test_urls_excluded_from_sampling

### DIFF
--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/sampler/test_aws_xray_sampling_client.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/sampler/test_aws_xray_sampling_client.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import time
 from importlib import reload
 from logging import getLogger
 from unittest import TestCase
@@ -186,7 +187,11 @@ class TestAwsXRaySamplingClient(TestCase):
         except requests.exceptions.RequestException:
             pass
 
+        timeout = time.time() + 1
         span_list = memory_exporter.get_finished_spans()
+        while len(span_list) != 1 and timeout > time.time():
+            span_list = memory_exporter.get_finished_spans()
+            time.sleep(0.1)
         self.assertEqual(1, len(span_list))
         span_http_url = span_list[0].attributes.get("http.url")
         self.assertEqual(span_http_url, "http://this_is_a_fake_url:3849/GetSamplingRules")
@@ -196,7 +201,11 @@ class TestAwsXRaySamplingClient(TestCase):
         except requests.exceptions.RequestException:
             pass
 
+        timeout = time.time() + 1
         span_list = memory_exporter.get_finished_spans()
+        while len(span_list) != 2 and timeout > time.time():
+            span_list = memory_exporter.get_finished_spans()
+            time.sleep(0.1)
         self.assertEqual(2, len(span_list))
         span_http_url = span_list[1].attributes.get("http.url")
         self.assertEqual(span_http_url, "http://this_is_a_fake_url:3849/SamplingTargets")


### PR DESCRIPTION
`test_urls_excluded_from_sampling` keeps failing on PR, causing annoying delays. I suspect that the problem is a race condition - we are exporting a span then grabbing it, and I believe that the delay between export and being "grabbable" is causing the test to fail (typically with `1 != 2`). As an attempted fix, I'm adding some retry logic that will attempt to grab for a full second.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

