### PR TITLE
Fix Flaky Test in AWS X-Ray Remote Sampler Client Test

### DIFF
--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/sampler/test_aws_xray_remote_sampler.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/sampler/test_aws_xray_remote_sampler.py
@@ -57,6 +57,10 @@ class TestAwsXRayRemoteSampler(TestCase):
         self.assertIsNotNone(rs._AwsXRayRemoteSampler__resource)
         self.assertTrue(len(rs._AwsXRayRemoteSampler__client_id), 24)
 
+        # Clean up timers
+        rs._rules_timer.cancel()
+        rs._targets_timer.cancel()
+
     def test_create_remote_sampler_with_populated_resource(self):
         rs = AwsXRayRemoteSampler(
             resource=Resource.create({"service.name": "test-service-name", "cloud.platform": "test-cloud-platform"})
@@ -67,6 +71,10 @@ class TestAwsXRayRemoteSampler(TestCase):
         self.assertIsNotNone(rs._AwsXRayRemoteSampler__resource)
         self.assertEqual(rs._AwsXRayRemoteSampler__resource.attributes["service.name"], "test-service-name")
         self.assertEqual(rs._AwsXRayRemoteSampler__resource.attributes["cloud.platform"], "test-cloud-platform")
+
+        # Clean up timers
+        rs._rules_timer.cancel()
+        rs._targets_timer.cancel()
 
     def test_create_remote_sampler_with_all_fields_populated(self):
         rs = AwsXRayRemoteSampler(
@@ -85,6 +93,10 @@ class TestAwsXRayRemoteSampler(TestCase):
         )
         self.assertEqual(rs._AwsXRayRemoteSampler__resource.attributes["service.name"], "test-service-name")
         self.assertEqual(rs._AwsXRayRemoteSampler__resource.attributes["cloud.platform"], "test-cloud-platform")
+
+        # Clean up timers
+        rs._rules_timer.cancel()
+        rs._targets_timer.cancel()
 
     @patch("requests.Session.post", side_effect=mocked_requests_get)
     @patch("amazon.opentelemetry.distro.sampler.aws_xray_remote_sampler.DEFAULT_TARGET_POLLING_INTERVAL_SECONDS", 2)
@@ -112,6 +124,10 @@ class TestAwsXRayRemoteSampler(TestCase):
         self.assertEqual(
             rs.should_sample(None, 0, "name", attributes={"abc": "1234"}).decision, Decision.RECORD_AND_SAMPLE
         )
+
+        # Clean up timers
+        rs._rules_timer.cancel()
+        rs._targets_timer.cancel()
 
     @patch("requests.Session.post", side_effect=mocked_requests_get)
     @patch("amazon.opentelemetry.distro.sampler.aws_xray_remote_sampler.DEFAULT_TARGET_POLLING_INTERVAL_SECONDS", 3)
@@ -155,6 +171,10 @@ class TestAwsXRayRemoteSampler(TestCase):
             100000,
         )
         self.assertEqual(sum_sampled, 100000)
+
+        # Clean up timers
+        rs._rules_timer.cancel()
+        rs._targets_timer.cancel()
 
     # pylint: disable=no-member
     @patch("requests.Session.post", side_effect=mocked_requests_get)
@@ -210,3 +230,7 @@ class TestAwsXRayRemoteSampler(TestCase):
             100,
         )
         self.assertEqual(sum_sampled, 100)
+
+        # Clean up timers
+        rs._rules_timer.cancel()
+        rs._targets_timer.cancel()

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/sampler/test_aws_xray_sampling_client.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/sampler/test_aws_xray_sampling_client.py
@@ -3,7 +3,6 @@
 import json
 import logging
 import os
-import time
 from importlib import reload
 from logging import getLogger
 from unittest import TestCase
@@ -187,11 +186,7 @@ class TestAwsXRaySamplingClient(TestCase):
         except requests.exceptions.RequestException:
             pass
 
-        timeout = time.time() + 1
         span_list = memory_exporter.get_finished_spans()
