### PR TITLE
Add Application Signals runtime metrics

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_aws_resource_attribute_configurator.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_aws_resource_attribute_configurator.py
@@ -1,0 +1,19 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+from amazon.opentelemetry.distro._aws_span_processing_util import UNKNOWN_SERVICE
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+
+# As per https://opentelemetry.io/docs/specs/semconv/resource/#service, if service name is not specified, SDK defaults
+# the service name to unknown_service:<process name> or just unknown_service.
+_OTEL_UNKNOWN_SERVICE_PREFIX: str = "unknown_service"
+
+
+def get_service_attribute(resource: Resource) -> (str, bool):
+    """Service is always derived from SERVICE_NAME"""
+    service: str = resource.attributes.get(SERVICE_NAME)
+
+    # In practice the service name is never None, but we can be defensive here.
+    if service is None or service.startswith(_OTEL_UNKNOWN_SERVICE_PREFIX):
+        return UNKNOWN_SERVICE, True
+
+    return service, False

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/scope_based_exporter.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/scope_based_exporter.py
@@ -1,0 +1,54 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+from logging import Logger, getLogger
+from typing import Optional, Set
+
+from opentelemetry.context import _SUPPRESS_INSTRUMENTATION_KEY, attach, detach, set_value
+from opentelemetry.sdk.metrics.export import MetricExporter, MetricsData, PeriodicExportingMetricReader, ResourceMetrics
+
+_logger: Logger = getLogger(__name__)
+
+
+class ScopeBasedPeriodicExportingMetricReader(PeriodicExportingMetricReader):
+
+    def __init__(
+        self,
+        exporter: MetricExporter,
+        export_interval_millis: Optional[float] = None,
+        export_timeout_millis: Optional[float] = None,
+        registered_scope_names: Set[str] = None,
+    ):
+        super().__init__(exporter, export_interval_millis, export_timeout_millis)
+        self._registered_scope_names = registered_scope_names
+
+    def _receive_metrics(
+        self,
+        metrics_data: MetricsData,
+        timeout_millis: float = 10_000,
+        **kwargs,
+    ) -> None:
+
+        token = attach(set_value(_SUPPRESS_INSTRUMENTATION_KEY, True))
+        # pylint: disable=broad-exception-caught,invalid-name
+        try:
+            with self._export_lock:
+                exporting_resource_metrics = []
+                for metric in metrics_data.resource_metrics:
+                    exporting_scope_metrics = []
+                    for scope_metric in metric.scope_metrics:
+                        if scope_metric.scope.name in self._registered_scope_names:
+                            exporting_scope_metrics.append(scope_metric)
+                    if len(exporting_scope_metrics) > 0:
+                        exporting_resource_metrics.append(
+                            ResourceMetrics(
+                                resource=metric.resource,
+                                scope_metrics=exporting_scope_metrics,
+                                schema_url=metric.schema_url,
+                            )
+                        )
+                if len(exporting_resource_metrics) > 0:
+                    new_metrics_data = MetricsData(resource_metrics=exporting_resource_metrics)
+                    self._exporter.export(new_metrics_data, timeout_millis=timeout_millis)
+        except Exception as e:
+            _logger.exception("Exception while exporting metrics %s", str(e))
+        detach(token)

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/scope_based_filtering_view.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/scope_based_filtering_view.py
@@ -1,0 +1,20 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+from typing import Optional
+
+from opentelemetry.metrics import Instrument
+from opentelemetry.sdk.metrics.view import DropAggregation, View
+
+
+class ScopeBasedRetainingView(View):
+    def __init__(
+        self,
+        meter_name: Optional[str] = None,
+    ) -> None:
+        super().__init__(meter_name=meter_name, aggregation=DropAggregation())
+
+    def _match(self, instrument: Instrument) -> bool:
+        if instrument.instrumentation_scope.name != self._meter_name:
+            return True
+
+        return False

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_scope_based_exporter.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_scope_based_exporter.py
@@ -1,0 +1,100 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import unittest
+from time import time_ns
+from unittest.mock import MagicMock
+
+from amazon.opentelemetry.distro.scope_based_exporter import ScopeBasedPeriodicExportingMetricReader
+from opentelemetry.sdk.metrics.export import (
+    Metric,
+    MetricExporter,
+    MetricsData,
+    NumberDataPoint,
+    ResourceMetrics,
+    ScopeMetrics,
+    Sum,
+)
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.util.instrumentation import InstrumentationScope
+
+
+class TestScopeBasedPeriodicExportingMetricReader(unittest.TestCase):
+    def setUp(self):
+        self.metric_exporter: MetricExporter = MagicMock()
+
+    def _create_periodic_reader(self, metrics, interval=60000, timeout=30000):
+        pmr = ScopeBasedPeriodicExportingMetricReader(
+            self.metric_exporter,
+            export_interval_millis=interval,
+            export_timeout_millis=timeout,
+            registered_scope_names={"io.test.retained"},
+        )
+
+        def _collect(reader, timeout_millis):
+            pmr._receive_metrics(metrics, timeout_millis)
+
+        pmr._set_collect_callback(_collect)
+        return pmr
+
+    def test_scope_based_metric_filter(self):
+        scope_metrics = _scope_metrics(5, "io.test.retained") + _scope_metrics(3, "io.test.dropped")
+        md = MetricsData(
+            resource_metrics=[
+                ResourceMetrics(
+                    schema_url="",
+                    resource=Resource.create(),
+                    scope_metrics=scope_metrics,
+                )
+            ]
+        )
+        pmr = self._create_periodic_reader(md)
+        pmr.collect()
+        args, _ = self.metric_exporter.export.call_args
+
+        exporting_metric_data: MetricsData = args[0]
+        self.assertEqual(len(exporting_metric_data.resource_metrics[0].scope_metrics), 5)
+
+    def test_empty_metrics(self):
+        md = MetricsData(
+            resource_metrics=[
+                ResourceMetrics(
+                    schema_url="",
+                    resource=Resource.create(),
+                    scope_metrics=[],
+                )
+            ]
+        )
+        pmr = self._create_periodic_reader(md)
+        pmr.collect()
+        self.metric_exporter.export.assert_not_called()
+
+
+def _scope_metrics(num: int, scope_name: str):
+    scope_metrics = []
+    for _ in range(num):
+        scope_metrics.append(
+            ScopeMetrics(
+                schema_url="",
+                scope=InstrumentationScope(name=scope_name),
+                metrics=[
+                    Metric(
+                        name="sum_name",
+                        description="",
+                        unit="",
+                        data=Sum(
+                            data_points=[
+                                NumberDataPoint(
+                                    attributes={},
+                                    start_time_unix_nano=time_ns(),
+                                    time_unix_nano=time_ns(),
+                                    value=2,
+                                )
+                            ],
+                            aggregation_temporality=1,
+                            is_monotonic=True,
+                        ),
+                    )
+                ],
+            ),
+        )
+    return scope_metrics

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_scope_based_filtering_view.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_scope_based_filtering_view.py
@@ -1,0 +1,21 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import unittest
+from unittest.mock import MagicMock
+
+from amazon.opentelemetry.distro.scope_based_filtering_view import ScopeBasedRetainingView
+from opentelemetry.metrics import Instrument
+
+
+class TestScopeBasedRetainingView(unittest.TestCase):
+    def test_retained(self):
+        instrument: Instrument = MagicMock()
+        instrument.instrumentation_scope.name = "not_matched"
+        view = ScopeBasedRetainingView(meter_name="test_meter")
+        self.assertTrue(view._match(instrument))
+
+    def test_dropped(self):
+        instrument: Instrument = MagicMock()
+        instrument.instrumentation_scope.name = "test_meter"
+        view = ScopeBasedRetainingView(meter_name="test_meter")
+        self.assertFalse(view._match(instrument))

