### PR TITLE
Limit OTLP metric histogram buckets to 100

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
@@ -7,10 +7,7 @@ from logging import Logger, getLogger
 from amazon.opentelemetry.distro.patches._instrumentation_patch import apply_instrumentation_patches
 from opentelemetry.distro import OpenTelemetryDistro
 from opentelemetry.environment_variables import OTEL_PROPAGATORS, OTEL_PYTHON_ID_GENERATOR
-from opentelemetry.sdk.environment_variables import (
-    OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION,
-    OTEL_EXPORTER_OTLP_PROTOCOL,
-)
+from opentelemetry.sdk.environment_variables import OTEL_EXPORTER_OTLP_PROTOCOL
 
 _logger: Logger = getLogger(__name__)
 
@@ -25,20 +22,14 @@ class AwsOpenTelemetryDistro(OpenTelemetryDistro):
         due to gRPC having a strict dependency on the Python version the artifact was built for (OTEL observed this:
         https://github.com/open-telemetry/opentelemetry-operator/blob/461ba68e80e8ac6bf2603eb353547cd026119ed2/autoinstrumentation/python/requirements.txt#L2-L3)
 
-        Also sets default OTEL_PROPAGATORS, OTEL_PYTHON_ID_GENERATOR, and
-        OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION to ensure good compatibility with X-Ray and Application
-        Signals.
+        Also sets default OTEL_PROPAGATORS and OTEL_PYTHON_ID_GENERATOR to ensure good compatibility with X-Ray and
+        Application Signals.
 
         Also applies patches to upstream instrumentation - usually these are stopgap measures until we can contribute
         long-term changes to upstream.
 
         kwargs:
             apply_patches: bool - apply patches to upstream instrumentation. Default is True.
-
-        TODO:
-         1. OTLPMetricExporterMixin is using hard coded histogram_aggregation_type, which reads
-            OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION environment variable. Need to work with upstream to
-            make it to be configurable.
         """
 
         # Issue: https://github.com/open-telemetry/opentelemetry-python-contrib/issues/2495
@@ -61,9 +52,6 @@ class AwsOpenTelemetryDistro(OpenTelemetryDistro):
 
         os.environ.setdefault(OTEL_PROPAGATORS, "xray,tracecontext,b3,b3multi")
         os.environ.setdefault(OTEL_PYTHON_ID_GENERATOR, "xray")
-        os.environ.setdefault(
-            OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION, "base2_exponential_bucket_histogram"
-        )
 
         if kwargs.get("apply_patches", True):
             apply_instrumentation_patches()

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_instrumentation_patch.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_instrumentation_patch.py
@@ -6,6 +6,7 @@ from logging import Logger, getLogger
 
 import pkg_resources
 
+from amazon.opentelemetry.distro.patches._otlp_metric_exporter_patches import _apply_otlp_metric_exporter_patches
 from amazon.opentelemetry.distro.patches._resource_detector_patches import _apply_resource_detector_patches
 
 _logger: Logger = getLogger(__name__)
@@ -31,6 +32,7 @@ def apply_instrumentation_patches() -> None:
     # No need to check if library is installed as this patches opentelemetry.sdk,
     # which must be installed for the distro to work at all.
     _apply_resource_detector_patches()
+    _apply_otlp_metric_exporter_patches()
 
 
 def _is_installed(req: str) -> bool:

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_otlp_metric_exporter_patches.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_otlp_metric_exporter_patches.py
@@ -41,7 +41,7 @@ from opentelemetry.util.re import parse_env_headers
 
 
 # The OpenTelemetry Authors code
-def _apply_otlp_metric_exporter_patches() -> None:
+def _apply_otlp_metric_exporter_patches() -> None:  # pragma: no cover
     """OTLP Metrics Exporter patches for getting the following change in the upstream:
     https://github.com/open-telemetry/opentelemetry-python/commit/12f449074e80fa88b59468a48b7a4b99dbcda34d
     """

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_otlp_metric_exporter_patches.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_otlp_metric_exporter_patches.py
@@ -52,6 +52,7 @@ def _apply_otlp_metric_exporter_patches() -> None:  # pragma: no cover
         preferred_aggregation: Dict[type, ViewAggregation] = None,
     ) -> None:
 
+        # pylint: disable=unnecessary-dunder-call
         MetricExporter.__init__(
             self,
             preferred_temporality=self._get_temporality(preferred_temporality),
@@ -250,6 +251,7 @@ def _apply_grpc_otlp_metric_exporter_patches():
 
         self._common_configuration(preferred_temporality, preferred_aggregation)
 
+        # pylint: disable=unnecessary-dunder-call
         OTLPExporterMixin.__init__(
             self,
             endpoint=endpoint or environ.get(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT),

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_otlp_metric_exporter_patches.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_otlp_metric_exporter_patches.py
@@ -92,9 +92,7 @@ def _apply_otlp_metric_exporter_patches() -> None:
             }
 
         else:
-            if otel_exporter_otlp_metrics_temporality_preference != (
-                    "CUMULATIVE"
-            ):
+            if otel_exporter_otlp_metrics_temporality_preference != ("CUMULATIVE"):
                 # pylint: disable=logging-fstring-interpolation
                 _logger.warning(
                     "Unrecognized OTEL_EXPORTER_METRICS_TEMPORALITY_PREFERENCE"
@@ -125,9 +123,7 @@ def _apply_otlp_metric_exporter_patches() -> None:
             "explicit_bucket_histogram",
         )
 
-        if otel_exporter_otlp_metrics_default_histogram_aggregation == (
-                "base2_exponential_bucket_histogram"
-        ):
+        if otel_exporter_otlp_metrics_default_histogram_aggregation == ("base2_exponential_bucket_histogram"):
 
             instrument_class_aggregation = {
                 Histogram: ExponentialBucketHistogramAggregation(),
@@ -135,16 +131,11 @@ def _apply_otlp_metric_exporter_patches() -> None:
 
         else:
 
-            if otel_exporter_otlp_metrics_default_histogram_aggregation != (
-                    "explicit_bucket_histogram"
-            ):
+            if otel_exporter_otlp_metrics_default_histogram_aggregation != ("explicit_bucket_histogram"):
 
                 # pylint: disable=implicit-str-concat
                 _logger.warning(
-                    (
-                        "Invalid value for %s: %s, using explicit bucket "
-                        "histogram aggregation"
-                    ),
+                    ("Invalid value for %s: %s, using explicit bucket " "histogram aggregation"),
                     OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION,
                     otel_exporter_otlp_metrics_default_histogram_aggregation,
                 )
@@ -170,9 +161,7 @@ def _apply_otlp_metric_exporter_patches() -> None:
     ):
         self._endpoint = endpoint or environ.get(
             OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,
-            _append_metrics_path(
-                environ.get(OTEL_EXPORTER_OTLP_ENDPOINT, DEFAULT_ENDPOINT)
-            ),
+            _append_metrics_path(environ.get(OTEL_EXPORTER_OTLP_ENDPOINT, DEFAULT_ENDPOINT)),
         )
         self._certificate_file = certificate_file or environ.get(
             OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE,
@@ -192,17 +181,11 @@ def _apply_otlp_metric_exporter_patches() -> None:
         self._compression = compression or _compression_from_env()
         self._session = session or requests.Session()
         self._session.headers.update(self._headers)
-        self._session.headers.update(
-            {"Content-Type": "application/x-protobuf"}
-        )
+        self._session.headers.update({"Content-Type": "application/x-protobuf"})
         if self._compression is not HttpCompression.NoCompression:
-            self._session.headers.update(
-                {"Content-Encoding": self._compression.value}
-            )
+            self._session.headers.update({"Content-Encoding": self._compression.value})
 
-        self._common_configuration(
-            preferred_temporality, preferred_aggregation
-        )
+        self._common_configuration(preferred_temporality, preferred_aggregation)
 
     OTLPMetricExporterMixin._common_configuration = patch_otlp_metric_exporter_mixin_common_configuration
     OTLPMetricExporterMixin._get_temporality = patch_otlp_metric_exporter_mixin_get_temporality
@@ -242,9 +225,7 @@ def _apply_grpc_otlp_metric_exporter_patches():
         endpoint: Optional[str] = None,
         insecure: Optional[bool] = None,
         credentials: Optional[ChannelCredentials] = None,
-        headers: Optional[
-            Union[TypingSequence[Tuple[str, str]], Dict[str, str], str]
-        ] = None,
+        headers: Optional[Union[TypingSequence[Tuple[str, str]], Dict[str, str], str]] = None,
         timeout: Optional[int] = None,
         compression: Optional[GrpcCompression] = None,
         preferred_temporality: Dict[type, AggregationTemporality] = None,
@@ -257,33 +238,21 @@ def _apply_grpc_otlp_metric_exporter_patches():
             if insecure is not None:
                 insecure = insecure.lower() == "true"
 
-        if (
-                not insecure
-                and environ.get(OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE) is not None
-        ):
-            credentials = _get_credentials(
-                credentials, OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE
-            )
+        if not insecure and environ.get(OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE) is not None:
+            credentials = _get_credentials(credentials, OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE)
 
         environ_timeout = environ.get(OTEL_EXPORTER_OTLP_METRICS_TIMEOUT)
-        environ_timeout = (
-            int(environ_timeout) if environ_timeout is not None else None
-        )
+        environ_timeout = int(environ_timeout) if environ_timeout is not None else None
 
         compression = (
-            environ_to_compression(OTEL_EXPORTER_OTLP_METRICS_COMPRESSION)
-            if compression is None
-            else compression
+            environ_to_compression(OTEL_EXPORTER_OTLP_METRICS_COMPRESSION) if compression is None else compression
         )
 
-        self._common_configuration(
-            preferred_temporality, preferred_aggregation
-        )
+        self._common_configuration(preferred_temporality, preferred_aggregation)
 
         OTLPExporterMixin.__init__(
             self,
-            endpoint=endpoint
-                     or environ.get(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT),
+            endpoint=endpoint or environ.get(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT),
             insecure=insecure,
             credentials=credentials,
             headers=headers or environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS),

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_otlp_metric_exporter_patches.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_otlp_metric_exporter_patches.py
@@ -1,0 +1,299 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+# Modifications Copyright The OpenTelemetry Authors. Licensed under the Apache License 2.0 License.
+from os import environ
+from typing import Dict, Optional
+
+import requests
+
+from opentelemetry.exporter.otlp.proto.common._internal.metrics_encoder import OTLPMetricExporterMixin, _logger
+from opentelemetry.exporter.otlp.proto.http import Compression as HttpCompression
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import DEFAULT_ENDPOINT, DEFAULT_TIMEOUT
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter as HttpOTLPMetricExporter
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import _append_metrics_path, _compression_from_env
+from opentelemetry.sdk.environment_variables import (
+    OTEL_EXPORTER_OTLP_CERTIFICATE,
+    OTEL_EXPORTER_OTLP_ENDPOINT,
+    OTEL_EXPORTER_OTLP_HEADERS,
+    OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE,
+    OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION,
+    OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,
+    OTEL_EXPORTER_OTLP_METRICS_HEADERS,
+    OTEL_EXPORTER_OTLP_METRICS_PROTOCOL,
+    OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE,
+    OTEL_EXPORTER_OTLP_METRICS_TIMEOUT,
+    OTEL_EXPORTER_OTLP_PROTOCOL,
+    OTEL_EXPORTER_OTLP_TIMEOUT,
+)
+from opentelemetry.sdk.metrics import (
+    Counter,
+    Histogram,
+    ObservableCounter,
+    ObservableGauge,
+    ObservableUpDownCounter,
+    UpDownCounter,
+)
+from opentelemetry.sdk.metrics._internal.aggregation import Aggregation as InternalAggregation
+from opentelemetry.sdk.metrics.export import AggregationTemporality, MetricExporter
+from opentelemetry.sdk.metrics.view import Aggregation as ViewAggregation
+from opentelemetry.sdk.metrics.view import ExplicitBucketHistogramAggregation, ExponentialBucketHistogramAggregation
+from opentelemetry.util.re import parse_env_headers
+
+
+# The OpenTelemetry Authors code
+def _apply_otlp_metric_exporter_patches() -> None:
+    """OTLP Metrics Exporter patches for getting the following change in the upstream:
+    https://github.com/open-telemetry/opentelemetry-python/commit/12f449074e80fa88b59468a48b7a4b99dbcda34d
+    """
+
+    def patch_otlp_metric_exporter_mixin_common_configuration(
+        self,
+        preferred_temporality: Dict[type, AggregationTemporality] = None,
+        preferred_aggregation: Dict[type, ViewAggregation] = None,
+    ) -> None:
+
+        MetricExporter.__init__(
+            self,
+            preferred_temporality=self._get_temporality(preferred_temporality),
+            preferred_aggregation=self._get_aggregation(preferred_aggregation),
+        )
+
+    def patch_otlp_metric_exporter_mixin_get_temporality(
+        self, preferred_temporality: Dict[type, AggregationTemporality]
+    ) -> Dict[type, AggregationTemporality]:
+
+        otel_exporter_otlp_metrics_temporality_preference = (
+            environ.get(
+                OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE,
+                "CUMULATIVE",
+            )
+            .upper()
+            .strip()
+        )
+
+        if otel_exporter_otlp_metrics_temporality_preference == "DELTA":
+            instrument_class_temporality = {
+                Counter: AggregationTemporality.DELTA,
+                UpDownCounter: AggregationTemporality.CUMULATIVE,
+                Histogram: AggregationTemporality.DELTA,
+                ObservableCounter: AggregationTemporality.DELTA,
+                ObservableUpDownCounter: AggregationTemporality.CUMULATIVE,
+                ObservableGauge: AggregationTemporality.CUMULATIVE,
+            }
+
+        elif otel_exporter_otlp_metrics_temporality_preference == "LOWMEMORY":
+            instrument_class_temporality = {
+                Counter: AggregationTemporality.DELTA,
+                UpDownCounter: AggregationTemporality.CUMULATIVE,
+                Histogram: AggregationTemporality.DELTA,
+                ObservableCounter: AggregationTemporality.CUMULATIVE,
+                ObservableUpDownCounter: AggregationTemporality.CUMULATIVE,
+                ObservableGauge: AggregationTemporality.CUMULATIVE,
+            }
+
+        else:
+            if otel_exporter_otlp_metrics_temporality_preference != (
+                    "CUMULATIVE"
+            ):
+                # pylint: disable=logging-fstring-interpolation
+                _logger.warning(
+                    "Unrecognized OTEL_EXPORTER_METRICS_TEMPORALITY_PREFERENCE"
+                    " value found: "
+                    f"{otel_exporter_otlp_metrics_temporality_preference}, "
+                    "using CUMULATIVE"
+                )
+            instrument_class_temporality = {
+                Counter: AggregationTemporality.CUMULATIVE,
+                UpDownCounter: AggregationTemporality.CUMULATIVE,
+                Histogram: AggregationTemporality.CUMULATIVE,
+                ObservableCounter: AggregationTemporality.CUMULATIVE,
+                ObservableUpDownCounter: AggregationTemporality.CUMULATIVE,
+                ObservableGauge: AggregationTemporality.CUMULATIVE,
+            }
+
+        instrument_class_temporality.update(preferred_temporality or {})
+
+        return instrument_class_temporality
+
+    def patch_otlp_metric_exporter_mixin_get_aggregation(
+        self,
+        preferred_aggregation: Dict[type, ViewAggregation],
+    ) -> Dict[type, ViewAggregation]:
+
+        otel_exporter_otlp_metrics_default_histogram_aggregation = environ.get(
+            OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION,
+            "explicit_bucket_histogram",
+        )
+
+        if otel_exporter_otlp_metrics_default_histogram_aggregation == (
+                "base2_exponential_bucket_histogram"
+        ):
+
+            instrument_class_aggregation = {
+                Histogram: ExponentialBucketHistogramAggregation(),
+            }
+
+        else:
+
+            if otel_exporter_otlp_metrics_default_histogram_aggregation != (
+                    "explicit_bucket_histogram"
+            ):
+
+                # pylint: disable=implicit-str-concat
+                _logger.warning(
+                    (
+                        "Invalid value for %s: %s, using explicit bucket "
+                        "histogram aggregation"
+                    ),
+                    OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION,
+                    otel_exporter_otlp_metrics_default_histogram_aggregation,
+                )
+
+            instrument_class_aggregation = {
+                Histogram: ExplicitBucketHistogramAggregation(),
+            }
+
+        instrument_class_aggregation.update(preferred_aggregation or {})
+
+        return instrument_class_aggregation
+
+    def patch_http_otlp_metric_exporter_init(
+        self,
+        endpoint: Optional[str] = None,
+        certificate_file: Optional[str] = None,
+        headers: Optional[Dict[str, str]] = None,
+        timeout: Optional[int] = None,
+        compression: Optional[HttpCompression] = None,
+        session: Optional[requests.Session] = None,
+        preferred_temporality: Dict[type, AggregationTemporality] = None,
+        preferred_aggregation: Dict[type, InternalAggregation] = None,
+    ):
+        self._endpoint = endpoint or environ.get(
+            OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,
+            _append_metrics_path(
+                environ.get(OTEL_EXPORTER_OTLP_ENDPOINT, DEFAULT_ENDPOINT)
+            ),
+        )
+        self._certificate_file = certificate_file or environ.get(
+            OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE,
+            environ.get(OTEL_EXPORTER_OTLP_CERTIFICATE, True),
+        )
+        headers_string = environ.get(
+            OTEL_EXPORTER_OTLP_METRICS_HEADERS,
+            environ.get(OTEL_EXPORTER_OTLP_HEADERS, ""),
+        )
+        self._headers = headers or parse_env_headers(headers_string)
+        self._timeout = timeout or int(
+            environ.get(
+                OTEL_EXPORTER_OTLP_METRICS_TIMEOUT,
+                environ.get(OTEL_EXPORTER_OTLP_TIMEOUT, DEFAULT_TIMEOUT),
+            )
+        )
+        self._compression = compression or _compression_from_env()
+        self._session = session or requests.Session()
+        self._session.headers.update(self._headers)
+        self._session.headers.update(
+            {"Content-Type": "application/x-protobuf"}
+        )
+        if self._compression is not HttpCompression.NoCompression:
+            self._session.headers.update(
+                {"Content-Encoding": self._compression.value}
+            )
+
+        self._common_configuration(
+            preferred_temporality, preferred_aggregation
+        )
+
+    OTLPMetricExporterMixin._common_configuration = patch_otlp_metric_exporter_mixin_common_configuration
+    OTLPMetricExporterMixin._get_temporality = patch_otlp_metric_exporter_mixin_get_temporality
+    OTLPMetricExporterMixin._get_aggregation = patch_otlp_metric_exporter_mixin_get_aggregation
+    HttpOTLPMetricExporter.__init__ = patch_http_otlp_metric_exporter_init
+
+    protocol = environ.get(
+        OTEL_EXPORTER_OTLP_METRICS_PROTOCOL, environ.get(OTEL_EXPORTER_OTLP_PROTOCOL, "http/protobuf")
+    )
+    if protocol == "grpc":
+        _apply_grpc_otlp_metric_exporter_patches()
+
+
+def _apply_grpc_otlp_metric_exporter_patches():
+    # pylint: disable=import-outside-toplevel
+    # Delay import to only occur if gRPC specifically requested. Vended Docker image will not have gRPC bundled,
+    # so importing it at the class level can cause runtime failures.
+    from typing import Sequence as TypingSequence
+    from typing import Tuple, Union
+
+    from grpc import ChannelCredentials
+    from grpc import Compression as GrpcCompression
+
+    from opentelemetry.exporter.otlp.proto.grpc.exporter import (
+        OTLPExporterMixin,
+        _get_credentials,
+        environ_to_compression,
+    )
+    from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter as GrpcOTLPMetricExporter
+    from opentelemetry.sdk.environment_variables import (
+        OTEL_EXPORTER_OTLP_METRICS_COMPRESSION,
+        OTEL_EXPORTER_OTLP_METRICS_INSECURE,
+    )
+
+    def patch_http_grpc_metric_exporter_init(
+        self,
+        endpoint: Optional[str] = None,
+        insecure: Optional[bool] = None,
+        credentials: Optional[ChannelCredentials] = None,
+        headers: Optional[
+            Union[TypingSequence[Tuple[str, str]], Dict[str, str], str]
+        ] = None,
+        timeout: Optional[int] = None,
+        compression: Optional[GrpcCompression] = None,
+        preferred_temporality: Dict[type, AggregationTemporality] = None,
+        preferred_aggregation: Dict[type, InternalAggregation] = None,
+        max_export_batch_size: Optional[int] = None,
+    ):
+
+        if insecure is None:
+            insecure = environ.get(OTEL_EXPORTER_OTLP_METRICS_INSECURE)
+            if insecure is not None:
+                insecure = insecure.lower() == "true"
+
+        if (
+                not insecure
+                and environ.get(OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE) is not None
+        ):
+            credentials = _get_credentials(
+                credentials, OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE
+            )
+
+        environ_timeout = environ.get(OTEL_EXPORTER_OTLP_METRICS_TIMEOUT)
+        environ_timeout = (
+            int(environ_timeout) if environ_timeout is not None else None
+        )
+
+        compression = (
+            environ_to_compression(OTEL_EXPORTER_OTLP_METRICS_COMPRESSION)
+            if compression is None
+            else compression
+        )
+
+        self._common_configuration(
+            preferred_temporality, preferred_aggregation
+        )
+
+        OTLPExporterMixin.__init__(
+            self,
+            endpoint=endpoint
+                     or environ.get(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT),
+            insecure=insecure,
+            credentials=credentials,
+            headers=headers or environ.get(OTEL_EXPORTER_OTLP_METRICS_HEADERS),
+            timeout=timeout or environ_timeout,
+            compression=compression,
+        )
+
+        self._max_export_batch_size: Optional[int] = max_export_batch_size
+
+    GrpcOTLPMetricExporter.__init__ = patch_http_grpc_metric_exporter_init
+
+
+# END The OpenTelemetry Authors code

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py
@@ -295,9 +295,6 @@ def validate_distro_environ():
 
     # Set by AwsOpenTelemetryDistro
     tc.assertEqual("http/protobuf", os.environ.get("OTEL_EXPORTER_OTLP_PROTOCOL"))
-    tc.assertEqual(
-        "base2_exponential_bucket_histogram", os.environ.get("OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION")
-    )
     tc.assertEqual("xray,tracecontext,b3,b3multi", os.environ.get("OTEL_PROPAGATORS"))
     tc.assertEqual("xray", os.environ.get("OTEL_PYTHON_ID_GENERATOR"))
 

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_instrumentation_patch.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_instrumentation_patch.py
@@ -1,13 +1,26 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-from typing import Dict
+from os import environ
+from typing import Dict, Tuple
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 import pkg_resources
 
 from amazon.opentelemetry.distro.patches._instrumentation_patch import apply_instrumentation_patches
+from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter as GrpcOTLPMetricExporter
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter as HttpOTLPMetricExporter
 from opentelemetry.instrumentation.botocore.extensions import _KNOWN_EXTENSIONS
+from opentelemetry.sdk.metrics import (
+    Counter,
+    Histogram,
+    ObservableCounter,
+    ObservableGauge,
+    ObservableUpDownCounter,
+    UpDownCounter,
+)
+from opentelemetry.sdk.metrics.export import AggregationTemporality
+from opentelemetry.sdk.metrics.view import Aggregation, ExponentialBucketHistogramAggregation
 from opentelemetry.semconv.trace import SpanAttributes
 
 _STREAM_NAME: str = "streamName"
@@ -17,50 +30,67 @@ _QUEUE_URL: str = "queueUrl"
 
 
 class TestInstrumentationPatch(TestCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.mock_get_distribution = patch(
+    """
+    This test class has exactly one test, test_instrumentation_patch. This is an anti-pattern, but the scenario is
+    fairly unusual and we feel justifies the code smell. Essentially the _instrumentation_patch module monkey-patches
+    upstream components, so once it's run, it's challenging to "undo" between tests. To work around this, we have a
+    monolith test framework that tests two major categories of test scenarios:
+    1. Patch behaviour
+    2. Patch mechanism
+
+    Patch behaviour tests validate upstream behaviour without patches, apply patches, and validate patched behaviour.
+    Patch mechanism tests validate the logic that is used to actually apply patches, and can be run regardless of the
+    pre- or post-patch behaviour.
+    """
+
+    mock_get_distribution: patch
+    mock_metric_exporter_init: patch
+
+    def test_instrumentation_patch(self):
+        # Set up mocks used by all tests
+        self.mock_get_distribution = patch(
             "amazon.opentelemetry.distro.patches._instrumentation_patch.pkg_resources.get_distribution"
         ).start()
+        self.mock_metric_exporter_init = patch(
+            "opentelemetry.sdk.metrics._internal.export.MetricExporter.__init__"
+        ).start()
 
-    @classmethod
-    def tearDownClass(cls):
-        super().tearDownClass()
-        cls.mock_get_distribution.stop()
+        # Run tests that validate patch behaviour before and after patching
+        self._run_patch_behaviour_tests()
+        # Run tests not specifically related to patch behaviour
+        self._run_patch_mechanism_tests()
 
-    def test_botocore_not_installed(self):
-        # Test scenario 1: Botocore package not installed
-        self.mock_get_distribution.side_effect = pkg_resources.DistributionNotFound
-        apply_instrumentation_patches()
-        with patch(
-            "amazon.opentelemetry.distro.patches._botocore_patches._apply_botocore_instrumentation_patches"
-        ) as mock_apply_patches:
-            mock_apply_patches.assert_not_called()
+        # Clean up method patches
+        self.mock_get_distribution.stop()
+        self.mock_metric_exporter_init.stop()
 
-    def test_botocore_installed_wrong_version(self):
-        # Test scenario 2: Botocore package installed with wrong version
-        self.mock_get_distribution.side_effect = pkg_resources.VersionConflict("botocore==1.0.0", "botocore==0.0.1")
-        apply_instrumentation_patches()
-        with patch(
-            "amazon.opentelemetry.distro.patches._botocore_patches._apply_botocore_instrumentation_patches"
-        ) as mock_apply_patches:
-            mock_apply_patches.assert_not_called()
-
-    def test_botocore_installed_correct_version(self):
-        # Test scenario 3: Botocore package installed with correct version
-        # Validate unpatched upstream behaviour - important to detect upstream changes that may break instrumentation
-        self._validate_unpatched_botocore_instrumentation()
-
+    def _run_patch_behaviour_tests(self):
+        # Test setup
+        environ["OTEL_EXPORTER_OTLP_PROTOCOL"] = "grpc"
         self.mock_get_distribution.return_value = "CorrectDistributionObject"
+
+        # Validate unpatched upstream behaviour - important to detect upstream changes that may break instrumentation
+        self._test_unpatched_botocore_instrumentation()
+        self._test_unpatched_otlp_metric_exporters()
 
         # Apply patches
         apply_instrumentation_patches()
 
         # Validate patched upstream behaviour - important to detect downstream changes that may break instrumentation
-        self._validate_patched_botocore_instrumentation()
+        self._test_patched_botocore_instrumentation()
+        self._test_patched_otlp_metric_exporters()
 
-    def _validate_unpatched_botocore_instrumentation(self):
+        # Test teardown
+        environ.pop("OTEL_EXPORTER_OTLP_PROTOCOL")
+        self._reset_mocks()
+
+    def _run_patch_mechanism_tests(self):
+        self._test_botocore_installed_flag()
+        self._reset_mocks()
+        self._test_otlp_protocol_flag()
+        self._reset_mocks()
+
+    def _test_unpatched_botocore_instrumentation(self):
         # Kinesis
         self.assertFalse("kinesis" in _KNOWN_EXTENSIONS, "Upstream has added a Kinesis extension")
 
@@ -74,7 +104,22 @@ class TestInstrumentationPatch(TestCase):
         self.assertFalse("aws.sqs.queue_url" in attributes)
         self.assertFalse("aws.sqs.queue_name" in attributes)
 
-    def _validate_patched_botocore_instrumentation(self):
+    def _test_unpatched_otlp_metric_exporters(self):
+        (temporality_dict, aggregation_dict) = _get_metric_exporter_dicts()
+
+        HttpOTLPMetricExporter(preferred_temporality=temporality_dict, preferred_aggregation=aggregation_dict)
+        self.mock_metric_exporter_init.assert_called_once()
+        self.assertEqual(temporality_dict, self.mock_metric_exporter_init.call_args[1]["preferred_temporality"])
+        self.assertNotEqual(aggregation_dict, self.mock_metric_exporter_init.call_args[1]["preferred_aggregation"])
+        self.mock_metric_exporter_init.reset_mock()
+
+        GrpcOTLPMetricExporter(preferred_temporality=temporality_dict, preferred_aggregation=aggregation_dict)
+        self.mock_metric_exporter_init.assert_called_once()
+        self.assertEqual(temporality_dict, self.mock_metric_exporter_init.call_args[1]["preferred_temporality"])
+        self.assertNotEqual(aggregation_dict, self.mock_metric_exporter_init.call_args[1]["preferred_aggregation"])
+        self.mock_metric_exporter_init.reset_mock()
+
+    def _test_patched_botocore_instrumentation(self):
         # Kinesis
         self.assertTrue("kinesis" in _KNOWN_EXTENSIONS)
         kinesis_attributes: Dict[str, str] = _do_extract_kinesis_attributes()
@@ -95,6 +140,80 @@ class TestInstrumentationPatch(TestCase):
         self.assertEqual(sqs_attributes["aws.sqs.queue_url"], _QUEUE_URL)
         self.assertTrue("aws.sqs.queue_name" in sqs_attributes)
         self.assertEqual(sqs_attributes["aws.sqs.queue_name"], _QUEUE_NAME)
+
+    def _test_patched_otlp_metric_exporters(self):
+        (temporality_dict, aggregation_dict) = _get_metric_exporter_dicts()
+
+        HttpOTLPMetricExporter(preferred_temporality=temporality_dict, preferred_aggregation=aggregation_dict)
+        self.mock_metric_exporter_init.assert_called_once()
+        self.assertEqual(temporality_dict, self.mock_metric_exporter_init.call_args[1]["preferred_temporality"])
+        self.assertEqual(aggregation_dict, self.mock_metric_exporter_init.call_args[1]["preferred_aggregation"])
+        self.mock_metric_exporter_init.reset_mock()
+
+        GrpcOTLPMetricExporter(preferred_temporality=temporality_dict, preferred_aggregation=aggregation_dict)
+        self.mock_metric_exporter_init.assert_called_once()
+        self.assertEqual(temporality_dict, self.mock_metric_exporter_init.call_args[1]["preferred_temporality"])
+        self.assertEqual(aggregation_dict, self.mock_metric_exporter_init.call_args[1]["preferred_aggregation"])
+        self.mock_metric_exporter_init.reset_mock()
+
+    def _test_botocore_installed_flag(self):
+        with patch(
+            "amazon.opentelemetry.distro.patches._botocore_patches._apply_botocore_instrumentation_patches"
+        ) as mock_apply_patches:
+            self.mock_get_distribution.side_effect = pkg_resources.DistributionNotFound
+            apply_instrumentation_patches()
+            mock_apply_patches.assert_not_called()
+
+            self.mock_get_distribution.side_effect = pkg_resources.VersionConflict("botocore==1.0.0", "botocore==0.0.1")
+            apply_instrumentation_patches()
+            mock_apply_patches.assert_not_called()
+
+            self.mock_get_distribution.side_effect = None
+            self.mock_get_distribution.return_value = "CorrectDistributionObject"
+            apply_instrumentation_patches()
+            mock_apply_patches.assert_called()
+
+    # pylint: disable=no-self-use
+    def _test_otlp_protocol_flag(self):
+        with patch(
+            "amazon.opentelemetry.distro.patches._otlp_metric_exporter_patches._apply_grpc_otlp_metric_exporter_patches"
+        ) as mock_apply_patch:
+            environ["OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"] = "http/protobuf"
+            environ["OTEL_EXPORTER_OTLP_PROTOCOL"] = "http/protobuf"
+            apply_instrumentation_patches()
+            mock_apply_patch.assert_not_called()
+
+            environ.pop("OTEL_EXPORTER_OTLP_METRICS_PROTOCOL")
+            environ.pop("OTEL_EXPORTER_OTLP_PROTOCOL")
+            apply_instrumentation_patches()
+            mock_apply_patch.assert_not_called()
+
+            environ["OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"] = "http/protobuf"
+            environ["OTEL_EXPORTER_OTLP_PROTOCOL"] = "grpc"
+            apply_instrumentation_patches()
+            mock_apply_patch.assert_not_called()
+
+            environ["OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"] = "grpc"
+            environ["OTEL_EXPORTER_OTLP_PROTOCOL"] = "http/protobuf"
+            apply_instrumentation_patches()
+            mock_apply_patch.assert_called_once()
+            mock_apply_patch.reset_mock()
+
+            environ["OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"] = "grpc"
+            environ.pop("OTEL_EXPORTER_OTLP_PROTOCOL")
+            apply_instrumentation_patches()
+            mock_apply_patch.assert_called_once()
+            mock_apply_patch.reset_mock()
+
+            environ.pop("OTEL_EXPORTER_OTLP_METRICS_PROTOCOL")
+            environ["OTEL_EXPORTER_OTLP_PROTOCOL"] = "grpc"
+            apply_instrumentation_patches()
+            mock_apply_patch.assert_called_once()
+            mock_apply_patch.reset_mock()
+
+    def _reset_mocks(self):
+        self.mock_get_distribution.reset_mock()
+        self.mock_metric_exporter_init.reset_mock()
 
 
 def _do_extract_kinesis_attributes() -> Dict[str, str]:
@@ -122,3 +241,19 @@ def _do_extract_attributes(service_name: str, params: Dict[str, str]) -> Dict[st
     sqs_extension = _KNOWN_EXTENSIONS[service_name]()(mock_call_context)
     sqs_extension.extract_attributes(attributes)
     return attributes
+
+
+def _get_metric_exporter_dicts() -> Tuple:
+    temporality_dict: Dict[type, AggregationTemporality] = {}
+    for typ in [
+        Counter,
+        UpDownCounter,
+        Histogram,
+        ObservableCounter,
+        ObservableUpDownCounter,
+        ObservableGauge,
+    ]:
+        temporality_dict[typ] = AggregationTemporality.DELTA
+
+    aggregation_dict: Dict[type, Aggregation] = {Histogram: ExponentialBucketHistogramAggregation(99, 20)}
+    return temporality_dict, aggregation_dict


### PR DESCRIPTION
### Description

Per [AWS EMF specifications](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html#CloudWatch_Embedded_Metric_Format_Specification_structure_target), metric histograms (numeric arrays) may contain no more than 100 values. Exceeding this results in invalid metric records. For the short term, we have decided that we will simply limit the number of histogram buckets to 100, to avoid this issue. 

In this pull request, we are applying this limitation in `aws_opentelemetry_configurator` by passing in a `preferred_aggregation` to the `OTLPMetricExporter`s . However, we are also doing a lot more in this PR. We never used to pass this information to the exporters because in the OTEL Python SDK release we currently use, the `preferred_aggregation` was not used. To work around this, in `aws_opentelemetry_distro`, we set `OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION` to `base2_exponential_bucket_histogram` so that ALL created histograms would use base2exponential. However, this would not allow us to modify the max number of buckets. Fortunately, the root issue was fixed in the upstream in [this commit](https://github.com/open-telemetry/opentelemetry-python/commit/12f449074e80fa88b59468a48b7a4b99dbcda34d). In this PR, we are creating a patch for `OTLPMetricExporter` that applies this commit - the diff should be identical except where we had to apply linters (which was separated out in a separate commit to make review easier). Because we no longer require the default histogram config, we have removed it from `aws_opentelemtry_distro`. A few other notes:
1. I disabled code coverage for the new patch as there is a lot of patched code that is unchanged and it is not valuable to test
2. `test_instrumentation_patch.py` had to be significantly re-written for reasons that are made clear in the class-level comments.
3. The patch can and should be removed when we take new versions from the upstream.

### Testing Done
Modified AwsSpanMetricsProcessor and contract tests to generate data that will reliably produce 160 histogram buckets (essentially in AwsSpanMetricsProcessor, add a loop that adds a bunch of values that we saw trigger this issue, then print everything in contract tests).

**Scenario 1**: Without any changes (note 161 buckets):
```
metrics {
  name: "Latency"
  unit: "Milliseconds"
  exponential_histogram {
    data_points {
      attributes {
        key: "aws.local.service"
        value {
          string_value: "aws-application-signals-tests-requests-app"
        }
      }
      attributes {
        key: "aws.local.operation"
        value {
          string_value: "InternalOperation"
        }
      }
      attributes {
        key: "aws.span.kind"
        value {
          string_value: "LOCAL_ROOT"
        }
      }
      start_time_unix_nano: 1718035808451029914
      time_unix_nano: 1718035817029199502
      count: 4629
      sum: 46.733796195585931
      scale: 4
      positive {
        offset: -134, bucket_counts: 88, bucket_counts: 1001, bucket_counts: 285, bucket_counts: 241, bucket_counts: 224, bucket_counts: 109, bucket_counts: 73, bucket_counts: 128, bucket_counts: 127, bucket_counts: 88, bucket_counts: 85, bucket_counts: 104, bucket_counts: 119, bucket_counts: 187, bucket_counts: 155, bucket_counts: 172, bucket_counts: 102, bucket_counts: 109, bucket_counts: 120, bucket_counts: 94, bucket_counts: 81, bucket_counts: 104, bucket_counts: 79, bucket_counts: 72, bucket_counts: 65, bucket_counts: 71, bucket_counts: 62, bucket_counts: 63, bucket_counts: 44, bucket_counts: 54, bucket_counts: 31, bucket_counts: 40, bucket_counts: 23, bucket_counts: 21, bucket_counts: 13, bucket_counts: 8, bucket_counts: 14, bucket_counts: 5, bucket_counts: 4, bucket_counts: 4, bucket_counts: 3, bucket_counts: 2, bucket_counts: 1, bucket_counts: 4, bucket_counts: 2, bucket_counts: 2, bucket_counts: 1, bucket_counts: 2, bucket_counts: 1, bucket_counts: 1, bucket_counts: 1, bucket_counts: 0, bucket_counts: 2, bucket_counts: 6, bucket_counts: 2, bucket_counts: 5, bucket_counts: 3, bucket_counts: 3, bucket_counts: 4, bucket_counts: 6, bucket_counts: 6, bucket_counts: 6, bucket_counts: 3, bucket_counts: 6, bucket_counts: 4, bucket_counts: 1, bucket_counts: 3, bucket_counts: 3, bucket_counts: 0, bucket_counts: 3, bucket_counts: 1, bucket_counts: 4, bucket_counts: 1, bucket_counts: 2, bucket_counts: 5, bucket_counts: 2, bucket_counts: 4, bucket_counts: 3, bucket_counts: 3, bucket_counts: 1, bucket_counts: 3, bucket_counts: 2, bucket_counts: 2, bucket_counts: 1, bucket_counts: 2, bucket_counts: 0, bucket_counts: 1, bucket_counts: 2, bucket_counts: 0, bucket_counts: 0, bucket_counts: 2, bucket_counts: 2, bucket_counts: 3, bucket_counts: 1, bucket_counts: 0, bucket_counts: 0, bucket_counts: 2, bucket_counts: 1, bucket_counts: 5, bucket_counts: 0, bucket_counts: 0, bucket_counts: 1, bucket_counts: 0, bucket_counts: 1, bucket_counts: 1, bucket_counts: 1, bucket_counts: 1, bucket_counts: 1, bucket_counts: 1, bucket_counts: 0, bucket_counts: 1, bucket_counts: 1, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 1, bucket_counts: 0, bucket_counts: 1, bucket_counts: 0, bucket_counts: 1, bucket_counts: 2, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 1, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 1, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 2, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 1, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0
      }
      negative { 
        bucket_counts: 0
      }
      min: 0.0030788097239816811
      max: 2.0442737824274104
    }
    data_points {
      attributes {
        key: "aws.local.service"
        value {
          string_value: "aws-application-signals-tests-requests-app"
        }
      }
      attributes {
        key: "aws.local.operation"
        value {
          string_value: "InternalOperation"
        }
      }
      attributes {
        key: "aws.remote.service"
        value {
          string_value: "backend:8080"
        }
      }
      attributes {
        key: "aws.remote.operation"
        value {
          string_value: "GET /backend"
        }
      }
      attributes {
        key: "aws.span.kind"
        value {
          string_value: "CLIENT"
        }
      }
      start_time_unix_nano: 1718035808451029914
      time_unix_nano: 1718035817029199502
      count: 4629
      sum: 46.733796195585931
      scale: 4
      positive {
        offset: -134, bucket_counts: 88, bucket_counts: 1001, bucket_counts: 285, bucket_counts: 241, bucket_counts: 224, bucket_counts: 109, bucket_counts: 73, bucket_counts: 128, bucket_counts: 127, bucket_counts: 88, bucket_counts: 85, bucket_counts: 104, bucket_counts: 119, bucket_counts: 187, bucket_counts: 155, bucket_counts: 172, bucket_counts: 102, bucket_counts: 109, bucket_counts: 120, bucket_counts: 94, bucket_counts: 81, bucket_counts: 104, bucket_counts: 79, bucket_counts: 72, bucket_counts: 65, bucket_counts: 71, bucket_counts: 62, bucket_counts: 63, bucket_counts: 44, bucket_counts: 54, bucket_counts: 31, bucket_counts: 40, bucket_counts: 23, bucket_counts: 21, bucket_counts: 13, bucket_counts: 8, bucket_counts: 14, bucket_counts: 5, bucket_counts: 4, bucket_counts: 4, bucket_counts: 3, bucket_counts: 2, bucket_counts: 1, bucket_counts: 4, bucket_counts: 2, bucket_counts: 2, bucket_counts: 1, bucket_counts: 2, bucket_counts: 1, bucket_counts: 1, bucket_counts: 1, bucket_counts: 0, bucket_counts: 2, bucket_counts: 6, bucket_counts: 2, bucket_counts: 5, bucket_counts: 3, bucket_counts: 3, bucket_counts: 4, bucket_counts: 6, bucket_counts: 6, bucket_counts: 6, bucket_counts: 3, bucket_counts: 6, bucket_counts: 4, bucket_counts: 1, bucket_counts: 3, bucket_counts: 3, bucket_counts: 0, bucket_counts: 3, bucket_counts: 1, bucket_counts: 4, bucket_counts: 1, bucket_counts: 2, bucket_counts: 5, bucket_counts: 2, bucket_counts: 4, bucket_counts: 3, bucket_counts: 3, bucket_counts: 1, bucket_counts: 3, bucket_counts: 2, bucket_counts: 2, bucket_counts: 1, bucket_counts: 2, bucket_counts: 0, bucket_counts: 1, bucket_counts: 2, bucket_counts: 0, bucket_counts: 0, bucket_counts: 2, bucket_counts: 2, bucket_counts: 3, bucket_counts: 1, bucket_counts: 0, bucket_counts: 0, bucket_counts: 2, bucket_counts: 1, bucket_counts: 5, bucket_counts: 0, bucket_counts: 0, bucket_counts: 1, bucket_counts: 0, bucket_counts: 1, bucket_counts: 1, bucket_counts: 1, bucket_counts: 1, bucket_counts: 1, bucket_counts: 1, bucket_counts: 0, bucket_counts: 1, bucket_counts: 1, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 1, bucket_counts: 0, bucket_counts: 1, bucket_counts: 0, bucket_counts: 1, bucket_counts: 2, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 1, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 1, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 2, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 1, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0
      }
      negative { 
        bucket_counts: 0
      }
      min: 0.0030788097239816811
      max: 2.0442737824274104
    }
    aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
  }
}
```

**Scenario 2**: Without patch applied (note it's using explicit buckets because we removed OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION logic):
```
    metrics {
      name: "Latency"
      unit: "Milliseconds"
      histogram {
        data_points {
          attributes {
            key: "aws.local.service"
            value {
              string_value: "aws-application-signals-tests-requests-app"
            }
          }
          attributes {
            key: "aws.local.operation"
            value {
              string_value: "InternalOperation"
            }
          }
          attributes {
            key: "aws.span.kind"
            value {
              string_value: "LOCAL_ROOT"
            }
          }
          start_time_unix_nano: 1718048103153902275
          time_unix_nano: 1718048106929937849
          count: 109
          sum: 15.14611171299984, 
          bucket_counts: 0, bucket_counts: 109, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0
          explicit_bounds: 0, explicit_bounds: 5, explicit_bounds: 10, explicit_bounds: 25, explicit_bounds: 50, explicit_bounds: 75, explicit_bounds: 100, explicit_bounds: 250, explicit_bounds: 500, explicit_bounds: 750, explicit_bounds: 1000, explicit_bounds: 2500, explicit_bounds: 5000, explicit_bounds: 7500, explicit_bounds: 10000
          min: 0.0030788097239816811
          max: 2.0442737824274104
        }
        data_points {
          attributes {
            key: "aws.local.service"
            value {
              string_value: "aws-application-signals-tests-requests-app"
            }
          }
          attributes {
            key: "aws.local.operation"
            value {
              string_value: "InternalOperation"
            }
          }
          attributes {
            key: "aws.remote.service"
            value {
              string_value: "backend:8080"
            }
          }
          attributes {
            key: "aws.remote.operation"
            value {
              string_value: "GET /backend"
            }
          }
          attributes {
            key: "aws.span.kind"
            value {
              string_value: "CLIENT"
            }
          }
          start_time_unix_nano: 1718048103153902275
          time_unix_nano: 1718048106929937849
          count: 109
          sum: 15.14611171299984
          bucket_counts: 0, bucket_counts: 109, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0
          explicit_bounds: 0, explicit_bounds: 5, explicit_bounds: 10, explicit_bounds: 25, explicit_bounds: 50, explicit_bounds: 75, explicit_bounds: 100, explicit_bounds: 250, explicit_bounds: 500, explicit_bounds: 750, explicit_bounds: 1000, explicit_bounds: 2500, explicit_bounds: 5000, explicit_bounds: 7500, explicit_bounds: 10000
          min: 0.0030788097239816811
          max: 2.0442737824274104
        }
        aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
      }
    }
  }
```

**Scenario 3**: With changes and patch (note 100 buckets):
```
metrics {
  name: "Latency"
  unit: "Milliseconds"
  exponential_histogram {
    data_points {
      attributes {
        key: "aws.local.service"
        value {
          string_value: "aws-application-signals-tests-requests-app"
        }
      }
      attributes {
        key: "aws.local.operation"
        value {
          string_value: "InternalOperation"
        }
      }
      attributes {
        key: "aws.span.kind"
        value {
          string_value: "LOCAL_ROOT"
        }
      }
      start_time_unix_nano: 1718036741890154426
      time_unix_nano: 1718036750422319159
      count: 4629
      sum: 46.733796195585931
      scale: 3
      positive {
        offset: -67, bucket_counts: 1089, bucket_counts: 526, bucket_counts: 333, bucket_counts: 201, bucket_counts: 215, bucket_counts: 189, bucket_counts: 306, bucket_counts: 327, bucket_counts: 211, bucket_counts: 214, bucket_counts: 185, bucket_counts: 151, bucket_counts: 136, bucket_counts: 125, bucket_counts: 98, bucket_counts: 71, bucket_counts: 44, bucket_counts: 21, bucket_counts: 19, bucket_counts: 8, bucket_counts: 5, bucket_counts: 5, bucket_counts: 4, bucket_counts: 3, bucket_counts: 2, bucket_counts: 1, bucket_counts: 8, bucket_counts: 7, bucket_counts: 6, bucket_counts: 10, bucket_counts: 12, bucket_counts: 9, bucket_counts: 5, bucket_counts: 6, bucket_counts: 3, bucket_counts: 5, bucket_counts: 3, bucket_counts: 7, bucket_counts: 7, bucket_counts: 4, bucket_counts: 5, bucket_counts: 3, bucket_counts: 2, bucket_counts: 3, bucket_counts: 0, bucket_counts: 4, bucket_counts: 4, bucket_counts: 0, bucket_counts: 3, bucket_counts: 5, bucket_counts: 1, bucket_counts: 1, bucket_counts: 2, bucket_counts: 2, bucket_counts: 1, bucket_counts: 2, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 1, bucket_counts: 1, bucket_counts: 1, bucket_counts: 2, bucket_counts: 0, bucket_counts: 0, bucket_counts: 1, bucket_counts: 0, bucket_counts: 0, bucket_counts: 1, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 2, bucket_counts: 0, bucket_counts: 1, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0
      }
      negative { 
        bucket_counts: 0
      }
      min: 0.0030788097239816811
      max: 2.0442737824274104
    }
    data_points {
      attributes {
        key: "aws.local.service"
        value {
          string_value: "aws-application-signals-tests-requests-app"
        }
      }
      attributes {
        key: "aws.local.operation"
        value {
          string_value: "InternalOperation"
        }
      }
      attributes {
        key: "aws.remote.service"
        value {
          string_value: "backend:8080"
        }
      }
      attributes {
        key: "aws.remote.operation"
        value {
          string_value: "GET /backend"
        }
      }
      attributes {
        key: "aws.span.kind"
        value {
          string_value: "CLIENT"
        }
      }
      start_time_unix_nano: 1718036741890154426
      time_unix_nano: 1718036750422319159
      count: 4629
      sum: 46.733796195585931
      scale: 3
      positive {
        offset: -67, bucket_counts: 1089, bucket_counts: 526, bucket_counts: 333, bucket_counts: 201, bucket_counts: 215, bucket_counts: 189, bucket_counts: 306, bucket_counts: 327, bucket_counts: 211, bucket_counts: 214, bucket_counts: 185, bucket_counts: 151, bucket_counts: 136, bucket_counts: 125, bucket_counts: 98, bucket_counts: 71, bucket_counts: 44, bucket_counts: 21, bucket_counts: 19, bucket_counts: 8, bucket_counts: 5, bucket_counts: 5, bucket_counts: 4, bucket_counts: 3, bucket_counts: 2, bucket_counts: 1, bucket_counts: 8, bucket_counts: 7, bucket_counts: 6, bucket_counts: 10, bucket_counts: 12, bucket_counts: 9, bucket_counts: 5, bucket_counts: 6, bucket_counts: 3, bucket_counts: 5, bucket_counts: 3, bucket_counts: 7, bucket_counts: 7, bucket_counts: 4, bucket_counts: 5, bucket_counts: 3, bucket_counts: 2, bucket_counts: 3, bucket_counts: 0, bucket_counts: 4, bucket_counts: 4, bucket_counts: 0, bucket_counts: 3, bucket_counts: 5, bucket_counts: 1, bucket_counts: 1, bucket_counts: 2, bucket_counts: 2, bucket_counts: 1, bucket_counts: 2, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 1, bucket_counts: 1, bucket_counts: 1, bucket_counts: 2, bucket_counts: 0, bucket_counts: 0, bucket_counts: 1, bucket_counts: 0, bucket_counts: 0, bucket_counts: 1, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 2, bucket_counts: 0, bucket_counts: 1, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0, bucket_counts: 0
      }
      negative { 
        bucket_counts: 0
      }
      min: 0.0030788097239816811
      max: 2.0442737824274104
    }
    aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
  }
}
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

