### PR TITLE
Fix removing gRPC in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN mkdir workspace && pip install --target workspace ./aws-opentelemetry-distro
 # will complain that grpc is not installed, which is more understandable. References:
 # * https://github.com/open-telemetry/opentelemetry-operator/blob/b5bb0ae34720d4be2d229dafecb87b61b37699b0/autoinstrumentation/python/requirements.txt#L2
 # * https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/azure-functions/recover-python-functions.md#troubleshoot-cannot-import-cygrpc
+ENV PYTHONPATH=/operator-build/workspace
 RUN pip uninstall opentelemetry-exporter-otlp-proto-grpc -y
 RUN pip uninstall grpcio -y
 


### PR DESCRIPTION
We are installing using `pip install --target`. To fix this we must set PYTHONPATH so pip can find and uninstall these packages.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