--- a/contract-tests/images/mock-collector/mock_collector_client.py
+++ b/contract-tests/images/mock-collector/mock_collector_client.py
@@ -87,7 +87,7 @@ class MockCollectorClient:
                         spans.append(ResourceScopeSpan(resource_span, scope_span, span))
         return spans
 
-    def get_metrics(self, present_metrics: Set[str]) -> List[ResourceScopeMetric]:
+    def get_metrics(self, present_metrics: Set[str], exact_match=True) -> List[ResourceScopeMetric]:
         """Get all metrics that are currently stored in the mock collector.
 
         Returns:
@@ -111,7 +111,9 @@ class MockCollectorClient:
                     for scope_metric in resource_metric.scope_metrics:
                         for metric in scope_metric.metrics:
                             received_metrics.add(metric.name.lower())
-            return 0 < len(exported) == len(current) and present_metrics_lower.issubset(received_metrics)
+            if exact_match:
+                return 0 < len(exported) == len(current) and present_metrics_lower.issubset(received_metrics)
+            return present_metrics_lower.issubset(received_metrics)
 
         exported_metrics: List[ExportMetricsServiceRequest] = _wait_for_content(get_export, wait_condition)
         metrics: List[ResourceScopeMetric] = []

--- a/contract-tests/tests/test/amazon/base/contract_test_base.py
+++ b/contract-tests/tests/test/amazon/base/contract_test_base.py
@@ -90,7 +90,7 @@ class ContractTestBase(TestCase):
             .with_exposed_ports(self.get_application_port())
             .with_env("OTEL_METRIC_EXPORT_INTERVAL", "50")
             .with_env("OTEL_AWS_APPLICATION_SIGNALS_ENABLED", "true")
-            .with_env("OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED", "false")
+            .with_env("OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED", self.is_runtime_enabled())
             .with_env("OTEL_METRICS_EXPORTER", "none")
             .with_env("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
             .with_env("OTEL_BSP_SCHEDULE_DELAY", "1")
@@ -216,6 +216,9 @@ class ContractTestBase(TestCase):
 
     def get_application_otel_resource_attributes(self) -> str:
         return "service.name=" + self.get_application_otel_service_name()
+
+    def is_runtime_enabled(self) -> str:
+        return "false"
 
     def _assert_aws_span_attributes(self, resource_scope_spans: List[ResourceScopeSpan], path: str, **kwargs):
         self.fail("Tests must implement this function")

--- a/contract-tests/tests/test/amazon/base/contract_test_base.py
+++ b/contract-tests/tests/test/amazon/base/contract_test_base.py
@@ -90,6 +90,7 @@ class ContractTestBase(TestCase):
             .with_exposed_ports(self.get_application_port())
             .with_env("OTEL_METRIC_EXPORT_INTERVAL", "50")
             .with_env("OTEL_AWS_APPLICATION_SIGNALS_ENABLED", "true")
+            .with_env("OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED", "false")
             .with_env("OTEL_METRICS_EXPORTER", "none")
             .with_env("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
             .with_env("OTEL_BSP_SCHEDULE_DELAY", "1")

--- a/contract-tests/tests/test/amazon/runtime/runtime_metrics_test.py
+++ b/contract-tests/tests/test/amazon/runtime/runtime_metrics_test.py
@@ -1,0 +1,104 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+from typing import Dict, List
+
+from mock_collector_client import ResourceScopeMetric
+from requests import Response
+from typing_extensions import override
+
+import amazon.utils.application_signals_constants as constants
+from amazon.base.contract_test_base import ContractTestBase
+from opentelemetry.proto.common.v1.common_pb2 import AnyValue
+from opentelemetry.proto.metrics.v1.metrics_pb2 import Metric, NumberDataPoint
+
+
+class RuntimeMetricsTest(ContractTestBase):
+    @override
+    def is_runtime_enabled(self) -> str:
+        return "true"
+
+    @override
+    @staticmethod
+    def get_application_image_name() -> str:
+        return "aws-application-signals-tests-django-app"
+
+    @override
+    def get_application_wait_pattern(self) -> str:
+        return "Quit the server with CONTROL-C."
+
+    @override
+    def get_application_extra_environment_variables(self):
+        return {"DJANGO_SETTINGS_MODULE": "django_server.settings"}
+
+    def test_runtime_succeeds(self) -> None:
+        self.mock_collector_client.clear_signals()
+        response: Response = self.send_request("GET", "success")
+        self.assertEqual(200, response.status_code)
+
+        metrics: List[ResourceScopeMetric] = self.mock_collector_client.get_metrics(
+            {
+                constants.LATENCY_METRIC,
+                constants.ERROR_METRIC,
+                constants.FAULT_METRIC,
+                constants.PYTHON_PROCESS_CPU_TIME,
+                constants.PYTHON_PROCESS_CPU_UTILIZATION,
+                constants.PYTHON_PROCESS_GC_COUNT,
+                constants.PYTHON_PROCESS_MEMORY_USED,
+                constants.PYTHON_PROCESS_THREAD_COUNT,
+            },
+            False,
+        )
+        self._assert_resource_attributes(metrics)
+        self._assert_counter_attribute_exists(metrics, constants.PYTHON_PROCESS_CPU_TIME, "")
+        self._assert_gauge_attribute_exists(metrics, constants.PYTHON_PROCESS_CPU_UTILIZATION, "")
+        self._assert_gauge_attribute_exists(metrics, constants.PYTHON_PROCESS_GC_COUNT, "count")
+        self._assert_gauge_attribute_exists(metrics, constants.PYTHON_PROCESS_MEMORY_USED, "type")
+        self._assert_gauge_attribute_exists(metrics, constants.PYTHON_PROCESS_THREAD_COUNT, "")
+
+    def _assert_resource_attributes(
+        self,
+        resource_scope_metrics: List[ResourceScopeMetric],
+    ) -> None:
+        for metric in resource_scope_metrics:
+            attribute_dict: Dict[str, AnyValue] = self._get_attributes_dict(metric.resource_metrics.resource.attributes)
+            self._assert_str_attribute(
+                attribute_dict, constants.AWS_LOCAL_SERVICE, self.get_application_otel_service_name()
+            )
+
+    def _assert_gauge_attribute_exists(
+        self,
+        resource_scope_metrics: List[ResourceScopeMetric],
+        metric_name: str,
+        attribute_key: str,
+    ) -> None:
+        target_metrics: List[Metric] = []
+        for resource_scope_metric in resource_scope_metrics:
+            if resource_scope_metric.metric.name.lower() == metric_name.lower():
+                target_metrics.append(resource_scope_metric.metric)
+        self.assertTrue(len(target_metrics) > 0)
+
+        for target_metric in target_metrics:
+            dp_list: List[NumberDataPoint] = target_metric.gauge.data_points
+            self.assertTrue(len(dp_list) > 0)
+            if attribute_key != "":
+                attribute_dict: Dict[str, AnyValue] = self._get_attributes_dict(dp_list[0].attributes)
+                self.assertIsNotNone(attribute_dict.get(attribute_key))
+
+    def _assert_counter_attribute_exists(
+        self,
+        resource_scope_metrics: List[ResourceScopeMetric],
+        metric_name: str,
+        attribute_key: str,
+    ) -> None:
+        target_metrics: List[Metric] = []
+        for resource_scope_metric in resource_scope_metrics:
+            if resource_scope_metric.metric.name.lower() == metric_name.lower():
+                target_metrics.append(resource_scope_metric.metric)
+        self.assertTrue(len(target_metrics) > 0)
+
+        for target_metric in target_metrics:
+            dp_list: List[NumberDataPoint] = target_metric.sum.data_points
+            self.assertTrue(len(dp_list) > 0)
+            if attribute_key != "":
+                attribute_dict: Dict[str, AnyValue] = self._get_attributes_dict(dp_list[0].attributes)
+                self.assertIsNotNone(attribute_dict.get(attribute_key))

--- a/contract-tests/tests/test/amazon/utils/application_signals_constants.py
+++ b/contract-tests/tests/test/amazon/utils/application_signals_constants.py
@@ -9,6 +9,12 @@ LATENCY_METRIC: str = "latency"
 ERROR_METRIC: str = "error"
 FAULT_METRIC: str = "fault"
 
+PYTHON_PROCESS_GC_COUNT = "process.runtime.cpython.gc_count"
+PYTHON_PROCESS_MEMORY_USED = "process.runtime.cpython.memory"
+PYTHON_PROCESS_THREAD_COUNT = "process.runtime.cpython.thread_count"
+PYTHON_PROCESS_CPU_TIME = "process.runtime.cpython.cpu_time"
+PYTHON_PROCESS_CPU_UTILIZATION = "process.runtime.cpython.cpu.utilization"
+
 # Attribute names
 AWS_CLOUDFORMATION_PRIMARY_IDENTIFIER: str = "aws.remote.resource.cfn.primary.identifier"
 AWS_LOCAL_SERVICE: str = "aws.local.service"


### PR DESCRIPTION
## Feature request
Add runtime metrics collection into Application Signals. Runtime metrics will be enabled by default if `OTEL_AWS_APPLICATION_SIGNALS_ENABLED` is `true`, and can be disabled separately by setting `OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED` to `false`.

## Description of changes:
1. Add `ScopeBasedPeriodicExportingMetricReader` to copy metrics from `opentelemetry.instrumentation.system_metrics` instrumentation scope to Application Signals exporter.
2. Set `aws.local.service` into resource attributes. 
3. Add views to workaround https://github.com/open-telemetry/opentelemetry-python-contrib/issues/2861.
4. Add contract testing for runtime metrics.

## Result example
```
{
  "resource_metrics": [
    {
      "resource": {
        "attributes": {
          "telemetry.sdk.language": "python",
          "telemetry.sdk.name": "opentelemetry",
          "telemetry.sdk.version": "1.25.0",
          "service.name": "unknown_service",
          "cloud.provider": "aws",
          "cloud.platform": "aws_ec2",
          "cloud.account.id": "633750930120",
          "cloud.region": "us-east-1",
          "cloud.availability_zone": "us-east-1a",
          "host.id": "i-03ff80a878a803e0e",
          "host.type": "t2.medium",
          "host.name": "ip-172-31-25-215.ec2.internal",
          "telemetry.auto.version": "0.3.0.dev0-aws",
          "aws.local.service": "UnknownService"
        },
        "schema_url": ""
      },
      "scope_metrics": [
        {
          "scope": {
            "name": "opentelemetry.instrumentation.system_metrics",
            "version": "0.46b0",
            "schema_url": "https://opentelemetry.io/schemas/1.11.0"
          },
          "metrics": [
            {
              "name": "process.runtime.cpython.memory",
              "description": "Runtime cpython memory",
              "unit": "bytes",
              "data": {
                "data_points": [
                  {
                    "attributes": {
                      "type": "rss"
                    },
                    "start_time_unix_nano": 1724953385390606423,
                    "time_unix_nano": 1724953385391126083,
                    "value": 75747328
                  },
                  {
                    "attributes": {
                      "type": "vms"
                    },
                    "start_time_unix_nano": 1724953385390606423,
                    "time_unix_nano": 1724953385391126083,
                    "value": 546709504
                  }
                ],
                "aggregation_temporality": 2,
                "is_monotonic": false
              }
            }
          ]
        }
      ]
    }
  ]
}
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.