### PR TITLE
adding mysql-connector driver contract test for some basic operations

### DIFF
--- a/contract-tests/images/applications/mysql-connector/Dockerfile
+++ b/contract-tests/images/applications/mysql-connector/Dockerfile
@@ -1,0 +1,15 @@
+# Meant to be run from aws-otel-python-instrumentation/contract-tests.
+# Assumes existence of dist/aws_opentelemetry_distro-<pkg_version>-py3-none-any.whl.
+# Assumes filename of aws_opentelemetry_distro-<pkg_version>-py3-none-any.whl is passed in as "DISTRO" arg.
+FROM python:3.10
+WORKDIR /mysql-connector
+COPY ./dist/$DISTRO /mysql-connector
+COPY ./contract-tests/images/applications/mysql-connector /mysql-connector
+
+ENV PIP_ROOT_USER_ACTION=ignore
+ARG DISTRO
+RUN pip install --upgrade pip && pip install -r requirements.txt && pip install ${DISTRO} --force-reinstall
+RUN opentelemetry-bootstrap -a install
+
+# Without `-u`, logs will be buffered and `wait_for_logs` will never return.
+CMD ["opentelemetry-instrument", "python", "-u", "./mysql_connector_server.py"]

--- a/contract-tests/images/applications/mysql-connector/mysql_connector_server.py
+++ b/contract-tests/images/applications/mysql-connector/mysql_connector_server.py
@@ -1,0 +1,90 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import atexit
+import os
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Thread
+from typing import Tuple
+
+import mysql.connector as mysql
+
+from typing_extensions import override
+
+_PREPARE_DB: str = "prepare_db"
+_SELECT: str = "select"
+_CREATE_DATABASE: str = "create_database"
+_DROP_TABLE: str = "drop_table"
+_FAULT: str = "fault"
+_PORT: int = 8080
+
+_DB_HOST = os.getenv("DB_HOST")
+_DB_USER = os.getenv("DB_USER")
+_DB_PASS = os.getenv("DB_PASS")
+_DB_NAME = os.getenv("DB_NAME")
+
+
+class RequestHandler(BaseHTTPRequestHandler):
+    @override
+    # pylint: disable=invalid-name
+    def do_GET(self):
+        status_code: int = 200
+        conn = mysql.connect(host=_DB_HOST, user=_DB_USER, password=_DB_PASS, database=_DB_NAME)
+        conn.autocommit = True  # CREATE DATABASE cannot run in a transaction block
+        if self.in_path(_PREPARE_DB):
+            cur = conn.cursor()
+            cur.execute("CREATE TABLE employee (id int, name varchar(255))")
+            cur.execute("INSERT INTO employee (id, name) values (1, 'A')")
+            cur.close()
+            status_code = 200
+        elif self.in_path(_SELECT):
+            cur = conn.cursor()
+            cur.execute("SELECT count(*) FROM employee")
+            result = cur.fetchall()
+            cur.close()
+            status_code = 200 if len(result) == 1 else 500
+        elif self.in_path(_DROP_TABLE):
+            cur = conn.cursor()
+            cur.execute("DROP TABLE IF EXISTS test_table")
+            cur.close()
+            status_code = 200
+        elif self.in_path(_CREATE_DATABASE):
+            cur = conn.cursor()
+            cur.execute("CREATE DATABASE test_database")
+            cur.close()
+            status_code = 200
+        elif self.in_path(_FAULT):
+            cur = conn.cursor()
+            try:
+                cur.execute("SELECT DISTINCT id, name FROM invalid_table")
+            except mysql.ProgrammingError as exception:
+                print("Expected Exception with Invalid SQL occurred:", exception)
+                status_code = 500
+            except Exception as exception:  # pylint: disable=broad-except
+                print("Exception Occurred:", exception)
+            else:
+                status_code = 200
+            finally:
+                cur.close()
+        else:
+            status_code = 404
+        conn.close()
+        self.send_response_only(status_code)
+        self.end_headers()
+
+    def in_path(self, sub_path: str):
+        return sub_path in self.path
+
+
+def main() -> None:
+    server_address: Tuple[str, int] = ("0.0.0.0", _PORT)
+    request_handler_class: type = RequestHandler
+    requests_server: ThreadingHTTPServer = ThreadingHTTPServer(server_address, request_handler_class)
+    atexit.register(requests_server.shutdown)
+    server_thread: Thread = Thread(target=requests_server.serve_forever)
+    server_thread.start()
+    print("Ready")
+    server_thread.join()
+
+
+if __name__ == "__main__":
+    main()

