### PR TITLE
Adds contract test for CREATE DATABASE for MySQL

### DIFF
--- a/contract-tests/images/applications/botocore/botocore_server.py
+++ b/contract-tests/images/applications/botocore/botocore_server.py
@@ -10,7 +10,7 @@ import boto3
 import requests
 from botocore.client import BaseClient
 from botocore.config import Config
-from typing_extensions import override
+from typing_extensions import Tuple, override
 
 _PORT: int = 8080
 _ERROR: str = "error"
@@ -253,7 +253,7 @@ def prepare_aws_server() -> None:
 
 def main() -> None:
     prepare_aws_server()
-    server_address: tuple[str, int] = ("0.0.0.0", _PORT)
+    server_address: Tuple[str, int] = ("0.0.0.0", _PORT)
     request_handler_class: type = RequestHandler
     requests_server: ThreadingHTTPServer = ThreadingHTTPServer(server_address, request_handler_class)
     atexit.register(requests_server.shutdown)

--- a/contract-tests/images/applications/pymysql/pymysql_server.py
+++ b/contract-tests/images/applications/pymysql/pymysql_server.py
@@ -9,10 +9,11 @@ from typing import Tuple
 import pymysql
 from typing_extensions import override
 
-_PORT: int = 8080
-_SUCCESS: str = "success"
+_CREATE_DATABASE: str = "create_database"
+_DROP_TABLE: str = "drop_table"
 _ERROR: str = "error"
 _FAULT: str = "fault"
+_PORT: int = 8080
 
 _DB_HOST = os.getenv("DB_HOST")
 _DB_USER = os.getenv("DB_USER")
@@ -26,9 +27,15 @@ class RequestHandler(BaseHTTPRequestHandler):
     def do_GET(self):
         status_code: int = 200
         conn = pymysql.connect(host=_DB_HOST, user=_DB_USER, password=_DB_PASS, database=_DB_NAME)
-        if self.in_path(_SUCCESS):
+        conn.autocommit = True  # CREATE DATABASE cannot run in a transaction block
+        if self.in_path(_DROP_TABLE):
             cur = conn.cursor()
             cur.execute("DROP TABLE IF EXISTS test_table")
+            cur.close()
+            status_code = 200
+        elif self.in_path(_CREATE_DATABASE):
+            cur = conn.cursor()
+            cur.execute("CREATE DATABASE test_database")
             cur.close()
             status_code = 200
         elif self.in_path(_FAULT):

--- a/contract-tests/tests/test/amazon/base/contract_test_base.py
+++ b/contract-tests/tests/test/amazon/base/contract_test_base.py
@@ -193,7 +193,8 @@ class ContractTestBase(TestCase):
     def get_application_network_aliases(self) -> List[str]:
         return []
 
-    def get_application_image_name(self) -> str:
+    @staticmethod
+    def get_application_image_name() -> str:
         return None
 
     def get_application_wait_pattern(self) -> str:

