### PR TITLE
Update requests version used in contract tests

### DIFF
--- a/contract-tests/images/applications/requests/requirements.txt
+++ b/contract-tests/images/applications/requests/requirements.txt
@@ -1,4 +1,4 @@
 opentelemetry-distro==0.43b0
 opentelemetry-exporter-otlp-proto-grpc==1.22.0
 typing-extensions==4.9.0
-requests==2.31.0
+requests~=2.0


### PR DESCRIPTION
GitHub complains about relying on 2.31.0 so changing this to pull the latest 2.x version, which is actually https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation says it supports: `requests ~= 2.0`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.