-        while len(span_list) != 1 and timeout > time.time():
-            span_list = memory_exporter.get_finished_spans()
-            time.sleep(0.1)
         self.assertEqual(1, len(span_list))
         span_http_url = span_list[0].attributes.get("http.url")
         self.assertEqual(span_http_url, "http://this_is_a_fake_url:3849/GetSamplingRules")
@@ -201,11 +196,7 @@ class TestAwsXRaySamplingClient(TestCase):
         except requests.exceptions.RequestException:
             pass
 
-        timeout = time.time() + 1
         span_list = memory_exporter.get_finished_spans()
-        while len(span_list) != 2 and timeout > time.time():
-            span_list = memory_exporter.get_finished_spans()
-            time.sleep(0.1)
         self.assertEqual(2, len(span_list))
         span_http_url = span_list[1].attributes.get("http.url")
         self.assertEqual(span_http_url, "http://this_is_a_fake_url:3849/SamplingTargets")

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py
@@ -175,6 +175,8 @@ class TestAwsOpenTelemetryConfigurator(TestCase):
         self.assertEqual(default_sampler.get_description(), DEFAULT_ON.get_description())
         # DEFAULT_ON is a ParentBased(ALWAYS_ON) sampler
 
+    @patch.object(AwsXRayRemoteSampler, "_AwsXRayRemoteSampler__start_sampling_rule_poller", lambda x: None)
+    @patch.object(AwsXRayRemoteSampler, "_AwsXRayRemoteSampler__start_sampling_target_poller", lambda x: None)
     def test_using_xray_sampler_sets_url_exclusion_env_vars(self):
         targets_to_exclude = "SamplingTargets,GetSamplingRules"
         os.environ.pop("OTEL_PYTHON_REQUESTS_EXCLUDED_URLS", None)
@@ -186,6 +188,8 @@ class TestAwsOpenTelemetryConfigurator(TestCase):
         self.assertEqual(os.environ.get("OTEL_PYTHON_REQUESTS_EXCLUDED_URLS", None), targets_to_exclude)
         self.assertEqual(os.environ.get("OTEL_PYTHON_URLLIB3_EXCLUDED_URLS", None), targets_to_exclude)
 
+    @patch.object(AwsXRayRemoteSampler, "_AwsXRayRemoteSampler__start_sampling_rule_poller", lambda x: None)
+    @patch.object(AwsXRayRemoteSampler, "_AwsXRayRemoteSampler__start_sampling_target_poller", lambda x: None)
     def test_using_xray_sampler_appends_url_exclusion_env_vars(self):
         targets_to_exclude = "SamplingTargets,GetSamplingRules"
         os.environ.pop("OTEL_PYTHON_REQUESTS_EXCLUDED_URLS", None)

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_version.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_version.py
@@ -1,0 +1,12 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest import TestCase
+
+from amazon.opentelemetry.distro.version import __version__
+
+
+class TestVersion(TestCase):
+    def test_version_is_not_empty_and_not_none(self):
+        self.assertIsNotNone(__version__)
+        self.assertNotEqual(__version__, "")


### PR DESCRIPTION
*Issue #, if available:*
This PR fixes flaky test `test_urls_excluded_from_sampling`, causing issues in PR workflows
- Example: https://github.com/aws-observability/aws-otel-python-instrumentation/actions/runs/9103811387/job/25026448867
 
Instantiation of `AwsXRayRemoteSampler` will spawn processes that will regularly (every 10s and 300s) make a Request call, and these processes stay alive between different unit tests. This means that the test that counts the number instrumented Request calls is affected by these "orphaned" processes.

The solution is to stop these processes inside the tests that they are created from, or stop them from being spawned in the first place if they are not needed.

*Description of changes:*
- Stop the daemon rule and target poller processes inside the tests that they are created from, or stop them from being spawned in the first place if they are not needed.
- Revert previous fix attempt
- Add test for version to increase and pass code coverage

*Testing:*
- Reproduced failing test by running test in loop of 10000 runs
- Failing test not reproducible after applying fix.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

