### PR TITLE
Update Python E2E Test Workflows to provide Test ID to the Validator

### DIFF
--- a/.github/workflows/application-signals-python-e2e-ec2-test.yml
+++ b/.github/workflows/application-signals-python-e2e-ec2-test.yml
@@ -173,7 +173,7 @@ jobs:
         continue-on-error: true
         run: |
           curl -S -s -o /dev/null http://${{ env.MAIN_SERVICE_ENDPOINT }}/outgoing-http-call
-          curl -S -s -o /dev/null http://${{ env.MAIN_SERVICE_ENDPOINT }}/aws-sdk-call
+          curl -S -s -o /dev/null http://${{ env.MAIN_SERVICE_ENDPOINT }}/aws-sdk-call?testingId=${{ env.TESTING_ID }}
           curl -S -s -o /dev/null http://${{ env.MAIN_SERVICE_ENDPOINT }}/remote-service?ip=${{ env.REMOTE_SERVICE_IP }}
           curl -S -s -o /dev/null http://${{ env.MAIN_SERVICE_ENDPOINT }}/client-call
 
@@ -207,7 +207,7 @@ jobs:
           --log-group ${{ env.LOG_GROUP_NAME }}
           --service-name python-sample-application-${{ env.TESTING_ID }}
           --remote-service-name python-sample-remote-application-${{ env.TESTING_ID }}
-          --request-body ip=${{ env.REMOTE_SERVICE_IP }}
+          --request-body ip=${{ env.REMOTE_SERVICE_IP }}&testingId=${{ env.TESTING_ID }}
           --instance-ami ${{ env.EC2_INSTANCE_AMI }}
           --rollup'
 

--- a/.github/workflows/application-signals-python-e2e-eks-test.yml
+++ b/.github/workflows/application-signals-python-e2e-eks-test.yml
@@ -247,7 +247,7 @@ jobs:
         continue-on-error: true
         run: |
           curl -S -s -o /dev/null http://${{ env.APP_ENDPOINT }}/outgoing-http-call
-          curl -S -s -o /dev/null http://${{ env.APP_ENDPOINT }}/aws-sdk-call
+          curl -S -s -o /dev/null http://${{ env.APP_ENDPOINT }}/aws-sdk-call?testingId=${{ env.TESTING_ID }}
           curl -S -s -o /dev/null http://${{ env.APP_ENDPOINT }}/remote-service?ip=${{ env.REMOTE_SERVICE_POD_IP }}
           curl -S -s -o /dev/null http://${{ env.APP_ENDPOINT }}/client-call
 
@@ -284,7 +284,7 @@ jobs:
           --service-name python-application-${{ env.TESTING_ID }}
           --remote-service-name python-remote-application-${{ env.TESTING_ID }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
-          --request-body ip=${{ env.REMOTE_SERVICE_POD_IP }}
+          --request-body ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}
           --rollup'
 
       - name: Call endpoints and validate generated traces


### PR DESCRIPTION
*Issue #, if available:*
These tests need to be updated once the Validator update is done.
This needs to be merged right after the following PR is merged: https://github.com/aws-observability/aws-application-signals-test-framework/pull/41


*Description of changes:*
- Update EKS/EC2 workflows
  - Provide  `testingId=${{ env.TESTING_ID }}` to the sample app via `--request-body` to pass new metric validations

*Testing done:*
15 minute canaries running successfully for 12+ hours:
EKS in IAD: https://github.com/jj22ee/aws-otel-python-instrumentation/actions/workflows/test-eks-python.yml
EC2 in IAD: https://github.com/jj22ee/aws-otel-python-instrumentation/actions/workflows/test-ec2-python.yml
- uses same workflows but updated to use personal aws account info, points to branch `aws-application-signals-test-framework/pull/41` for validations

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

