### PR TITLE
Adding data base user attribute in Python EMF logs

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_aws_attribute_keys.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_aws_attribute_keys.py
@@ -4,6 +4,7 @@
 AWS_SPAN_KIND: str = "aws.span.kind"
 AWS_LOCAL_SERVICE: str = "aws.local.service"
 AWS_LOCAL_OPERATION: str = "aws.local.operation"
+AWS_REMOTE_DB_USER: str = "aws.remote.db.user"
 AWS_REMOTE_SERVICE: str = "aws.remote.service"
 AWS_REMOTE_OPERATION: str = "aws.remote.operation"
 AWS_REMOTE_RESOURCE_TYPE: str = "aws.remote.resource.type"

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_aws_metric_attribute_generator.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_aws_metric_attribute_generator.py
@@ -10,6 +10,7 @@ from amazon.opentelemetry.distro._aws_attribute_keys import (
     AWS_LOCAL_SERVICE,
     AWS_QUEUE_NAME,
     AWS_QUEUE_URL,
+    AWS_REMOTE_DB_USER,
     AWS_REMOTE_OPERATION,
     AWS_REMOTE_RESOURCE_IDENTIFIER,
     AWS_REMOTE_RESOURCE_TYPE,
@@ -52,6 +53,7 @@ _DB_NAME: str = SpanAttributes.DB_NAME
 _DB_OPERATION: str = SpanAttributes.DB_OPERATION
 _DB_STATEMENT: str = SpanAttributes.DB_STATEMENT
 _DB_SYSTEM: str = SpanAttributes.DB_SYSTEM
+_DB_USER: str = SpanAttributes.DB_USER
 _FAAS_INVOKED_NAME: str = SpanAttributes.FAAS_INVOKED_NAME
 _FAAS_TRIGGER: str = SpanAttributes.FAAS_TRIGGER
 _GRAPHQL_OPERATION_TYPE: str = SpanAttributes.GRAPHQL_OPERATION_TYPE
@@ -126,6 +128,7 @@ def _generate_dependency_metric_attributes(span: ReadableSpan, resource: Resourc
     _set_egress_operation(span, attributes)
     _set_remote_service_and_operation(span, attributes)
     _set_remote_type_and_identifier(span, attributes)
+    _set_remote_db_user(span, attributes)
     _set_span_kind_for_dependency(span, attributes)
     return attributes
 
@@ -450,6 +453,9 @@ def _escape_delimiters(input_str: str) -> Optional[str]:
         return None
     return input_str.replace("^", "^^").replace("|", "^|")
 
+def _set_remote_db_user(span: ReadableSpan, attributes: BoundedAttributes) -> None:
+    if is_db_span(span) and is_key_present(span, _DB_USER):
+        attributes[AWS_REMOTE_DB_USER] = span.attributes.get(_DB_USER)
 
 def _set_span_kind_for_dependency(span: ReadableSpan, attributes: BoundedAttributes) -> None:
     span_kind: str = span.kind.name

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_aws_metric_attribute_generator.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_aws_metric_attribute_generator.py
@@ -453,9 +453,11 @@ def _escape_delimiters(input_str: str) -> Optional[str]:
         return None
     return input_str.replace("^", "^^").replace("|", "^|")
 
+
 def _set_remote_db_user(span: ReadableSpan, attributes: BoundedAttributes) -> None:
     if is_db_span(span) and is_key_present(span, _DB_USER):
         attributes[AWS_REMOTE_DB_USER] = span.attributes.get(_DB_USER)
+
 
 def _set_span_kind_for_dependency(span: ReadableSpan, attributes: BoundedAttributes) -> None:
     span_kind: str = span.kind.name

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_aws_span_processing_util.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_aws_span_processing_util.py
@@ -91,7 +91,6 @@ def is_db_span(span: ReadableSpan) -> bool:
         is_key_present(span, SpanAttributes.DB_SYSTEM)
         or is_key_present(span, SpanAttributes.DB_OPERATION)
         or is_key_present(span, SpanAttributes.DB_STATEMENT)
-        or is_key_present(span, SpanAttributes.DB_USER)
     )
 
 

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_aws_span_processing_util.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_aws_span_processing_util.py
@@ -91,6 +91,7 @@ def is_db_span(span: ReadableSpan) -> bool:
         is_key_present(span, SpanAttributes.DB_SYSTEM)
         or is_key_present(span, SpanAttributes.DB_OPERATION)
         or is_key_present(span, SpanAttributes.DB_STATEMENT)
+        or is_key_present(span, SpanAttributes.DB_USER)
     )
 
 

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_metric_attribute_generator.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_metric_attribute_generator.py
@@ -13,13 +13,13 @@ from amazon.opentelemetry.distro._aws_attribute_keys import (
     AWS_LOCAL_SERVICE,
     AWS_QUEUE_NAME,
     AWS_QUEUE_URL,
+    AWS_REMOTE_DB_USER,
     AWS_REMOTE_OPERATION,
     AWS_REMOTE_RESOURCE_IDENTIFIER,
     AWS_REMOTE_RESOURCE_TYPE,
     AWS_REMOTE_SERVICE,
     AWS_SPAN_KIND,
     AWS_STREAM_NAME,
-    AWS_REMOTE_DB_USER,
 )
 from amazon.opentelemetry.distro._aws_metric_attribute_generator import _AwsMetricAttributeGenerator
 from amazon.opentelemetry.distro.metric_attribute_generator import DEPENDENCY_METRIC, SERVICE_METRIC
