### PR TITLE
Workaround requests issue

### DIFF
--- a/contract-tests/tests/pyproject.toml
+++ b/contract-tests/tests/pyproject.toml
@@ -15,7 +15,8 @@ dependencies = [
     "testcontainers==3.7.1",
     "grpcio==1.60.0",
     "docker==7.0.0",
-    "mock-collector==1.0.0"
+    "mock-collector==1.0.0",
+    "requests==2.31.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
See https://github.com/aws-observability/aws-otel-python-instrumentation/pull/188 for context on the bug itself. The problem is that contract tests have transitive dependency on `requests~=2.7`, which pulls in 2.32.0, which has an issue with current version of docker. To fix this, we temporarily take a hard dependency on 2.31.0, which does not have the issue. This code can be removed once we upgrade successfully to 2.32.0.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