--- a/contract-tests/images/applications/mysql-connector/pyproject.toml
+++ b/contract-tests/images/applications/mysql-connector/pyproject.toml
@@ -1,0 +1,6 @@
+[project]
+name = "mysql-connector-server"
+description = "Simple server that relies on mysql-connector library"
+version = "1.0.0"
+license = "Apache-2.0"
+requires-python = ">=3.8"

--- a/contract-tests/images/applications/mysql-connector/requirements.txt
+++ b/contract-tests/images/applications/mysql-connector/requirements.txt
@@ -1,0 +1,4 @@
+opentelemetry-distro==0.43b0
+opentelemetry-exporter-otlp-proto-grpc==1.22.0
+typing-extensions==4.9.0
+mysql-connector-python~=8.0

--- a/contract-tests/tests/test/amazon/base/contract_test_base.py
+++ b/contract-tests/tests/test/amazon/base/contract_test_base.py
@@ -128,10 +128,7 @@ class ContractTestBase(TestCase):
     def do_test_requests(
         self, path: str, method: str, status_code: int, expected_error: int, expected_fault: int, **kwargs
     ) -> None:
-        address: str = self.application.get_container_host_ip()
-        port: str = self.application.get_exposed_port(self.get_application_port())
-        url: str = f"http://{address}:{port}/{path}"
-        response: Response = request(method, url, timeout=20)
+        response: Response = self.send_request(method, path)
         self.assertEqual(status_code, response.status_code)
 
         resource_scope_spans: List[ResourceScopeSpan] = self.mock_collector_client.get_traces()
@@ -144,6 +141,12 @@ class ContractTestBase(TestCase):
         self._assert_metric_attributes(metrics, LATENCY_METRIC, 5000, **kwargs)
         self._assert_metric_attributes(metrics, ERROR_METRIC, expected_error, **kwargs)
         self._assert_metric_attributes(metrics, FAULT_METRIC, expected_fault, **kwargs)
+
+    def send_request(self, method, path) -> Response:
+        address: str = self.application.get_container_host_ip()
+        port: str = self.application.get_exposed_port(self.get_application_port())
+        url: str = f"http://{address}:{port}/{path}"
+        return request(method, url, timeout=20)
 
     def _get_attributes_dict(self, attributes_list: List[KeyValue]) -> Dict[str, AnyValue]:
         attributes_dict: Dict[str, AnyValue] = {}

--- a/contract-tests/tests/test/amazon/base/database_contract_test_base.py
+++ b/contract-tests/tests/test/amazon/base/database_contract_test_base.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 from typing import Dict, List
-
+import time
 from mock_collector_client import ResourceScopeMetric, ResourceScopeSpan
 from typing_extensions import override
 
@@ -54,6 +54,13 @@ class DatabaseContractTestBase(ContractTestBase):
     def assert_create_database_succeeds(self) -> None:
         self.mock_collector_client.clear_signals()
         self.do_test_requests("create_database", "GET", 200, 0, 0, sql_command="CREATE DATABASE")
+
+    def assert_select_succeeds(self) -> None:
+        self.send_request("GET", "prepare_db")
+        # wait for metrics and traces to be available on the collector before clearing the signals
+        time.sleep(1)
+        self.mock_collector_client.clear_signals()
+        self.do_test_requests("select", "GET", 200, 0, 0, sql_command="SELECT")
 
     def assert_fault(self) -> None:
         self.mock_collector_client.clear_signals()