--- a/contract-tests/tests/test/amazon/base/database_contract_test_base.py
+++ b/contract-tests/tests/test/amazon/base/database_contract_test_base.py
@@ -1,0 +1,152 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+from typing import Dict, List
+
+from mock_collector_client import ResourceScopeMetric, ResourceScopeSpan
+from typing_extensions import override
+
+from amazon.base.contract_test_base import ContractTestBase
+from amazon.utils.application_signals_constants import (
+    AWS_LOCAL_OPERATION,
+    AWS_LOCAL_SERVICE,
+    AWS_REMOTE_OPERATION,
+    AWS_REMOTE_RESOURCE_IDENTIFIER,
+    AWS_REMOTE_RESOURCE_TYPE,
+    AWS_REMOTE_SERVICE,
+    AWS_SPAN_KIND,
+)
+from opentelemetry.proto.common.v1.common_pb2 import AnyValue, KeyValue
+from opentelemetry.proto.metrics.v1.metrics_pb2 import ExponentialHistogramDataPoint, Metric
+from opentelemetry.proto.trace.v1.trace_pb2 import Span
+from opentelemetry.trace import StatusCode
+
+DATABASE_HOST: str = "mydb"
+DATABASE_USER: str = "root"
+DATABASE_PASSWORD: str = "example"
+DATABASE_NAME: str = "testdb"
+
+
+class DatabaseContractTestBase(ContractTestBase):
+    def assert_drop_table_succeeds(self) -> None:
+        self.mock_collector_client.clear_signals()
+        self.do_test_requests("drop_table", "GET", 200, 0, 0, sql_command="DROP TABLE")
+
+    def assert_create_database_succeeds(self) -> None:
+        self.mock_collector_client.clear_signals()
+        self.do_test_requests("create_database", "GET", 200, 0, 0, sql_command="CREATE DATABASE")
+
+    def assert_fault(self) -> None:
+        self.mock_collector_client.clear_signals()
+        self.do_test_requests("fault", "GET", 500, 0, 1, sql_command="SELECT DISTINCT")
+
+    @override
+    def get_application_extra_environment_variables(self) -> Dict[str, str]:
+        return {
+            "DB_HOST": DATABASE_HOST,
+            "DB_USER": DATABASE_USER,
+            "DB_PASS": DATABASE_PASSWORD,
+            "DB_NAME": DATABASE_NAME,
+        }
+
+    @override
+    def _assert_aws_span_attributes(self, resource_scope_spans: List[ResourceScopeSpan], path: str, **kwargs) -> None:
+        target_spans: List[Span] = []
+        for resource_scope_span in resource_scope_spans:
+            # pylint: disable=no-member
+            if resource_scope_span.span.kind == Span.SPAN_KIND_CLIENT:
+                target_spans.append(resource_scope_span.span)
+
+        self.assertEqual(len(target_spans), 1)
+        self._assert_aws_attributes(target_spans[0].attributes, **kwargs)
+
+    @override
+    def _assert_semantic_conventions_span_attributes(
+        self, resource_scope_spans: List[ResourceScopeSpan], method: str, path: str, status_code: int, **kwargs
+    ) -> None:
+        target_spans: List[Span] = []
+        for resource_scope_span in resource_scope_spans:
+            # pylint: disable=no-member
+            if resource_scope_span.span.kind == Span.SPAN_KIND_CLIENT:
+                target_spans.append(resource_scope_span.span)
+
+        self.assertEqual(target_spans[0].name, kwargs.get("sql_command").split()[0])
+        if status_code == 200:
+            self.assertEqual(target_spans[0].status.code, StatusCode.UNSET.value)
+        else:
+            self.assertEqual(target_spans[0].status.code, StatusCode.ERROR.value)
+
+        self._assert_semantic_conventions_attributes(target_spans[0].attributes, kwargs.get("sql_command"))
+
+    def _assert_semantic_conventions_attributes(self, attributes_list: List[KeyValue], command: str) -> None:
+        attributes_dict: Dict[str, AnyValue] = self._get_attributes_dict(attributes_list)
+        self.assertTrue(attributes_dict.get("db.statement").string_value.startswith(command))
+        self._assert_str_attribute(attributes_dict, "db.system", self.get_remote_service())
+        self._assert_str_attribute(attributes_dict, "db.name", DATABASE_NAME)
+        self._assert_str_attribute(attributes_dict, "net.peer.name", DATABASE_HOST)
+        self._assert_int_attribute(attributes_dict, "net.peer.port", self.get_database_port())
+        self.assertTrue("server.address" not in attributes_dict)
+        self.assertTrue("server.port" not in attributes_dict)
+        self.assertTrue("db.operation" not in attributes_dict)
+
+    @override
+    def _assert_aws_attributes(self, attributes_list: List[KeyValue], **kwargs) -> None:
+        attributes_dict: Dict[str, AnyValue] = self._get_attributes_dict(attributes_list)
+        self._assert_str_attribute(attributes_dict, AWS_LOCAL_SERVICE, self.get_application_otel_service_name())
+        # InternalOperation as OTEL does not instrument the basic server we are using, so the client span is a local
+        # root.
+        self._assert_str_attribute(attributes_dict, AWS_LOCAL_OPERATION, "InternalOperation")
+        self._assert_str_attribute(attributes_dict, AWS_REMOTE_SERVICE, self.get_remote_service())
+        self._assert_str_attribute(attributes_dict, AWS_REMOTE_OPERATION, kwargs.get("sql_command"))
+        self._assert_str_attribute(attributes_dict, AWS_REMOTE_RESOURCE_TYPE, "DB::Connection")
+        self._assert_str_attribute(
+            attributes_dict, AWS_REMOTE_RESOURCE_IDENTIFIER, self.get_remote_resource_identifier()
+        )
+        # See comment above AWS_LOCAL_OPERATION
+        self._assert_str_attribute(attributes_dict, AWS_SPAN_KIND, "LOCAL_ROOT")
+
+    @override
+    def _assert_metric_attributes(
+        self, resource_scope_metrics: List[ResourceScopeMetric], metric_name: str, expected_sum: int, **kwargs
+    ) -> None:
+        target_metrics: List[Metric] = []
+        for resource_scope_metric in resource_scope_metrics:
+            if resource_scope_metric.metric.name.lower() == metric_name.lower():
+                target_metrics.append(resource_scope_metric.metric)
+
+        self.assertEqual(len(target_metrics), 1)
+        target_metric: Metric = target_metrics[0]
+        dp_list: List[ExponentialHistogramDataPoint] = target_metric.exponential_histogram.data_points
+
+        self.assertEqual(len(dp_list), 2)
+        dependency_dp: ExponentialHistogramDataPoint = dp_list[0]
+        service_dp: ExponentialHistogramDataPoint = dp_list[1]
+        if len(dp_list[1].attributes) > len(dp_list[0].attributes):
+            dependency_dp = dp_list[1]
+            service_dp = dp_list[0]
+        attribute_dict: Dict[str, AnyValue] = self._get_attributes_dict(dependency_dp.attributes)
+        self._assert_str_attribute(attribute_dict, AWS_LOCAL_SERVICE, self.get_application_otel_service_name())
+        # See comment on AWS_LOCAL_OPERATION in _assert_aws_attributes
+        self._assert_str_attribute(attribute_dict, AWS_LOCAL_OPERATION, "InternalOperation")
+        self._assert_str_attribute(attribute_dict, AWS_REMOTE_SERVICE, self.get_remote_service())
+        self._assert_str_attribute(attribute_dict, AWS_REMOTE_OPERATION, kwargs.get("sql_command"))
+        self._assert_str_attribute(attribute_dict, AWS_REMOTE_RESOURCE_TYPE, "DB::Connection")
+        self._assert_str_attribute(
+            attribute_dict, AWS_REMOTE_RESOURCE_IDENTIFIER, self.get_remote_resource_identifier()
+        )
+        self._assert_str_attribute(attribute_dict, AWS_SPAN_KIND, "CLIENT")
+        self.check_sum(metric_name, dependency_dp.sum, expected_sum)
+
+        attribute_dict: Dict[str, AnyValue] = self._get_attributes_dict(service_dp.attributes)
+        # See comment on AWS_LOCAL_OPERATION in _assert_aws_attributes
+        self._assert_str_attribute(attribute_dict, AWS_LOCAL_OPERATION, "InternalOperation")
+        self._assert_str_attribute(attribute_dict, AWS_SPAN_KIND, "LOCAL_ROOT")
+        self.check_sum(metric_name, service_dp.sum, expected_sum)
+
+    def get_remote_resource_identifier(self) -> str:
+        return f"{DATABASE_NAME}|{DATABASE_HOST}|{self.get_database_port()}"
+
+    def get_remote_service(self) -> str:
+        return None
+
+    def get_database_port(self) -> int:
+        return None

