### PR TITLE
Only log unknown attributes if debug is enabled

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_aws_metric_attribute_generator.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_aws_metric_attribute_generator.py
@@ -373,4 +373,5 @@ def _set_span_kind_for_dependency(span: ReadableSpan, attributes: BoundedAttribu
 
 def _log_unknown_attribute(attribute_key: str, span: ReadableSpan) -> None:
     message: str = "No valid %s value found for %s span %s"
-    _logger.log(DEBUG, message, attribute_key, span.kind.name, str(span.context.span_id))
+    if _logger.isEnabledFor(DEBUG):
+        _logger.log(DEBUG, message, attribute_key, span.kind.name, str(span.context.span_id))


### PR DESCRIPTION
Using [`timeit.Timer.repeat`](https://docs.python.org/3/library/timeit.html), I found that `_logger.log` could add a lot of slowness, even if it does not log. It seems to caused by the fact that calling `log` checks if `isInstance`, and that slows things down. Adding this logic feels redundant, but the data suggests it is a good idea.

Testing done (10000 iterations, 10 repeats): 
* Always call _log_unknown_attribute
   * Average: '1.2189'
   * Repeat results: ['1.2502', '1.2157', '1.2180', '1.2184', '1.2127', '1.2176', '1.2141', '1.2187', '1.2104', '1.2136'])
* Wrap _log_unknown_attribute with if _logger.isEnabledFor(DEBUG):
   * Average: '0.3957'
   * Repeat results: ['0.4270', '0.3732', '0.4228', '0.3735', '0.3726', '0.3919', '0.3820', '0.3768', '0.4235', '0.4140'])

Suggests 4x perf hit, in worse case scenario

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

