### PR TITLE
Skip image scan if the image is not pushed to ECR

### DIFF
--- a/.github/actions/artifacts_build/action.yml
+++ b/.github/actions/artifacts_build/action.yml
@@ -94,6 +94,7 @@ runs:
         load: ${{ inputs.load_image }}
 
     - name: Perform image scan
+      if: ${{ inputs.push_image == true || inputs.push_image == 'true' }}
       uses: ./.github/actions/image_scan
       with:
         image-ref: ${{ inputs.image_uri_with_tag }}


### PR DESCRIPTION
*Issue #, if available:*
Otherwise the workflow fails. example: https://github.com/aws-observability/aws-otel-python-instrumentation/actions/runs/8692589074/job/23837547147

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