--- a/contract-tests/tests/test/amazon/base/database_contract_test_base.py
+++ b/contract-tests/tests/test/amazon/base/database_contract_test_base.py
@@ -27,6 +27,26 @@ DATABASE_NAME: str = "testdb"
 
 
 class DatabaseContractTestBase(ContractTestBase):
+    @staticmethod
+    def get_remote_service() -> str:
+        return None
+
+    @staticmethod
+    def get_database_port() -> int:
+        return None
+
+    def get_remote_resource_identifier(self) -> str:
+        return f"{DATABASE_NAME}|{DATABASE_HOST}|{self.get_database_port()}"
+
+    @override
+    def get_application_extra_environment_variables(self) -> Dict[str, str]:
+        return {
+            "DB_HOST": DATABASE_HOST,
+            "DB_USER": DATABASE_USER,
+            "DB_PASS": DATABASE_PASSWORD,
+            "DB_NAME": DATABASE_NAME,
+        }
+
     def assert_drop_table_succeeds(self) -> None:
         self.mock_collector_client.clear_signals()
         self.do_test_requests("drop_table", "GET", 200, 0, 0, sql_command="DROP TABLE")
@@ -38,15 +58,6 @@ class DatabaseContractTestBase(ContractTestBase):
     def assert_fault(self) -> None:
         self.mock_collector_client.clear_signals()
         self.do_test_requests("fault", "GET", 500, 0, 1, sql_command="SELECT DISTINCT")
-
-    @override
-    def get_application_extra_environment_variables(self) -> Dict[str, str]:
-        return {
-            "DB_HOST": DATABASE_HOST,
-            "DB_USER": DATABASE_USER,
-            "DB_PASS": DATABASE_PASSWORD,
-            "DB_NAME": DATABASE_NAME,
-        }
 
     @override
     def _assert_aws_span_attributes(self, resource_scope_spans: List[ResourceScopeSpan], path: str, **kwargs) -> None:
@@ -141,12 +152,3 @@ class DatabaseContractTestBase(ContractTestBase):
         self._assert_str_attribute(attribute_dict, AWS_LOCAL_OPERATION, "InternalOperation")
         self._assert_str_attribute(attribute_dict, AWS_SPAN_KIND, "LOCAL_ROOT")
         self.check_sum(metric_name, service_dp.sum, expected_sum)
-
-    def get_remote_resource_identifier(self) -> str:
-        return f"{DATABASE_NAME}|{DATABASE_HOST}|{self.get_database_port()}"
-
-    def get_remote_service(self) -> str:
-        return None
-
-    def get_database_port(self) -> int:
-        return None

--- a/contract-tests/tests/test/amazon/botocore/botocore_test.py
+++ b/contract-tests/tests/test/amazon/botocore/botocore_test.py
@@ -49,7 +49,8 @@ class BotocoreTest(ContractTestBase):
         return ["error.test", "fault.test"]
 
     @override
-    def get_application_image_name(self) -> str:
+    @staticmethod
+    def get_application_image_name() -> str:
         return "aws-application-signals-tests-botocore-app"
 
     @classmethod

--- a/contract-tests/tests/test/amazon/django/django_test.py
+++ b/contract-tests/tests/test/amazon/django/django_test.py
@@ -15,7 +15,8 @@ from opentelemetry.semconv.trace import SpanAttributes
 
 class DjangoTest(ContractTestBase):
     @override
-    def get_application_image_name(self) -> str:
+    @staticmethod
+    def get_application_image_name() -> str:
         return "aws-application-signals-tests-django-app"
 
     @override

--- a/contract-tests/tests/test/amazon/misc/configuration_test.py
+++ b/contract-tests/tests/test/amazon/misc/configuration_test.py
@@ -17,7 +17,8 @@ from opentelemetry.sdk.metrics.export import AggregationTemporality
 
 class ConfigurationTest(ContractTestBase):
     @override
