### PR TITLE
Use bot to execute Pre and Post release schedule

### DIFF
--- a/.github/workflows/post_release_version_bump.yml
+++ b/.github/workflows/post_release_version_bump.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Configure AWS credentials for BOT secrets
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN_PYPI_RELEASE }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_SECRETS_MANAGER }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
       - name: Get Bot secrets

--- a/.github/workflows/post_release_version_bump.yml
+++ b/.github/workflows/post_release_version_bump.yml
@@ -7,7 +7,11 @@ on:
         description: 'Version number (e.g., 1.0.1)'
         required: true
 
+env:
+  AWS_DEFAULT_REGION: us-east-1
+
 permissions:
+  id-token: write
   contents: write
   pull-requests: write
 
@@ -31,7 +35,7 @@ jobs:
         run: |
           CURRENT_VERSION=$(grep '__version__' aws-opentelemetry-distro/src/amazon/opentelemetry/distro/version.py | sed -E 's/__version__ = "([0-9]+\.[0-9]+)\.[0-9]+.*"/\1/')
           echo "CURRENT_MAJOR_MINOR_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
-          
+
       - name: Set major and minor for current version
         run: |
           echo "CURRENT_MAJOR=$(echo $CURRENT_MAJOR_MINOR_VERSION | cut -d. -f1)" >> $GITHUB_ENV
@@ -48,23 +52,31 @@ jobs:
             echo "Input version is behind main's current major.minor version, don't need to update major version"
             exit 1
           fi
-          
+  
 
   prepare-main:
     runs-on: ubuntu-latest
     needs: check-version
     steps:
-      - name: Configure AWS credentials for Bot Access Token
+      - name: Configure AWS credentials for BOT secrets
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_PYPI_RELEASE }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
+      - name: Get Bot secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        id: bot_secrets
+        with:
+          secret-ids: |
+            BOT_TOKEN ,${{ secrets.BOT_TOKEN_SECRET_ARN }}
+          parse-json-secrets: true
+
       - name: Setup Git
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          token: ${{ secrets.GIT_RW_BOT_TOKEN }}
+          token: ${{ env.BOT_TOKEN_GITHUB_RW_PATOKEN }}
 
       - name: Configure Git
         run: |
@@ -95,7 +107,7 @@ jobs:
 
       - name: Create Pull Request to main
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ env.BOT_TOKEN_GITHUB_RW_PATOKEN }}
         run: |
           DEV_VERSION="${{ github.event.inputs.version }}.dev0"
           gh pr create --title "Post release $VERSION: Update version to $DEV_VERSION" \

--- a/.github/workflows/post_release_version_bump.yml
+++ b/.github/workflows/post_release_version_bump.yml
@@ -54,6 +54,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: check-version
     steps:
+      - name: Configure AWS credentials for Bot Access Token
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_PYPI_RELEASE }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
       - name: Setup Git
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/post_release_version_bump.yml
+++ b/.github/workflows/post_release_version_bump.yml
@@ -58,6 +58,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          token: ${{ secrets.GIT_RW_BOT_TOKEN }}
 
       - name: Configure Git
         run: |

--- a/.github/workflows/pre_release_prepare.yml
+++ b/.github/workflows/pre_release_prepare.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Configure AWS credentials for BOT secrets
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN_PYPI_RELEASE }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_SECRETS_MANAGER }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
       - name: Get Bot secrets

--- a/.github/workflows/pre_release_prepare.yml
+++ b/.github/workflows/pre_release_prepare.yml
@@ -11,19 +11,38 @@ on:
         required: true
         default: 'false'
 
+env:
+  AWS_DEFAULT_REGION: us-east-1
+
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 
 jobs:
   update-version-and-create-pr:
     runs-on: ubuntu-latest
     steps:
+      - name: Configure AWS credentials for BOT secrets
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_PYPI_RELEASE }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
+      - name: Get Bot secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        id: bot_secrets
+        with:
+          secret-ids: |
+            BOT_TOKEN ,${{ secrets.BOT_TOKEN_SECRET_ARN }}
+          parse-json-secrets: true
+
       - name: Checkout main branch
         uses: actions/checkout@v3
         with:
           ref: 'main'
+          token: ${{ env.BOT_TOKEN_GITHUB_RW_PATOKEN }}
 
       - name: Setup Git
         run: |
@@ -77,7 +96,7 @@ jobs:
 
       - name: Create pull request against the release branch
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ env.BOT_TOKEN_GITHUB_RW_PATOKEN }}
         run: |
           gh pr create --title "Pre-release: Update version to ${VERSION}" \
                        --body "This PR updates the version to ${VERSION}.

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Configure AWS credentials for PyPI secrets
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN_PYPI_RELEASE }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_SECRETS_MANAGER }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
       
       - name: Get PyPI secrets


### PR DESCRIPTION
*Description of changes:*
For code clean purpose, update the role ARN's name 
 
Add a bot account and use the bot account's token to perform workflow update in pre and post-release.
That have two benefits:
1. Allow modify workflow file for post release
2. Create PR with bot account will automatically trigger check workflows

Tested functional:
Modified post-release runs: https://github.com/XinRanZhAWS/aws-otel-python-instrumentation/actions/runs/8837317974
PR created with check enabled: https://github.com/XinRanZhAWS/aws-otel-python-instrumentation/pull/20
Modified pre-release runs: https://github.com/XinRanZhAWS/aws-otel-python-instrumentation/actions/runs/8837526972
PR created with check enabled: https://github.com/XinRanZhAWS/aws-otel-python-instrumentation/pull/19

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

