### PR TITLE
Correct checkout step name in workflows

### DIFF
--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -31,7 +31,7 @@ jobs:
       staging_repository: ${{ steps.python_output.outputs.stagingRepository}}
       staging_wheel_file: ${{ steps.staging_wheel_output.outputs.STAGING_WHEEL}}
     steps:
-      - name: Checkout Contrib Repo @ SHA - ${{ github.sha }}
+      - name: Checkout Repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
 
       - name: Get Python Distro Output

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
-      - name: Checkout Contrib Repo @ SHA - ${{ github.sha }}
+      - name: Checkout Repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
 
       - name: Build Wheel and Image Files
@@ -43,7 +43,7 @@ jobs:
       matrix:
         tox-environment: ["spellcheck", "lint"]
     steps:
-      - name: Checkout Contrib Repo @ SHA - ${{ github.sha }}
+      - name: Checkout Repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
 
       - name: Install libsnappy-dev
@@ -64,7 +64,7 @@ jobs:
   spotless:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Contrib Repo @ SHA - ${{ github.sha }}
+      - name: Checkout Repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
 
       - name: Gradle validation

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -24,7 +24,7 @@ jobs:
     environment: Release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Contrib Repo @ SHA - ${{ github.sha }}
+      - name: Checkout Repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@v4
 
       - name: Build Wheel and Image Files


### PR DESCRIPTION
*Description of changes:*
- The `name: Checkout Contrib Repo @ SHA - ${{ github.sha }}` is confusing since we are checking out the current repo which is not "Contrib". So we should just call it "Checkout Repo".


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