-    def get_application_image_name(self) -> str:
+    @staticmethod
+    def get_application_image_name() -> str:
         return "aws-application-signals-tests-django-app"
 
     @override

--- a/contract-tests/tests/test/amazon/misc/resource_attributes_test_base.py
+++ b/contract-tests/tests/test/amazon/misc/resource_attributes_test_base.py
@@ -30,7 +30,8 @@ def _get_k8s_attributes():
 
 class ResourceAttributesTest(ContractTestBase):
     @override
-    def get_application_image_name(self) -> str:
+    @staticmethod
+    def get_application_image_name() -> str:
         return "aws-application-signals-tests-django-app"
 
     @override

--- a/contract-tests/tests/test/amazon/psycopg2/psycopg2_test.py
+++ b/contract-tests/tests/test/amazon/psycopg2/psycopg2_test.py
@@ -30,16 +30,19 @@ class Psycopg2Test(DatabaseContractTestBase):
         cls.container.stop()
 
     @override
-    def get_application_image_name(self) -> str:
-        return "aws-application-signals-tests-psycopg2-app"
-
-    @override
-    def get_remote_service(self) -> str:
+    @staticmethod
+    def get_remote_service() -> str:
         return "postgresql"
 
     @override
-    def get_database_port(self) -> int:
+    @staticmethod
+    def get_database_port() -> int:
         return 5432
+
+    @override
+    @staticmethod
+    def get_application_image_name() -> str:
+        return "aws-application-signals-tests-psycopg2-app"
 
     def test_drop_table_succeeds(self) -> None:
         self.assert_drop_table_succeeds()

--- a/contract-tests/tests/test/amazon/psycopg2/psycopg2_test.py
+++ b/contract-tests/tests/test/amazon/psycopg2/psycopg2_test.py
@@ -1,35 +1,26 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-from typing import Dict, List
-
-from mock_collector_client import ResourceScopeMetric, ResourceScopeSpan
 from testcontainers.postgres import PostgresContainer
 from typing_extensions import override
 
