### PR TITLE
Remove old branch from main_build

### DIFF
--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - "release/v*"
-      - e2e-parallel
 env:
   AWS_DEFAULT_REGION: us-east-1
   STAGING_ECR_REGISTRY: 637423224110.dkr.ecr.us-east-1.amazonaws.com


### PR DESCRIPTION
e2e-parallel branch was used for some testing, but shouldn't have been left to trigger main_build. Cleaning up.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

