### PR TITLE
Adds contract test for CREATE DATABASE for PostgreSQL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ examples/**/build/
 
 # Performance test results
 **/performance-tests/results/
+

--- a/contract-tests/images/applications/psycopg2/psycopg2_server.py
+++ b/contract-tests/images/applications/psycopg2/psycopg2_server.py
@@ -27,7 +27,7 @@ class RequestHandler(BaseHTTPRequestHandler):
     def do_GET(self):
         status_code: int = 200
         conn = psycopg2.connect(dbname=_DB_NAME, user=_DB_USER, password=_DB_PASS, host=_DB_HOST)
-        conn.autocommit = True # CREATE DATABASE cannot run in a transaction block
+        conn.autocommit = True  # CREATE DATABASE cannot run in a transaction block
         if self.in_path(_DROP_TABLE):
             cur = conn.cursor()
             cur.execute("DROP TABLE IF EXISTS test_table")

--- a/contract-tests/images/applications/psycopg2/psycopg2_server.py
+++ b/contract-tests/images/applications/psycopg2/psycopg2_server.py
@@ -10,9 +10,10 @@ import psycopg2
 from typing_extensions import override
 
 _PORT: int = 8080
-_SUCCESS: str = "success"
+_DROP_TABLE: str = "drop_table"
 _ERROR: str = "error"
 _FAULT: str = "fault"
+_CREATE_DATABASE: str = "create_database"
 
 _DB_HOST = os.getenv("DB_HOST")
 _DB_USER = os.getenv("DB_USER")
@@ -26,9 +27,15 @@ class RequestHandler(BaseHTTPRequestHandler):
     def do_GET(self):
         status_code: int = 200
         conn = psycopg2.connect(dbname=_DB_NAME, user=_DB_USER, password=_DB_PASS, host=_DB_HOST)
-        if self.in_path(_SUCCESS):
+        conn.autocommit = True # CREATE DATABASE cannot run in a transaction block
+        if self.in_path(_DROP_TABLE):
             cur = conn.cursor()
             cur.execute("DROP TABLE IF EXISTS test_table")
+            cur.close()
+            status_code = 200
+        elif self.in_path(_CREATE_DATABASE):
+            cur = conn.cursor()
+            cur.execute("CREATE DATABASE test_database")
             cur.close()
             status_code = 200
         elif self.in_path(_FAULT):

--- a/contract-tests/tests/test/amazon/psycopg2/psycopg2_test.py
+++ b/contract-tests/tests/test/amazon/psycopg2/psycopg2_test.py
@@ -51,9 +51,13 @@ class Psycopg2Test(ContractTestBase):
     def get_application_image_name(self) -> str:
         return "aws-application-signals-tests-psycopg2-app"
 
-    def test_success(self) -> None:
+    def test_drop_table_succeeds(self) -> None:
         self.mock_collector_client.clear_signals()
-        self.do_test_requests("success", "GET", 200, 0, 0, sql_command="DROP TABLE")
+        self.do_test_requests("drop_table", "GET", 200, 0, 0, sql_command="DROP TABLE")
+
+    def test_create_database_succeeds(self) -> None:
+        self.mock_collector_client.clear_signals()
+        self.do_test_requests("create_database", "GET", 200, 0, 0, sql_command="CREATE DATABASE")
 
     def test_fault(self) -> None:
         self.mock_collector_client.clear_signals()


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Adding PostgreSQL contract tests for app signals to ensure that customer experience doesn't break with any change. The new contract test covers the CREATE DATABASE SQL command.

