### PR TITLE
Use new created cluster to run EKS E2E test

### DIFF
--- a/.github/workflows/appsignals-python-e2e-ec2-canary-test.yml
+++ b/.github/workflows/appsignals-python-e2e-ec2-canary-test.yml
@@ -7,8 +7,8 @@
 ## including logs, metrics, and traces.
 name: App Signals Enablement - Python E2E EC2 Canary Testing
 on:
-#  schedule:
-#    - cron: '*/15 * * * *' # run the workflow every 15 minutes
+  schedule:
+    - cron: '*/15 * * * *' # run the workflow every 15 minutes
   workflow_dispatch: # be able to run the workflow on demand
 
 permissions:

--- a/.github/workflows/appsignals-python-e2e-ec2-canary-test.yml
+++ b/.github/workflows/appsignals-python-e2e-ec2-canary-test.yml
@@ -28,4 +28,4 @@ jobs:
     secrets: inherit
     with:
       aws-region: ${{ matrix.aws-region }}
-      caller-workflow-name: 'appsignals-python-e2e-ec2-canary-test-second'
+      caller-workflow-name: 'appsignals-python-e2e-ec2-canary-test'

--- a/.github/workflows/appsignals-python-e2e-ec2-canary-test.yml
+++ b/.github/workflows/appsignals-python-e2e-ec2-canary-test.yml
@@ -7,8 +7,8 @@
 ## including logs, metrics, and traces.
 name: App Signals Enablement - Python E2E EC2 Canary Testing
 on:
-  schedule:
-    - cron: '*/15 * * * *' # run the workflow every 15 minutes
+#  schedule:
+#    - cron: '*/15 * * * *' # run the workflow every 15 minutes
   workflow_dispatch: # be able to run the workflow on demand
 
 permissions:
@@ -28,4 +28,4 @@ jobs:
     secrets: inherit
     with:
       aws-region: ${{ matrix.aws-region }}
-      caller-workflow-name: 'appsignals-python-e2e-ec2-canary-test'
+      caller-workflow-name: 'appsignals-python-e2e-ec2-canary-test-second'

--- a/.github/workflows/appsignals-python-e2e-eks-canary-test.yml
+++ b/.github/workflows/appsignals-python-e2e-eks-canary-test.yml
@@ -7,8 +7,8 @@
 ## including logs, metrics, and traces.
 name: App Signals Enablement - Python E2E EKS Canary Testing
 on:
-  schedule:
-    - cron: '*/15 * * * *' # run the workflow every 15 minutes
+#  schedule:
+#    - cron: '*/15 * * * *' # run the workflow every 15 minutes
   workflow_dispatch: # be able to run the workflow on demand
 
 concurrency:
@@ -25,13 +25,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        aws-region: ['af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
-                     'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
-                     'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
-                     'us-east-1','us-east-2', 'us-west-1', 'us-west-2']
+        aws-region: ['us-east-2']
     uses: ./.github/workflows/application-signals-python-e2e-eks-test.yml
     secrets: inherit
     with:
       aws-region: ${{ matrix.aws-region }}
-      test-cluster-name: 'e2e-python-canary-test'
-      caller-workflow-name: 'appsignals-python-e2e-eks-canary-test'
+      test-cluster-name: 'e2e-python-second-test'
+      caller-workflow-name: 'appsignals-python-e2e-eks-canary-test-second'

--- a/.github/workflows/appsignals-python-e2e-eks-canary-test.yml
+++ b/.github/workflows/appsignals-python-e2e-eks-canary-test.yml
@@ -34,4 +34,4 @@ jobs:
     with:
       aws-region: ${{ matrix.aws-region }}
       test-cluster-name: 'e2e-python-second-test'
-      caller-workflow-name: 'appsignals-python-e2e-eks-canary-test-second'
+      caller-workflow-name: 'appsignals-python-e2e-eks-canary-test'

--- a/.github/workflows/appsignals-python-e2e-eks-canary-test.yml
+++ b/.github/workflows/appsignals-python-e2e-eks-canary-test.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch: # be able to run the workflow on demand
 
 concurrency:
-  group: ${{ github.workflow }}
+  group: 'parallel'
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/appsignals-python-e2e-eks-canary-test.yml
+++ b/.github/workflows/appsignals-python-e2e-eks-canary-test.yml
@@ -25,7 +25,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        aws-region: ['us-east-2']
+        aws-region: ['af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
+                     'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
+                     'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
+                     'us-east-1','us-east-2', 'us-west-1', 'us-west-2']
     uses: ./.github/workflows/application-signals-python-e2e-eks-test.yml
     secrets: inherit
     with:

--- a/.github/workflows/appsignals-python-e2e-eks-canary-test.yml
+++ b/.github/workflows/appsignals-python-e2e-eks-canary-test.yml
@@ -7,12 +7,12 @@
 ## including logs, metrics, and traces.
 name: App Signals Enablement - Python E2E EKS Canary Testing
 on:
-#  schedule:
-#    - cron: '*/15 * * * *' # run the workflow every 15 minutes
+  schedule:
+    - cron: '*/15 * * * *' # run the workflow every 15 minutes
   workflow_dispatch: # be able to run the workflow on demand
 
 concurrency:
-  group: 'parallel'
+  group: ${{ github.workflow }}
   cancel-in-progress: false
 
 permissions:


### PR DESCRIPTION
Use new created cluster to run EKS E2E test preparing for test migration to [aws-application-signals-test-framework](https://github.com/aws-observability/aws-application-signals-test-framework) repo.

Test workflow:
EC2: https://github.com/aws-observability/aws-otel-python-instrumentation/actions/runs/8741157281
EKS: https://github.com/aws-observability/aws-otel-python-instrumentation/actions/runs/8741152630


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

