### PR TITLE
Fail artifact build if load and push are both false

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,4 @@
 [codespell]
 # skipping auto generated folders
 skip = ./.tox,./.mypy_cache,./target,*/LICENSE,./venv,*/sql_dialect_keywords.json
-ignore-words-list = afterall
+ignore-words-list = afterall,assertIn

--- a/.github/actions/artifacts_build/action.yml
+++ b/.github/actions/artifacts_build/action.yml
@@ -36,6 +36,12 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # Either push_image or load_image must be true.
+    - name: Action verification
+      if: ${{ (inputs.load_image == false || inputs.load_image == 'false') && (inputs.push_image == false || inputs.push_image == 'false') }}
+      shell: bash
+      run: exit 1
+
     - name: Set up
       uses: ./.github/actions/set_up
       with:

--- a/.github/actions/artifacts_build/action.yml
+++ b/.github/actions/artifacts_build/action.yml
@@ -36,11 +36,12 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # Either push_image or load_image must be true.
     - name: Action verification
       if: ${{ (inputs.load_image == false || inputs.load_image == 'false') && (inputs.push_image == false || inputs.push_image == 'false') }}
       shell: bash
-      run: exit 1
+      run: |
+        echo "At least one of push_image or load_image must be true" 
+        exit 1
 
     - name: Set up
       uses: ./.github/actions/set_up

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           image_uri_with_tag: pr_build/${{ matrix.python-version }}
           push_image: false
-          load_image: false
+          load_image: true
           python_version: ${{ matrix.python-version }}
           package_name: aws-opentelemetry-distro
           os: ubuntu-latest

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           image_uri_with_tag: pr_build/${{ matrix.python-version }}
           push_image: false
-          load_image: true
+          load_image: false
           python_version: ${{ matrix.python-version }}
           package_name: aws-opentelemetry-distro
           os: ubuntu-latest


### PR DESCRIPTION
If both are false, we get somewhat arcane failures. All existing workflows set one to true and the other to false, this just enforces it.

Also, Fix a codespell issue that was introduced in 2.3.0 (previously using 2.2.6).

Testing: Set  both options to false in pr_build- https://github.com/aws-observability/aws-otel-python-instrumentation/actions/runs/9230011064/job/25397368739?pr=195

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