--- a/contract-tests/tests/test/amazon/mysql-connector/mysql_connector_test.py
+++ b/contract-tests/tests/test/amazon/mysql-connector/mysql_connector_test.py
@@ -1,0 +1,57 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+from testcontainers.mysql import MySqlContainer
+from typing_extensions import override
+
+from amazon.base.contract_test_base import NETWORK_NAME
+from amazon.base.database_contract_test_base import (
+    DATABASE_HOST,
+    DATABASE_NAME,
+    DATABASE_PASSWORD,
+    DATABASE_USER,
+    DatabaseContractTestBase,
+)
+
+
+class MysqlConnectorTest(DatabaseContractTestBase):
+    @override
+    @classmethod
+    def set_up_dependency_container(cls) -> None:
+        cls.container = (
+            MySqlContainer(MYSQL_USER=DATABASE_USER, MYSQL_PASSWORD=DATABASE_PASSWORD, MYSQL_DATABASE=DATABASE_NAME)
+            .with_kwargs(network=NETWORK_NAME)
+            .with_name(DATABASE_HOST)
+        )
+        cls.container.start()
+
+    @override
+    @classmethod
+    def tear_down_dependency_container(cls) -> None:
+        cls.container.stop()
+
+    @override
+    @staticmethod
+    def get_remote_service() -> str:
+        return "mysql"
+
+    @override
+    @staticmethod
+    def get_database_port() -> int:
+        return 3306
+
+    @override
+    @staticmethod
+    def get_application_image_name() -> str:
+        return "aws-application-signals-tests-mysql-connector-app"
+
+    def test_select_succeeds(self) -> None:
+        self.assert_select_succeeds()
+
+    def test_create_database_succeeds(self) -> None:
+        self.assert_create_database_succeeds()
+
+    def test_drop_table_succeeds(self) -> None:
+        self.assert_drop_table_succeeds()
+
+    def test_fault(self) -> None:
+        self.assert_fault()

--- a/scripts/set-up-contract-tests.sh
+++ b/scripts/set-up-contract-tests.sh
@@ -18,12 +18,14 @@ rm -rf dist/mock_collector*
 rm -rf dist/contract_tests*
 
 # Install python dependency for contract-test
-pip install pymysql
-pip install cryptography
+python3 -m pip install pytest
+python3 -m pip install pymysql
+python3 -m pip install cryptography
+python3 -m pip install mysql-connector-python
 
 # To be clear, install binary for psycopg2 have no negative influence on otel here
 # since Otel-Instrumentation running in container that install psycopg2 from source
-pip install sqlalchemy psycopg2-binary
+python3 -m pip install sqlalchemy psycopg2-binary
 
 # Create mock-collector image
 cd contract-tests/images/mock-collector
@@ -57,12 +59,12 @@ done
 cd contract-tests/images/mock-collector
 python3 -m build --outdir ../../../dist
 cd ../../../dist
-pip install mock_collector-1.0.0-py3-none-any.whl --force-reinstall
+python3 -m pip install mock_collector-1.0.0-py3-none-any.whl --force-reinstall
 
 # Build and install contract-tests
 cd ../contract-tests/tests
 python3 -m build --outdir ../../dist
 cd ../../dist
 # --force-reinstall causes `ERROR: No matching distribution found for mock-collector==1.0.0`, but uninstalling and reinstalling works pretty reliably.
-pip uninstall contract-tests -y
-pip install contract_tests-1.0.0-py3-none-any.whl
+python3 -m pip uninstall contract-tests -y
+python3 -m pip install contract_tests-1.0.0-py3-none-any.whl


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Adding contract tests for mysql-connector driver for MySQL.

Includes `SELECT`, `CREATE DATABASE`, `DROP TABLE` 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


```
./scripts/build_and_install_distro.sh && \
./scripts/set-up-contract-tests.sh && \
python3 -m pytest contract-tests/tests/test/amazon/mysql-connector/mysql_connector_test.py

...
...
..
..
======================================================================= warnings summary ========================================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: Type google._upb._message.MessageMapContainer uses PyType_Spec with a metaclass that has custom tp_new. This is deprecated and will no longer be allowed in Python 3.14.

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: Type google._upb._message.ScalarMapContainer uses PyType_Spec with a metaclass that has custom tp_new. This is deprecated and will no longer be allowed in Python 3.14.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================ 4 passed, 2 warnings in 50.84s =================================================================
```
```