The new contract test follows the same structure as the current [Python test](https://github.com/aws-observability/aws-otel-python-instrumentation/blob/main/contract-tests/tests/test/amazon/psycopg2/psycopg2_test.py) and asserts on the same fields of the spans and attributes.

Contract tests running successfully:
```
$ ./scripts/build_and_install_distro.sh
...
$ ./scripts/set-up-contract-tests.sh
...
$ pytest contract-tests/tests
============================= test session starts ==============================
...
platform linux -- Python 3.8.11, pytest-7.1.3, pluggy-1.5.0
rootdir: /home/gbochile/aws-otel-python-instrumentation/contract-tests/tests, configfile: pyproject.toml
plugins: cov-4.1.0, flaky-3.7.0
collected 3 items

../../../../home/gbochile/aws-otel-python-instrumentation/contract-tests/tests/test/amazon/psycopg2/psycopg2_test.py::Psycopg2Test::test_create_database_succeeds 
-------------------------------- live log setup --------------------------------
2024-06-12 12:47:45 [    INFO] Pulling image aws-application-signals-mock-collector-python (container.py:53)
2024-06-12 12:47:45 [    INFO] Container started: d245255255f2 (container.py:64)
2024-06-12 12:47:46 [    INFO] Pulling image postgres:latest (container.py:53)
2024-06-12 12:47:47 [    INFO] Container started: 74ed6462ad77 (container.py:64)
2024-06-12 12:47:47 [    INFO] Waiting to be ready... (waiting_utils.py:46)
2024-06-12 12:47:47 [    INFO] Waiting to be ready... (waiting_utils.py:46)
2024-06-12 12:47:48 [    INFO] Waiting to be ready... (waiting_utils.py:46)
-------------------------------- live log call ---------------------------------
2024-06-12 12:47:48 [    INFO] Pulling image aws-application-signals-tests-psycopg2-app (container.py:53)
2024-06-12 12:47:48 [    INFO] Container started: e46d8cee477f (container.py:64)
2024-06-12 12:47:54 [    INFO] Waiting to be ready... (waiting_utils.py:46)
2024-06-12 12:47:54 [    INFO] Waiting to be ready... (waiting_utils.py:46)
2024-06-12 12:47:55 [    INFO] Application stdout (contract_test_base.py:118)
2024-06-12 12:47:55 [    INFO] Ready
 (contract_test_base.py:119)
2024-06-12 12:47:55 [    INFO] Application stderr (contract_test_base.py:120)
2024-06-12 12:47:55 [    INFO] Failed to get k8s token: [Errno 2] No such file or directory: '/var/run/secrets/kubernetes.io/serviceaccount/token'
AwsEcsResourceDetector failed: Missing ECS_CONTAINER_METADATA_URI therefore process is not on ECS.
AwsEksResourceDetector failed: [Errno 2] No such file or directory: '/var/run/secrets/kubernetes.io/serviceaccount/token'
Exception  in detector <opentelemetry.sdk.extension.aws.resource.ec2.AwsEc2ResourceDetector object at 0x7fef12fac460>, ignoring
AwsEc2ResourceDetector failed: timed out
Configuration of configurator not loaded, aws_configurator already loaded
 (contract_test_base.py:121)
PASSED                                                                   [ 33%]
../../../../home/gbochile/aws-otel-python-instrumentation/contract-tests/tests/test/amazon/psycopg2/psycopg2_test.py::Psycopg2Test::test_drop_table_succeeds 
-------------------------------- live log call ---------------------------------
2024-06-12 12:47:55 [    INFO] Pulling image aws-application-signals-tests-psycopg2-app (container.py:53)
2024-06-12 12:47:55 [    INFO] Container started: d40b97a71e67 (container.py:64)
2024-06-12 12:48:01 [    INFO] Waiting to be ready... (waiting_utils.py:46)
2024-06-12 12:48:02 [    INFO] Waiting to be ready... (waiting_utils.py:46)
2024-06-12 12:48:02 [    INFO] Application stdout (contract_test_base.py:118)
2024-06-12 12:48:02 [    INFO] Ready
 (contract_test_base.py:119)
2024-06-12 12:48:02 [    INFO] Application stderr (contract_test_base.py:120)
2024-06-12 12:48:02 [    INFO] Failed to get k8s token: [Errno 2] No such file or directory: '/var/run/secrets/kubernetes.io/serviceaccount/token'
AwsEcsResourceDetector failed: Missing ECS_CONTAINER_METADATA_URI therefore process is not on ECS.
AwsEksResourceDetector failed: [Errno 2] No such file or directory: '/var/run/secrets/kubernetes.io/serviceaccount/token'
Exception  in detector <opentelemetry.sdk.extension.aws.resource.ec2.AwsEc2ResourceDetector object at 0x7ffadf954340>, ignoring
AwsEc2ResourceDetector failed: timed out
Configuration of configurator not loaded, aws_configurator already loaded
 (contract_test_base.py:121)
PASSED                                                                   [ 66%]
../../../../home/gbochile/aws-otel-python-instrumentation/contract-tests/tests/test/amazon/psycopg2/psycopg2_test.py::Psycopg2Test::test_fault 
-------------------------------- live log call ---------------------------------
2024-06-12 12:48:02 [    INFO] Pulling image aws-application-signals-tests-psycopg2-app (container.py:53)
2024-06-12 12:48:03 [    INFO] Container started: fce0d7a0c79d (container.py:64)
2024-06-12 12:48:09 [    INFO] Waiting to be ready... (waiting_utils.py:46)
2024-06-12 12:48:09 [    INFO] Waiting to be ready... (waiting_utils.py:46)
2024-06-12 12:48:09 [    INFO] Application stdout (contract_test_base.py:118)
2024-06-12 12:48:09 [    INFO] Ready
Expected Exception with Invalid SQL occurred: relation "invalid_table" does not exist
LINE 1: SELECT DISTINCT id, name FROM invalid_table
                                      ^

 (contract_test_base.py:119)
2024-06-12 12:48:09 [    INFO] Application stderr (contract_test_base.py:120)
2024-06-12 12:48:09 [    INFO] Failed to get k8s token: [Errno 2] No such file or directory: '/var/run/secrets/kubernetes.io/serviceaccount/token'
AwsEcsResourceDetector failed: Missing ECS_CONTAINER_METADATA_URI therefore process is not on ECS.
AwsEksResourceDetector failed: [Errno 2] No such file or directory: '/var/run/secrets/kubernetes.io/serviceaccount/token'
Exception  in detector <opentelemetry.sdk.extension.aws.resource.ec2.AwsEc2ResourceDetector object at 0x7f22a937c940>, ignoring
AwsEc2ResourceDetector failed: timed out
Configuration of configurator not loaded, aws_configurator already loaded
 (contract_test_base.py:121)
PASSED                                                                   [100%]
------------------------------ live log teardown -------------------------------
2024-06-12 12:48:10 [    INFO] MockCollector stdout (contract_test_base.py:71)
2024-06-12 12:48:10 [    INFO] Ready
 (contract_test_base.py:72)
2024-06-12 12:48:10 [    INFO] MockCollector stderr (contract_test_base.py:73)
2024-06-12 12:48:10 [    INFO]  (contract_test_base.py:74)
...
======================== 36 passed in 310.77s (0:05:10) ========================
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

