### PR TITLE
Fix Workflow File Name for E2E Test

### DIFF
--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -102,7 +102,7 @@ jobs:
   # Application Signals specific e2e tests for ec2
   application-signals-python-e2e-ec2-test:
     needs: [ build ]
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/application-signals-python-e2e-ec2-test.yml@main
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/application-signals-python-e2e-ec2-default-test.yml@main
     secrets: inherit
     with:
       aws-region: ${{ needs.build.outputs.aws_default_region }}


### PR DESCRIPTION
*Issue #, if available:*
The workflow file name for E2E EC2 test changed from `application-signals-python-e2e-ec2-test.yml` to `application-signals-python-e2e-ec2-default-test.yml` in the framework repository

*Description of changes:*
Update the file name to the correct value

Test run: https://github.com/aws-observability/aws-otel-python-instrumentation/actions/runs/9603406106


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

