### PR TITLE
Move to public ECR for DockerFile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 #   update the `PYTHONPATH` environment variable accordingly. Then in the second stage, copy the directory to `/autoinstrumentation`.
 
 # Stage 1: Install ADOT Python in the /operator-build folder
-FROM python:3.11 AS build
+FROM public.ecr.aws/docker/library/python:3.11 AS build
 
 WORKDIR /operator-build
 
@@ -21,7 +21,7 @@ RUN sed -i "/opentelemetry-exporter-otlp-proto-grpc/d" ./aws-opentelemetry-distr
 RUN mkdir workspace && pip install --target workspace ./aws-opentelemetry-distro
 
 # Stage 2: Build the cp-utility binary
-FROM rust:1.75 as builder
+FROM public.ecr.aws/docker/library/rust:1.75 as builder
 
 WORKDIR /usr/src/cp-utility
 COPY ./tools/cp-utility .


### PR DESCRIPTION
In this commit, we are updating the Dockerfile to use python3.11 and rust1.75 images to build the ADOT Python Instrumentation image vended by this repo. This should be a no-op as a) the public ECRs should be mirrors of the DockerHub equivalent and b) these images are only used in the build process, not the final produced image (which is built from `scratch`).

We will be using:
* https://gallery.ecr.aws/docker/library/python
* https://gallery.ecr.aws/docker/library/rust

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

