### PR TITLE
Upgrade requests dependency

### DIFF
--- a/contract-tests/images/applications/requests/requirements.txt
+++ b/contract-tests/images/applications/requests/requirements.txt
@@ -1,4 +1,4 @@
 opentelemetry-distro==0.43b0
 opentelemetry-exporter-otlp-proto-grpc==1.22.0
 typing-extensions==4.9.0
-requests==2.31.0
+requests==2.32.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,7 +11,7 @@ bleach==4.1.0 # transient dependency for readme-renderer
 protobuf~=3.13
 markupsafe>=2.0.1
 codespell==2.1.0
-requests==2.31.0
+requests==2.32.0
 ruamel.yaml==0.17.21
 flaky==3.7.0
 botocore==1.34.67


### PR DESCRIPTION
Fixes https://github.com/aws-observability/aws-otel-python-instrumentation/pull/188 - For some reason Dependabot can't detect the second requirements file.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