@@ -788,7 +788,7 @@ class TestAwsMetricAttributeGenerator(TestCase):
         self._mock_attribute(SpanAttributes.DB_USER, None)
         self.span_mock.kind = SpanKind.CLIENT
 
-        actual_attributes = _GENERATOR.generate_metric_attributes_dict_from_span(
+        actual_attributes: Attributes = _GENERATOR.generate_metric_attributes_dict_from_span(
             self.span_mock, self.resource
         ).get(DEPENDENCY_METRIC)
         self.assertIsNone(actual_attributes.get(AWS_REMOTE_DB_USER))
@@ -798,7 +798,7 @@ class TestAwsMetricAttributeGenerator(TestCase):
         self._mock_attribute([SpanAttributes.DB_USER], [db_user])
         self.span_mock.kind = SpanKind.SERVER
 
-        actual_attributes = _GENERATOR.generate_metric_attributes_dict_from_span(
+        actual_attributes: Attributes = _GENERATOR.generate_metric_attributes_dict_from_span(
             self.span_mock, self.resource
         ).get(SERVICE_METRIC)
         self.assertIsNone(actual_attributes.get(AWS_REMOTE_DB_USER))
@@ -808,7 +808,7 @@ class TestAwsMetricAttributeGenerator(TestCase):
         self._mock_attribute([SpanAttributes.DB_USER], [db_user])
         self.span_mock.kind = SpanKind.CLIENT
 
-        actual_attributes = _GENERATOR.generate_metric_attributes_dict_from_span(
+        actual_attributes: Attributes = _GENERATOR.generate_metric_attributes_dict_from_span(
             self.span_mock, self.resource
         ).get(DEPENDENCY_METRIC)
         self.assertEqual(actual_attributes.get(AWS_REMOTE_DB_USER), db_user)

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_metric_attribute_generator.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_metric_attribute_generator.py
@@ -19,6 +19,7 @@ from amazon.opentelemetry.distro._aws_attribute_keys import (
     AWS_REMOTE_SERVICE,
     AWS_SPAN_KIND,
     AWS_STREAM_NAME,
+    AWS_REMOTE_DB_USER,
 )
 from amazon.opentelemetry.distro._aws_metric_attribute_generator import _AwsMetricAttributeGenerator
 from amazon.opentelemetry.distro.metric_attribute_generator import DEPENDENCY_METRIC, SERVICE_METRIC
@@ -772,6 +773,45 @@ class TestAwsMetricAttributeGenerator(TestCase):
 
         self.assertIsNotNone(service_attributes)
         self.assertIsNotNone(dependency_attributes)
+
+    def test_db_user_attribute(self):
+        db_user: str = "test_user"
+        self._mock_attribute([SpanAttributes.DB_USER], [db_user])
+        self.span_mock.kind = SpanKind.CLIENT
+
+        actual_attributes: Attributes = _GENERATOR.generate_metric_attributes_dict_from_span(
+            self.span_mock, self.resource
+        ).get(DEPENDENCY_METRIC)
+        self.assertEqual(actual_attributes.get(AWS_REMOTE_DB_USER), db_user)
+
+    def test_db_user_attribute_absent(self):
+        self._mock_attribute(SpanAttributes.DB_USER, None)
+        self.span_mock.kind = SpanKind.CLIENT
+
+        actual_attributes = _GENERATOR.generate_metric_attributes_dict_from_span(
+            self.span_mock, self.resource
+        ).get(DEPENDENCY_METRIC)
+        self.assertIsNone(actual_attributes.get(AWS_REMOTE_DB_USER))
+
+    def test_db_user_attribute_not_present_in_service_metric_for_server_span(self):
+        db_user: str = "test_user"
+        self._mock_attribute([SpanAttributes.DB_USER], [db_user])
+        self.span_mock.kind = SpanKind.SERVER
+
+        actual_attributes = _GENERATOR.generate_metric_attributes_dict_from_span(
+            self.span_mock, self.resource
+        ).get(SERVICE_METRIC)
+        self.assertIsNone(actual_attributes.get(AWS_REMOTE_DB_USER))
+
+    def test_db_user_attribute_with_different_values(self):
+        db_user: str = "non_db_user"
+        self._mock_attribute([SpanAttributes.DB_USER], [db_user])
+        self.span_mock.kind = SpanKind.CLIENT
+
+        actual_attributes = _GENERATOR.generate_metric_attributes_dict_from_span(
+            self.span_mock, self.resource
+        ).get(DEPENDENCY_METRIC)
+        self.assertEqual(actual_attributes.get(AWS_REMOTE_DB_USER), db_user)
 
     def test_local_root_boto3_span(self):
         self._update_resource_with_service_name()

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_metric_attribute_generator.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_metric_attribute_generator.py
@@ -785,7 +785,7 @@ class TestAwsMetricAttributeGenerator(TestCase):
         self.assertEqual(actual_attributes.get(AWS_REMOTE_DB_USER), db_user)
 
     def test_db_user_attribute_absent(self):
-        self._mock_attribute(SpanAttributes.DB_USER, None)
+        self._mock_attribute([SpanAttributes.DB_USER], [None])
         self.span_mock.kind = SpanKind.CLIENT
 
         actual_attributes: Attributes = _GENERATOR.generate_metric_attributes_dict_from_span(

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_metric_attribute_generator.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_metric_attribute_generator.py
@@ -775,17 +775,17 @@ class TestAwsMetricAttributeGenerator(TestCase):
         self.assertIsNotNone(dependency_attributes)
 
     def test_db_user_attribute(self):
-        db_user: str = "test_user"
-        self._mock_attribute([SpanAttributes.DB_USER], [db_user])
+        self._mock_attribute([SpanAttributes.DB_OPERATION, SpanAttributes.DB_USER], ["db_operation", "db_user"])
         self.span_mock.kind = SpanKind.CLIENT
 
         actual_attributes: Attributes = _GENERATOR.generate_metric_attributes_dict_from_span(
             self.span_mock, self.resource
         ).get(DEPENDENCY_METRIC)
-        self.assertEqual(actual_attributes.get(AWS_REMOTE_DB_USER), db_user)
+        self.assertEqual(actual_attributes.get(AWS_REMOTE_OPERATION), "db_operation")
+        self.assertEqual(actual_attributes.get(AWS_REMOTE_DB_USER), "db_user")
 
     def test_db_user_attribute_absent(self):
-        self._mock_attribute([SpanAttributes.DB_USER], [None])
+        self._mock_attribute([SpanAttributes.DB_SYSTEM], ["db_system"])
         self.span_mock.kind = SpanKind.CLIENT
 
         actual_attributes: Attributes = _GENERATOR.generate_metric_attributes_dict_from_span(
@@ -794,8 +794,7 @@ class TestAwsMetricAttributeGenerator(TestCase):
         self.assertIsNone(actual_attributes.get(AWS_REMOTE_DB_USER))
 
     def test_db_user_attribute_not_present_in_service_metric_for_server_span(self):
-        db_user: str = "test_user"
-        self._mock_attribute([SpanAttributes.DB_USER], [db_user])
+        self._mock_attribute([SpanAttributes.DB_USER, SpanAttributes.DB_SYSTEM], ["db_user", "db_system"])
         self.span_mock.kind = SpanKind.SERVER
 
         actual_attributes: Attributes = _GENERATOR.generate_metric_attributes_dict_from_span(
@@ -804,14 +803,22 @@ class TestAwsMetricAttributeGenerator(TestCase):
         self.assertIsNone(actual_attributes.get(AWS_REMOTE_DB_USER))
 
     def test_db_user_attribute_with_different_values(self):
-        db_user: str = "non_db_user"
-        self._mock_attribute([SpanAttributes.DB_USER], [db_user])
+        self._mock_attribute([SpanAttributes.DB_OPERATION, SpanAttributes.DB_USER], ["db_operation", "non_db_user"])
         self.span_mock.kind = SpanKind.CLIENT
 
         actual_attributes: Attributes = _GENERATOR.generate_metric_attributes_dict_from_span(
             self.span_mock, self.resource
         ).get(DEPENDENCY_METRIC)
-        self.assertEqual(actual_attributes.get(AWS_REMOTE_DB_USER), db_user)
+        self.assertEqual(actual_attributes.get(AWS_REMOTE_DB_USER), "non_db_user")
+
+    def test_db_user_present_and_is_db_span_false(self):
+        self._mock_attribute([SpanAttributes.DB_USER], ["db_user"])
+        self.span_mock.kind = SpanKind.CLIENT
+
+        actual_attributes: Attributes = _GENERATOR.generate_metric_attributes_dict_from_span(
+            self.span_mock, self.resource
+        ).get(DEPENDENCY_METRIC)
+        self.assertIsNone(actual_attributes.get(AWS_REMOTE_DB_USER))
 
     def test_local_root_boto3_span(self):
         self._update_resource_with_service_name()

--- a/contract-tests/tests/test/amazon/base/database_contract_test_base.py
+++ b/contract-tests/tests/test/amazon/base/database_contract_test_base.py
@@ -9,11 +9,11 @@ from amazon.base.contract_test_base import ContractTestBase
 from amazon.utils.application_signals_constants import (
     AWS_LOCAL_OPERATION,
     AWS_LOCAL_SERVICE,
+    AWS_REMOTE_DB_USER,
     AWS_REMOTE_OPERATION,
     AWS_REMOTE_RESOURCE_IDENTIFIER,
     AWS_REMOTE_RESOURCE_TYPE,
     AWS_REMOTE_SERVICE,
-    AWS_REMOTE_DB_USER,
     AWS_SPAN_KIND,
 )
 from opentelemetry.proto.common.v1.common_pb2 import AnyValue, KeyValue

--- a/contract-tests/tests/test/amazon/base/database_contract_test_base.py
+++ b/contract-tests/tests/test/amazon/base/database_contract_test_base.py
@@ -20,11 +20,12 @@ from opentelemetry.proto.metrics.v1.metrics_pb2 import ExponentialHistogramDataP
 from opentelemetry.proto.trace.v1.trace_pb2 import Span
 from opentelemetry.trace import StatusCode
 
+AWS_REMOTE_DB_USER: str = "aws.remote.db.user"
 DATABASE_HOST: str = "mydb"
 DATABASE_USER: str = "root"
 DATABASE_PASSWORD: str = "example"
 DATABASE_NAME: str = "testdb"
-
+DB_USER: str = "db.user"
 
 class DatabaseContractTestBase(ContractTestBase):
     @staticmethod
@@ -98,6 +99,7 @@ class DatabaseContractTestBase(ContractTestBase):
         self.assertTrue("server.address" not in attributes_dict)
         self.assertTrue("server.port" not in attributes_dict)
         self.assertTrue("db.operation" not in attributes_dict)
+        self._assert_str_attribute(attributes_dict, AWS_REMOTE_DB_USER, DB_USER)
 
     @override
     def _assert_aws_attributes(self, attributes_list: List[KeyValue], **kwargs) -> None:
@@ -114,6 +116,7 @@ class DatabaseContractTestBase(ContractTestBase):
         )
         # See comment above AWS_LOCAL_OPERATION
         self._assert_str_attribute(attributes_dict, AWS_SPAN_KIND, "LOCAL_ROOT")
+        self._assert_str_attribute(attributes_dict, AWS_REMOTE_DB_USER, DB_USER)
 
     @override
     def _assert_metric_attributes(
@@ -145,6 +148,7 @@ class DatabaseContractTestBase(ContractTestBase):
             attribute_dict, AWS_REMOTE_RESOURCE_IDENTIFIER, self.get_remote_resource_identifier()
         )
         self._assert_str_attribute(attribute_dict, AWS_SPAN_KIND, "CLIENT")
+        self._assert_str_attribute(attribute_dict, AWS_REMOTE_DB_USER, DB_USER)
         self.check_sum(metric_name, dependency_dp.sum, expected_sum)
 
         attribute_dict: Dict[str, AnyValue] = self._get_attributes_dict(service_dp.attributes)

--- a/contract-tests/tests/test/amazon/base/database_contract_test_base.py
+++ b/contract-tests/tests/test/amazon/base/database_contract_test_base.py
@@ -20,12 +20,10 @@ from opentelemetry.proto.metrics.v1.metrics_pb2 import ExponentialHistogramDataP
 from opentelemetry.proto.trace.v1.trace_pb2 import Span
 from opentelemetry.trace import StatusCode
 
-AWS_REMOTE_DB_USER: str = "aws.remote.db.user"
 DATABASE_HOST: str = "mydb"
 DATABASE_USER: str = "root"
 DATABASE_PASSWORD: str = "example"
 DATABASE_NAME: str = "testdb"
-DB_USER: str = "db.user"
 
 
 class DatabaseContractTestBase(ContractTestBase):
@@ -100,7 +98,6 @@ class DatabaseContractTestBase(ContractTestBase):
         self.assertTrue("server.address" not in attributes_dict)
         self.assertTrue("server.port" not in attributes_dict)
         self.assertTrue("db.operation" not in attributes_dict)
-        self._assert_str_attribute(attributes_dict, AWS_REMOTE_DB_USER, DB_USER)
 
     @override
     def _assert_aws_attributes(self, attributes_list: List[KeyValue], **kwargs) -> None:
@@ -117,7 +114,6 @@ class DatabaseContractTestBase(ContractTestBase):
         )
         # See comment above AWS_LOCAL_OPERATION
         self._assert_str_attribute(attributes_dict, AWS_SPAN_KIND, "LOCAL_ROOT")
-        self._assert_str_attribute(attributes_dict, AWS_REMOTE_DB_USER, DB_USER)
 
     @override
     def _assert_metric_attributes(
@@ -149,7 +145,6 @@ class DatabaseContractTestBase(ContractTestBase):
             attribute_dict, AWS_REMOTE_RESOURCE_IDENTIFIER, self.get_remote_resource_identifier()
         )
         self._assert_str_attribute(attribute_dict, AWS_SPAN_KIND, "CLIENT")
-        self._assert_str_attribute(attribute_dict, AWS_REMOTE_DB_USER, DB_USER)
         self.check_sum(metric_name, dependency_dp.sum, expected_sum)
 
         attribute_dict: Dict[str, AnyValue] = self._get_attributes_dict(service_dp.attributes)

--- a/contract-tests/tests/test/amazon/base/database_contract_test_base.py
+++ b/contract-tests/tests/test/amazon/base/database_contract_test_base.py
@@ -27,6 +27,7 @@ DATABASE_PASSWORD: str = "example"
 DATABASE_NAME: str = "testdb"
 DB_USER: str = "db.user"
 
+
 class DatabaseContractTestBase(ContractTestBase):
     @staticmethod
     def get_remote_service() -> str:

--- a/contract-tests/tests/test/amazon/base/database_contract_test_base.py
+++ b/contract-tests/tests/test/amazon/base/database_contract_test_base.py
@@ -13,6 +13,7 @@ from amazon.utils.application_signals_constants import (
     AWS_REMOTE_RESOURCE_IDENTIFIER,
     AWS_REMOTE_RESOURCE_TYPE,
     AWS_REMOTE_SERVICE,
+    AWS_REMOTE_DB_USER,
     AWS_SPAN_KIND,
 )
 from opentelemetry.proto.common.v1.common_pb2 import AnyValue, KeyValue
@@ -109,6 +110,7 @@ class DatabaseContractTestBase(ContractTestBase):
         self._assert_str_attribute(attributes_dict, AWS_REMOTE_SERVICE, self.get_remote_service())
         self._assert_str_attribute(attributes_dict, AWS_REMOTE_OPERATION, kwargs.get("sql_command"))
         self._assert_str_attribute(attributes_dict, AWS_REMOTE_RESOURCE_TYPE, "DB::Connection")
+        self._assert_str_attribute(attributes_dict, AWS_REMOTE_DB_USER, DATABASE_USER)
         self._assert_str_attribute(
             attributes_dict, AWS_REMOTE_RESOURCE_IDENTIFIER, self.get_remote_resource_identifier()
         )

--- a/contract-tests/tests/test/amazon/utils/application_signals_constants.py
+++ b/contract-tests/tests/test/amazon/utils/application_signals_constants.py
@@ -12,6 +12,7 @@ FAULT_METRIC: str = "fault"
 # Attribute names
 AWS_LOCAL_SERVICE: str = "aws.local.service"
 AWS_LOCAL_OPERATION: str = "aws.local.operation"
+AWS_REMOTE_DB_USER: str = "aws.remote.db.user"
 AWS_REMOTE_SERVICE: str = "aws.remote.service"
 AWS_REMOTE_OPERATION: str = "aws.remote.operation"
 AWS_REMOTE_RESOURCE_TYPE: str = "aws.remote.resource.type"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Adding data base user attribute in Python EMF logs - db.user.
- Added unit test for data base user attribute
- Added contract-tests

Output of EMF log:
```
{
    “Environment”: “ECS”,
    “RemoteDbUser”: “myuser”, <- Added Data base user
    “RemoteService”: “mysql”,
    “Service”: “python-appsignals-auto-cwa”,
        …
    },
    “Latency”: {
        “Values”: [
            …
        ],
        “Counts”: [
            …
        ],
        …
    }
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