-from amazon.base.contract_test_base import NETWORK_NAME, ContractTestBase
-from amazon.utils.application_signals_constants import (
-    AWS_LOCAL_OPERATION,
-    AWS_LOCAL_SERVICE,
-    AWS_REMOTE_OPERATION,
-    AWS_REMOTE_RESOURCE_IDENTIFIER,
-    AWS_REMOTE_RESOURCE_TYPE,
-    AWS_REMOTE_SERVICE,
-    AWS_SPAN_KIND,
+from amazon.base.contract_test_base import NETWORK_NAME
+from amazon.base.database_contract_test_base import (
+    DATABASE_HOST,
+    DATABASE_NAME,
+    DATABASE_PASSWORD,
+    DATABASE_USER,
+    DatabaseContractTestBase,
 )
-from opentelemetry.proto.common.v1.common_pb2 import AnyValue, KeyValue
-from opentelemetry.proto.metrics.v1.metrics_pb2 import ExponentialHistogramDataPoint, Metric
-from opentelemetry.proto.trace.v1.trace_pb2 import Span
-from opentelemetry.trace import StatusCode
 
 
-class Psycopg2Test(ContractTestBase):
+class Psycopg2Test(DatabaseContractTestBase):
     @override
     @classmethod
     def set_up_dependency_container(cls) -> None:
         cls.container = (
-            PostgresContainer(user="dbuser", password="example", dbname="postgres")
+            PostgresContainer(user=DATABASE_USER, password=DATABASE_PASSWORD, dbname=DATABASE_NAME)
             .with_kwargs(network=NETWORK_NAME)
-            .with_name("mydb")
+            .with_name(DATABASE_HOST)
         )
         cls.container.start()
 
@@ -39,117 +30,22 @@ class Psycopg2Test(ContractTestBase):
         cls.container.stop()
 
     @override
-    def get_application_extra_environment_variables(self) -> Dict[str, str]:
-        return {
-            "DB_HOST": "mydb",
-            "DB_USER": "dbuser",
-            "DB_PASS": "example",
-            "DB_NAME": "postgres",
-        }
-
-    @override
     def get_application_image_name(self) -> str:
         return "aws-application-signals-tests-psycopg2-app"
 
+    @override
+    def get_remote_service(self) -> str:
+        return "postgresql"
+
+    @override
+    def get_database_port(self) -> int:
+        return 5432
+
     def test_drop_table_succeeds(self) -> None:
-        self.mock_collector_client.clear_signals()
-        self.do_test_requests("drop_table", "GET", 200, 0, 0, sql_command="DROP TABLE")
+        self.assert_drop_table_succeeds()
 
     def test_create_database_succeeds(self) -> None:
-        self.mock_collector_client.clear_signals()
-        self.do_test_requests("create_database", "GET", 200, 0, 0, sql_command="CREATE DATABASE")
+        self.assert_create_database_succeeds()
 
     def test_fault(self) -> None:
-        self.mock_collector_client.clear_signals()
-        self.do_test_requests("fault", "GET", 500, 0, 1, sql_command="SELECT DISTINCT")
-
-    @override
-    def _assert_aws_span_attributes(self, resource_scope_spans: List[ResourceScopeSpan], path: str, **kwargs) -> None:
-        target_spans: List[Span] = []
-        for resource_scope_span in resource_scope_spans:
-            # pylint: disable=no-member
-            if resource_scope_span.span.kind == Span.SPAN_KIND_CLIENT:
-                target_spans.append(resource_scope_span.span)
-
-        self.assertEqual(len(target_spans), 1)
-        self._assert_aws_attributes(target_spans[0].attributes, **kwargs)
-
-    @override
-    def _assert_aws_attributes(self, attributes_list: List[KeyValue], **kwargs) -> None:
-        attributes_dict: Dict[str, AnyValue] = self._get_attributes_dict(attributes_list)
-        self._assert_str_attribute(attributes_dict, AWS_LOCAL_SERVICE, self.get_application_otel_service_name())
-        # InternalOperation as OTEL does not instrument the basic server we are using, so the client span is a local
-        # root.
-        self._assert_str_attribute(attributes_dict, AWS_LOCAL_OPERATION, "InternalOperation")
-        self._assert_str_attribute(attributes_dict, AWS_REMOTE_SERVICE, "postgresql")
-        command: str = kwargs.get("sql_command")
-        self._assert_str_attribute(attributes_dict, AWS_REMOTE_OPERATION, f"{command}")
-        self._assert_str_attribute(attributes_dict, AWS_REMOTE_RESOURCE_TYPE, "DB::Connection")
-        self._assert_str_attribute(attributes_dict, AWS_REMOTE_RESOURCE_IDENTIFIER, "postgres|mydb|5432")
-        # See comment above AWS_LOCAL_OPERATION
-        self._assert_str_attribute(attributes_dict, AWS_SPAN_KIND, "LOCAL_ROOT")
-
-    @override
-    def _assert_semantic_conventions_span_attributes(
-        self, resource_scope_spans: List[ResourceScopeSpan], method: str, path: str, status_code: int, **kwargs
-    ) -> None:
-        target_spans: List[Span] = []
-        for resource_scope_span in resource_scope_spans:
-            # pylint: disable=no-member
-            if resource_scope_span.span.kind == Span.SPAN_KIND_CLIENT:
-                target_spans.append(resource_scope_span.span)
-
-        self.assertEqual(target_spans[0].name, kwargs.get("sql_command").split()[0])
-        if status_code == 200:
-            self.assertEqual(target_spans[0].status.code, StatusCode.UNSET.value)
-        else:
-            self.assertEqual(target_spans[0].status.code, StatusCode.ERROR.value)
-
-        self._assert_semantic_conventions_attributes(target_spans[0].attributes, kwargs.get("sql_command"))
-
-    def _assert_semantic_conventions_attributes(self, attributes_list: List[KeyValue], command: str) -> None:
-        attributes_dict: Dict[str, AnyValue] = self._get_attributes_dict(attributes_list)
-        self.assertTrue(attributes_dict.get("db.statement").string_value.startswith(command))
-        self._assert_str_attribute(attributes_dict, "db.system", "postgresql")
-        self._assert_str_attribute(attributes_dict, "db.name", "postgres")
-        self._assert_str_attribute(attributes_dict, "net.peer.name", "mydb")
-        self._assert_int_attribute(attributes_dict, "net.peer.port", 5432)
-        self.assertTrue("server.address" not in attributes_dict)
-        self.assertTrue("server.port" not in attributes_dict)
-        self.assertTrue("db.operation" not in attributes_dict)
-
-    @override
-    def _assert_metric_attributes(
-        self, resource_scope_metrics: List[ResourceScopeMetric], metric_name: str, expected_sum: int, **kwargs
-    ) -> None:
-        target_metrics: List[Metric] = []
-        for resource_scope_metric in resource_scope_metrics:
-            if resource_scope_metric.metric.name.lower() == metric_name.lower():
-                target_metrics.append(resource_scope_metric.metric)
-
-        self.assertEqual(len(target_metrics), 1)
-        target_metric: Metric = target_metrics[0]
-        dp_list: List[ExponentialHistogramDataPoint] = target_metric.exponential_histogram.data_points
-
-        self.assertEqual(len(dp_list), 2)
-        dependency_dp: ExponentialHistogramDataPoint = dp_list[0]
-        service_dp: ExponentialHistogramDataPoint = dp_list[1]
-        if len(dp_list[1].attributes) > len(dp_list[0].attributes):
-            dependency_dp = dp_list[1]
-            service_dp = dp_list[0]
-        attribute_dict: Dict[str, AnyValue] = self._get_attributes_dict(dependency_dp.attributes)
-        self._assert_str_attribute(attribute_dict, AWS_LOCAL_SERVICE, self.get_application_otel_service_name())
-        # See comment on AWS_LOCAL_OPERATION in _assert_aws_attributes
-        self._assert_str_attribute(attribute_dict, AWS_LOCAL_OPERATION, "InternalOperation")
-        self._assert_str_attribute(attribute_dict, AWS_REMOTE_SERVICE, "postgresql")
-        self._assert_str_attribute(attribute_dict, AWS_REMOTE_OPERATION, kwargs.get("sql_command"))
-        self._assert_str_attribute(attribute_dict, AWS_REMOTE_RESOURCE_TYPE, "DB::Connection")
-        self._assert_str_attribute(attribute_dict, AWS_REMOTE_RESOURCE_IDENTIFIER, "postgres|mydb|5432")
-        self._assert_str_attribute(attribute_dict, AWS_SPAN_KIND, "CLIENT")
-        self.check_sum(metric_name, dependency_dp.sum, expected_sum)
-
-        attribute_dict: Dict[str, AnyValue] = self._get_attributes_dict(service_dp.attributes)
-        # See comment on AWS_LOCAL_OPERATION in _assert_aws_attributes
-        self._assert_str_attribute(attribute_dict, AWS_LOCAL_OPERATION, "InternalOperation")
-        self._assert_str_attribute(attribute_dict, AWS_SPAN_KIND, "LOCAL_ROOT")
-        self.check_sum(metric_name, service_dp.sum, expected_sum)
+        self.assert_fault()

--- a/contract-tests/tests/test/amazon/pymysql/pymysql_test.py
+++ b/contract-tests/tests/test/amazon/pymysql/pymysql_test.py
@@ -30,16 +30,19 @@ class PyMysqlTest(DatabaseContractTestBase):
         cls.container.stop()
 
     @override
-    def get_application_image_name(self) -> str:
-        return "aws-application-signals-tests-pymysql-app"
-
-    @override
-    def get_remote_service(self) -> str:
+    @staticmethod
+    def get_remote_service() -> str:
         return "mysql"
 
     @override
-    def get_database_port(self) -> int:
+    @staticmethod
+    def get_database_port() -> int:
         return 3306
+
+    @override
+    @staticmethod
+    def get_application_image_name() -> str:
+        return "aws-application-signals-tests-pymysql-app"
 
     def test_drop_table_succeeds(self) -> None:
         self.assert_drop_table_succeeds()

--- a/contract-tests/tests/test/amazon/requests/requests_test.py
+++ b/contract-tests/tests/test/amazon/requests/requests_test.py
@@ -21,7 +21,8 @@ from opentelemetry.semconv.trace import SpanAttributes
 
 class RequestsTest(ContractTestBase):
     @override
-    def get_application_image_name(self) -> str:
+    @staticmethod
+    def get_application_image_name() -> str:
         return "aws-application-signals-tests-requests-app"
 
     @override


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Adding MySQL contract tests for app signals to ensure that customer experience doesn't break with any change. The new contract test covers the CREATE DATABASE SQL command. It also takes the opportunity to refactor the code in common with [the PostgreSQL contract tests](https://github.com/aws-observability/aws-otel-python-instrumentation/blob/main/contract-tests/tests/test/amazon/psycopg2/psycopg2_test.py) to avoid code duplication.

Contract tests running successfully:
```
$ ./scripts/build_and_install_distro.sh
...
$ ./scripts/set-up-contract-tests.sh
...
$ pytest contract-tests/tests
============================= test session starts ==============================
platform linux -- Python 3.8.11, pytest-7.1.3, pluggy-1.5.0
rootdir: /local/home/gbochile/aws-otel-python-instrumentation/contract-tests/tests, configfile: pyproject.toml
plugins: cov-4.1.0, flaky-3.7.0
collected 39 items

contract-tests/tests/test/amazon/psycopg2/psycopg2_test.py::Psycopg2Test::test_create_database_succeeds
-------------------------------- live log setup --------------------------------
2024-06-20 14:55:44 [    INFO] Pulling image aws-application-signals-mock-collector-python (container.py:53)
2024-06-20 14:55:45 [    INFO] Container started: d9689f28b345 (container.py:64)
2024-06-20 14:55:46 [    INFO] Pulling image postgres:latest (container.py:53)
2024-06-20 14:55:46 [    INFO] Container started: 23e433c8ee6e (container.py:64)
2024-06-20 14:55:46 [    INFO] Waiting to be ready... (waiting_utils.py:46)
2024-06-20 14:55:46 [    INFO] Waiting to be ready... (waiting_utils.py:46)
2024-06-20 14:55:47 [    INFO] Waiting to be ready... (waiting_utils.py:46)
-------------------------------- live log call ---------------------------------
2024-06-20 14:55:47 [    INFO] Pulling image aws-application-signals-tests-psycopg2-app (container.py:53)
2024-06-20 14:55:48 [    INFO] Container started: 68f62688d322 (container.py:64)
2024-06-20 14:55:54 [    INFO] Waiting to be ready... (waiting_utils.py:46)
2024-06-20 14:55:54 [    INFO] Waiting to be ready... (waiting_utils.py:46)
2024-06-20 14:55:54 [    INFO] Application stdout (contract_test_base.py:118)
2024-06-20 14:55:54 [    INFO] Ready
 (contract_test_base.py:119)
2024-06-20 14:55:54 [    INFO] Application stderr (contract_test_base.py:120)
2024-06-20 14:55:54 [    INFO] Failed to get k8s token: [Errno 2] No such file or directory: '/var/run/secrets/kubernetes.io/serviceaccount/token'
AwsEcsResourceDetector failed: Missing ECS_CONTAINER_METADATA_URI therefore process is not on ECS.
AwsEksResourceDetector failed: [Errno 2] No such file or directory: '/var/run/secrets/kubernetes.io/serviceaccount/token'
Exception  in detector <opentelemetry.sdk.extension.aws.resource.ec2.AwsEc2ResourceDetector object at 0x7f2938bc3730>, ignoring
AwsEc2ResourceDetector failed: timed out
Configuration of configurator not loaded, aws_configurator already loaded
 (contract_test_base.py:121)
PASSED                                                                   [ 71%]
contract-tests/tests/test/amazon/psycopg2/psycopg2_test.py::Psycopg2Test::test_drop_table_succeeds
-------------------------------- live log call ---------------------------------
2024-06-20 14:55:55 [    INFO] Pulling image aws-application-signals-tests-psycopg2-app (container.py:53)
2024-06-20 14:55:55 [    INFO] Container started: 38c2e2937827 (container.py:64)
2024-06-20 14:56:01 [    INFO] Waiting to be ready... (waiting_utils.py:46)
2024-06-20 14:56:01 [    INFO] Waiting to be ready... (waiting_utils.py:46)
2024-06-20 14:56:02 [    INFO] Application stdout (contract_test_base.py:118)
2024-06-20 14:56:02 [    INFO] Ready
 (contract_test_base.py:119)
2024-06-20 14:56:02 [    INFO] Application stderr (contract_test_base.py:120)
2024-06-20 14:56:02 [    INFO] Failed to get k8s token: [Errno 2] No such file or directory: '/var/run/secrets/kubernetes.io/serviceaccount/token'
AwsEcsResourceDetector failed: Missing ECS_CONTAINER_METADATA_URI therefore process is not on ECS.
AwsEksResourceDetector failed: [Errno 2] No such file or directory: '/var/run/secrets/kubernetes.io/serviceaccount/token'
Exception  in detector <opentelemetry.sdk.extension.aws.resource.ec2.AwsEc2ResourceDetector object at 0x7fa54b22f790>, ignoring
AwsEc2ResourceDetector failed: timed out
Configuration of configurator not loaded, aws_configurator already loaded
 (contract_test_base.py:121)
PASSED                                                                   [ 74%]
contract-tests/tests/test/amazon/psycopg2/psycopg2_test.py::Psycopg2Test::test_fault
-------------------------------- live log call ---------------------------------
2024-06-20 14:56:02 [    INFO] Pulling image aws-application-signals-tests-psycopg2-app (container.py:53)
2024-06-20 14:56:03 [    INFO] Container started: 2df7a0957e52 (container.py:64)
2024-06-20 14:56:09 [    INFO] Waiting to be ready... (waiting_utils.py:46)
2024-06-20 14:56:09 [    INFO] Waiting to be ready... (waiting_utils.py:46)
2024-06-20 14:56:09 [    INFO] Application stdout (contract_test_base.py:118)
2024-06-20 14:56:09 [    INFO] Ready
Expected Exception with Invalid SQL occurred: relation "invalid_table" does not exist
LINE 1: SELECT DISTINCT id, name FROM invalid_table
                                      ^

 (contract_test_base.py:119)
2024-06-20 14:56:09 [    INFO] Application stderr (contract_test_base.py:120)
2024-06-20 14:56:09 [    INFO] Failed to get k8s token: [Errno 2] No such file or directory: '/var/run/secrets/kubernetes.io/serviceaccount/token'
AwsEksResourceDetector failed: [Errno 2] No such file or directory: '/var/run/secrets/kubernetes.io/serviceaccount/token'
AwsEcsResourceDetector failed: Missing ECS_CONTAINER_METADATA_URI therefore process is not on ECS.
Exception  in detector <opentelemetry.sdk.extension.aws.resource.ec2.AwsEc2ResourceDetector object at 0x7f4a5f0e77f0>, ignoring
AwsEc2ResourceDetector failed: timed out
Configuration of configurator not loaded, aws_configurator already loaded
 (contract_test_base.py:121)
PASSED                                                                   [ 76%]

...

contract-tests/tests/test/amazon/pymysql/pymysql_test.py::PyMysqlTest::test_create_database_succeeds
-------------------------------- live log setup --------------------------------
2024-06-20 14:56:11 [    INFO] Pulling image aws-application-signals-mock-collector-python (container.py:53)
2024-06-20 14:56:12 [    INFO] Container started: 593e6565ee45 (container.py:64)
2024-06-20 14:56:13 [    INFO] Pulling image mysql:latest (container.py:53)
2024-06-20 14:56:13 [    INFO] Container started: 5e44c6384697 (container.py:64)
2024-06-20 14:56:13 [    INFO] Waiting to be ready... (waiting_utils.py:46)
2024-06-20 14:56:13 [    INFO] Waiting to be ready... (waiting_utils.py:46)
2024-06-20 14:56:14 [    INFO] Waiting to be ready... (waiting_utils.py:46)
2024-06-20 14:56:15 [    INFO] Waiting to be ready... (waiting_utils.py:46)
2024-06-20 14:56:17 [    INFO] Waiting to be ready... (waiting_utils.py:46)
2024-06-20 14:56:18 [    INFO] Waiting to be ready... (waiting_utils.py:46)
2024-06-20 14:56:19 [    INFO] Waiting to be ready... (waiting_utils.py:46)
2024-06-20 14:56:20 [    INFO] Waiting to be ready... (waiting_utils.py:46)
2024-06-20 14:56:21 [    INFO] Waiting to be ready... (waiting_utils.py:46)
2024-06-20 14:56:22 [    INFO] Waiting to be ready... (waiting_utils.py:46)
2024-06-20 14:56:23 [    INFO] Waiting to be ready... (waiting_utils.py:46)
-------------------------------- live log call ---------------------------------
2024-06-20 14:56:23 [    INFO] Pulling image aws-application-signals-tests-pymysql-app (container.py:53)
2024-06-20 14:56:24 [    INFO] Container started: 518b7ef0c507 (container.py:64)
2024-06-20 14:56:30 [    INFO] Waiting to be ready... (waiting_utils.py:46)
2024-06-20 14:56:30 [    INFO] Waiting to be ready... (waiting_utils.py:46)
2024-06-20 14:56:30 [    INFO] Application stdout (contract_test_base.py:118)
2024-06-20 14:56:30 [    INFO] Ready
 (contract_test_base.py:119)
2024-06-20 14:56:30 [    INFO] Application stderr (contract_test_base.py:120)
2024-06-20 14:56:30 [    INFO] Failed to get k8s token: [Errno 2] No such file or directory: '/var/run/secrets/kubernetes.io/serviceaccount/token'
AwsEcsResourceDetector failed: Missing ECS_CONTAINER_METADATA_URI therefore process is not on ECS.
AwsEksResourceDetector failed: [Errno 2] No such file or directory: '/var/run/secrets/kubernetes.io/serviceaccount/token'
Exception  in detector <opentelemetry.sdk.extension.aws.resource.ec2.AwsEc2ResourceDetector object at 0x7fbfc92c7ac0>, ignoring
AwsEc2ResourceDetector failed: timed out
Configuration of configurator not loaded, aws_configurator already loaded
 (contract_test_base.py:121)
PASSED                                                                   [ 79%]
contract-tests/tests/test/amazon/pymysql/pymysql_test.py::PyMysqlTest::test_drop_table_succeeds
-------------------------------- live log call ---------------------------------
2024-06-20 14:56:31 [    INFO] Pulling image aws-application-signals-tests-pymysql-app (container.py:53)
2024-06-20 14:56:31 [    INFO] Container started: 079eaf40b262 (container.py:64)
2024-06-20 14:56:37 [    INFO] Waiting to be ready... (waiting_utils.py:46)
2024-06-20 14:56:37 [    INFO] Waiting to be ready... (waiting_utils.py:46)
2024-06-20 14:56:38 [    INFO] Application stdout (contract_test_base.py:118)
2024-06-20 14:56:38 [    INFO] Ready
 (contract_test_base.py:119)
2024-06-20 14:56:38 [    INFO] Application stderr (contract_test_base.py:120)
2024-06-20 14:56:38 [    INFO] Failed to get k8s token: [Errno 2] No such file or directory: '/var/run/secrets/kubernetes.io/serviceaccount/token'
AwsEcsResourceDetector failed: Missing ECS_CONTAINER_METADATA_URI therefore process is not on ECS.
AwsEksResourceDetector failed: [Errno 2] No such file or directory: '/var/run/secrets/kubernetes.io/serviceaccount/token'
Exception  in detector <opentelemetry.sdk.extension.aws.resource.ec2.AwsEc2ResourceDetector object at 0x7fc21bf53a00>, ignoring
AwsEc2ResourceDetector failed: timed out
Configuration of configurator not loaded, aws_configurator already loaded
 (contract_test_base.py:121)
PASSED                                                                   [ 82%]
contract-tests/tests/test/amazon/pymysql/pymysql_test.py::PyMysqlTest::test_fault
-------------------------------- live log call ---------------------------------
2024-06-20 14:56:38 [    INFO] Pulling image aws-application-signals-tests-pymysql-app (container.py:53)
2024-06-20 14:56:39 [    INFO] Container started: 1e5f0eaf1238 (container.py:64)
2024-06-20 14:56:45 [    INFO] Waiting to be ready... (waiting_utils.py:46)
2024-06-20 14:56:45 [    INFO] Waiting to be ready... (waiting_utils.py:46)
2024-06-20 14:56:45 [    INFO] Application stdout (contract_test_base.py:118)
2024-06-20 14:56:45 [    INFO] Ready
Expected Exception with Invalid SQL occurred: (1146, "Table 'testdb.invalid_table' doesn't exist")
 (contract_test_base.py:119)
2024-06-20 14:56:45 [    INFO] Application stderr (contract_test_base.py:120)
2024-06-20 14:56:45 [    INFO] Failed to get k8s token: [Errno 2] No such file or directory: '/var/run/secrets/kubernetes.io/serviceaccount/token'
AwsEcsResourceDetector failed: Missing ECS_CONTAINER_METADATA_URI therefore process is not on ECS.
AwsEksResourceDetector failed: [Errno 2] No such file or directory: '/var/run/secrets/kubernetes.io/serviceaccount/token'
Exception  in detector <opentelemetry.sdk.extension.aws.resource.ec2.AwsEc2ResourceDetector object at 0x7f4b2a841420>, ignoring
AwsEc2ResourceDetector failed: timed out
Configuration of configurator not loaded, aws_configurator already loaded
 (contract_test_base.py:121)
PASSED                                                                   [ 84%]

...
======================== 39 passed in 363.85s (0:06:03) ========================
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.