### PR TITLE
Export unsampled span in AWS Lambda environment

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_aws_attribute_keys.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_aws_attribute_keys.py
@@ -11,6 +11,7 @@ AWS_REMOTE_RESOURCE_TYPE: str = "aws.remote.resource.type"
 AWS_REMOTE_RESOURCE_IDENTIFIER: str = "aws.remote.resource.identifier"
 AWS_SDK_DESCENDANT: str = "aws.sdk.descendant"
 AWS_CONSUMER_PARENT_SPAN_KIND: str = "aws.consumer.parent.span.kind"
+AWS_TRACE_FLAG_UNSAMPLED: str = "aws.trace.flag.unsampled"
 
 # AWS_#_NAME attributes are not supported in python as they are not part of the Semantic Conventions.
 # TODO：Move to Semantic Conventions when these attributes are added.

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_batch_unsampled_span_processor.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_batch_unsampled_span_processor.py
@@ -1,0 +1,37 @@
+import logging
+from typing import Optional
+
+from amazon.opentelemetry.distro._aws_attribute_keys import AWS_TRACE_FLAG_UNSAMPLED
+from opentelemetry.context import Context
+from opentelemetry.sdk.trace import ReadableSpan, Span
+from opentelemetry.sdk.trace.export import BatchSpanProcessor as BaseBatchSpanProcessor
+
+logger = logging.getLogger(__name__)
+
+SPANUNSAMPLED_FLAG = "OTEL_AWS_APP_SIGNALS_ENABLED"
+
+
+class BatchUnsampledSpanProcessor(BaseBatchSpanProcessor):
+
+    def on_start(self, span: Span, parent_context: Optional[Context] = None) -> None:
+        if not span.context.trace_flags.sampled:
+            span.set_attribute(AWS_TRACE_FLAG_UNSAMPLED, "True")
+
+    def on_end(self, span: ReadableSpan) -> None:
+        if span.context.trace_flags.sampled:
+            return
+
+        if self.done:
+            logger.warning("Already shutdown, dropping span.")
+            return
+
+        if len(self.queue) == self.max_queue_size:
+            if not self._spans_dropped:
+                logger.warning("Queue is full, likely spans will be dropped.")
+                self._spans_dropped = True
+
+        self.queue.appendleft(span)
+
+        if len(self.queue) >= self.max_export_batch_size:
+            with self.condition:
+                self.condition.notify()

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_batch_unsampled_span_processor.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_batch_unsampled_span_processor.py
@@ -18,7 +18,7 @@ class BatchUnsampledSpanProcessor(BaseBatchSpanProcessor):
     # pylint: disable=no-self-use
     def on_start(self, span: Span, parent_context: Optional[Context] = None) -> None:
         if not span.context.trace_flags.sampled:
-            span.set_attribute(AWS_TRACE_FLAG_UNSAMPLED, "True")
+            span.set_attribute(AWS_TRACE_FLAG_UNSAMPLED, True)
 
     def on_end(self, span: ReadableSpan) -> None:
         if span.context.trace_flags.sampled:

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_batch_unsampled_span_processor.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_batch_unsampled_span_processor.py
@@ -32,6 +32,7 @@ class BatchUnsampledSpanProcessor(BaseBatchSpanProcessor):
             # pylint: disable=access-member-before-definition
             if not self._spans_dropped:
                 logger.warning("Queue is full, likely spans will be dropped.")
+                # pylint: disable=attribute-defined-outside-init
                 self._spans_dropped = True
 
         self.queue.appendleft(span)

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_batch_unsampled_span_processor.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_batch_unsampled_span_processor.py
@@ -1,3 +1,5 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 import logging
 from typing import Optional
 
@@ -13,6 +15,7 @@ SPANUNSAMPLED_FLAG = "OTEL_AWS_APP_SIGNALS_ENABLED"
 
 class BatchUnsampledSpanProcessor(BaseBatchSpanProcessor):
 
+    # pylint: disable=no-self-use
     def on_start(self, span: Span, parent_context: Optional[Context] = None) -> None:
         if not span.context.trace_flags.sampled:
             span.set_attribute(AWS_TRACE_FLAG_UNSAMPLED, "True")
@@ -26,6 +29,7 @@ class BatchUnsampledSpanProcessor(BaseBatchSpanProcessor):
             return
 
         if len(self.queue) == self.max_queue_size:
+            # pylint: disable=access-member-before-definition
             if not self._spans_dropped:
                 logger.warning("Queue is full, likely spans will be dropped.")
                 self._spans_dropped = True

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
@@ -155,7 +155,6 @@ def _init_tracing(
         span_exporter = _customize_exporter(span_exporter, resource)
         trace_provider.add_span_processor(BatchSpanProcessor(span_exporter))
 
-    _export_unsampled_span_for_lambda(trace_provider, resource)
     _customize_span_processors(trace_provider, resource)
 
     set_tracer_provider(trace_provider)
@@ -275,6 +274,8 @@ def _customize_exporter(span_exporter: SpanExporter, resource: Resource) -> Span
 def _customize_span_processors(provider: TracerProvider, resource: Resource) -> None:
     if not _is_application_signals_enabled():
         return
+
+    _export_unsampled_span_for_lambda(provider, resource)
 
     # Construct and set local and remote attributes span processor
     provider.add_span_processor(AttributePropagatingSpanProcessorBuilder().build())

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
@@ -154,8 +154,8 @@ def _init_tracing(
         span_exporter: SpanExporter = exporter_class(**exporter_args)
         span_exporter = _customize_exporter(span_exporter, resource)
         trace_provider.add_span_processor(BatchSpanProcessor(span_exporter))
-        _export_unsampled_span_for_lambda(trace_provider, resource)
 
+    _export_unsampled_span_for_lambda(trace_provider, resource)
     _customize_span_processors(trace_provider, resource)
 
     set_tracer_provider(trace_provider)

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_batch_unsampled_span_processor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_batch_unsampled_span_processor.py
@@ -1,3 +1,5 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_batch_unsampled_span_processor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_batch_unsampled_span_processor.py
@@ -10,7 +10,7 @@ class TestBatchUnsampledSpanProcessor(TestCase):
 
     def setUp(self):
         self.mock_exporter = MagicMock()
-        self.processor = BatchUnsampledSpanProcessor(self.mock_exporter)
+        self.processor = BatchUnsampledSpanProcessor(self.mock_exporter, max_queue_size=1, max_export_batch_size=1)
 
     @patch("opentelemetry.sdk.trace.Span")
     def test_on_end_sampled(self, mock_span_class):

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_batch_unsampled_span_processor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_batch_unsampled_span_processor.py
@@ -21,7 +21,6 @@ class TestBatchUnsampledSpanProcessor(TestCase):
 
         self.processor.on_start(mock_span)
         self.processor.on_end(mock_span)
-        self.processor.shutdown()
 
         self.assertEqual(len(self.processor.queue), 0)
         mock_span.set_attribute.assert_not_called()
@@ -44,10 +43,10 @@ class TestBatchUnsampledSpanProcessor(TestCase):
         self.assertEqual(len(self.processor.queue), 1)
         self.assertIn(AWS_TRACE_FLAG_UNSAMPLED, mock_span1.set_attribute.call_args_list[0][0][0])
 
+        self.processor.shutdown()
         mock_span2 = mock_span_class.return_value
         mock_span2.context.trace_flags = trace_flags
         self.processor.on_start(mock_span2)
         self.processor.on_end(mock_span2)
 
-        self.assertEqual(len(self.processor.queue), 1)
-        self.assertIn(AWS_TRACE_FLAG_UNSAMPLED, mock_span2.set_attribute.call_args_list[0][0][0])
+        self.assertEqual(len(self.processor.queue), 0)

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_batch_unsampled_span_processor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_batch_unsampled_span_processor.py
@@ -1,0 +1,39 @@
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from amazon.opentelemetry.distro._aws_attribute_keys import AWS_TRACE_FLAG_UNSAMPLED
+from amazon.opentelemetry.distro.aws_batch_unsampled_span_processor import BatchUnsampledSpanProcessor
+from opentelemetry.trace import TraceFlags
+
+
+class TestBatchUnsampledSpanProcessor(TestCase):
+
+    def setUp(self):
+        self.mock_exporter = MagicMock()
+        self.processor = BatchUnsampledSpanProcessor(self.mock_exporter)
+
+    @patch("opentelemetry.sdk.trace.Span")
+    def test_on_end_sampled(self, mock_span_class):
+        trace_flags = TraceFlags(TraceFlags.SAMPLED)
+
+        mock_span = mock_span_class.return_value
+        mock_span.context.trace_flags = trace_flags
+
+        self.processor.on_start(mock_span)
+        self.processor.on_end(mock_span)
+
+        self.assertEqual(len(self.processor.queue), 0)
+        mock_span.set_attribute.assert_not_called()
+
+    @patch("opentelemetry.sdk.trace.Span")
+    def test_on_end_not_sampled(self, mock_span_class):
+
+        trace_flags = TraceFlags(0)
+        mock_span = mock_span_class.return_value
+        mock_span.context.trace_flags = trace_flags
+
+        self.processor.on_start(mock_span)
+        self.processor.on_end(mock_span)
+
+        self.assertEqual(len(self.processor.queue), 1)
+        self.assertIn(AWS_TRACE_FLAG_UNSAMPLED, mock_span.set_attribute.call_args_list[0][0][0])

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py
@@ -39,6 +39,7 @@ from opentelemetry.sdk.trace.sampling import DEFAULT_ON, Sampler
 from opentelemetry.trace import get_tracer_provider
 
 
+# pylint: disable=too-many-public-methods
 class TestAwsOpenTelemetryConfigurator(TestCase):
     """Tests AwsOpenTelemetryConfigurator and AwsOpenTelemetryDistro
 

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_otlp_udp_exporter.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_otlp_udp_exporter.py
@@ -8,12 +8,12 @@ from unittest.mock import MagicMock, patch
 
 from amazon.opentelemetry.distro.otlp_udp_exporter import (
     DEFAULT_ENDPOINT,
+    FORMAT_OTEL_SAMPLED_TRACES_BINARY_PREFIX,
+    FORMAT_OTEL_UNSAMPLED_TRACES_BINARY_PREFIX,
     PROTOCOL_HEADER,
     OTLPUdpMetricExporter,
     OTLPUdpSpanExporter,
     UdpExporter,
-    FORMAT_OTEL_SAMPLED_TRACES_BINARY_PREFIX,
-    FORMAT_OTEL_UNSAMPLED_TRACES_BINARY_PREFIX,
 )
 from opentelemetry.sdk.metrics._internal.export import MetricExportResult
 from opentelemetry.sdk.trace.export import SpanExportResult

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_otlp_udp_exporter.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_otlp_udp_exporter.py
@@ -12,9 +12,12 @@ from amazon.opentelemetry.distro.otlp_udp_exporter import (
     OTLPUdpMetricExporter,
     OTLPUdpSpanExporter,
     UdpExporter,
+    FORMAT_OTEL_UNSAMPLED_TRACES_BINARY_PREFIX,
 )
 from opentelemetry.sdk.metrics._internal.export import MetricExportResult
 from opentelemetry.sdk.trace.export import SpanExportResult
+
+from build.python.amazon.opentelemetry.distro.otlp_udp_exporter import FORMAT_OTEL_SAMPLED_TRACES_BINARY_PREFIX
 
 
 class TestUdpExporter(TestCase):
@@ -102,9 +105,11 @@ class TestOTLPUdpSpanExporter(unittest.TestCase):
         mock_udp_exporter_instance = mock_udp_exporter.return_value
         mock_encoded_data = MagicMock()
         mock_encode_spans.return_value.SerializeToString.return_value = mock_encoded_data
-        exporter = OTLPUdpSpanExporter()
+        exporter = OTLPUdpSpanExporter(sampled=False)
         result = exporter.export(MagicMock())
-        mock_udp_exporter_instance.send_data.assert_called_once_with(data=mock_encoded_data, signal_format_prefix="T1")
+        mock_udp_exporter_instance.send_data.assert_called_once_with(
+            data=mock_encoded_data, signal_format_prefix=FORMAT_OTEL_UNSAMPLED_TRACES_BINARY_PREFIX
+        )
         self.assertEqual(result, SpanExportResult.SUCCESS)
 
     @patch("amazon.opentelemetry.distro.otlp_udp_exporter.encode_spans")

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_otlp_udp_exporter.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_otlp_udp_exporter.py
@@ -12,6 +12,7 @@ from amazon.opentelemetry.distro.otlp_udp_exporter import (
     OTLPUdpMetricExporter,
     OTLPUdpSpanExporter,
     UdpExporter,
+    FORMAT_OTEL_SAMPLED_TRACES_BINARY_PREFIX,
     FORMAT_OTEL_UNSAMPLED_TRACES_BINARY_PREFIX,
 )
 from opentelemetry.sdk.metrics._internal.export import MetricExportResult
@@ -99,7 +100,7 @@ class TestOTLPUdpSpanExporter(unittest.TestCase):
 
     @patch("amazon.opentelemetry.distro.otlp_udp_exporter.encode_spans")
     @patch("amazon.opentelemetry.distro.otlp_udp_exporter.UdpExporter")
-    def test_export(self, mock_udp_exporter, mock_encode_spans):
+    def test_export_unsampled_span(self, mock_udp_exporter, mock_encode_spans):
         mock_udp_exporter_instance = mock_udp_exporter.return_value
         mock_encoded_data = MagicMock()
         mock_encode_spans.return_value.SerializeToString.return_value = mock_encoded_data
@@ -107,6 +108,19 @@ class TestOTLPUdpSpanExporter(unittest.TestCase):
         result = exporter.export(MagicMock())
         mock_udp_exporter_instance.send_data.assert_called_once_with(
             data=mock_encoded_data, signal_format_prefix=FORMAT_OTEL_UNSAMPLED_TRACES_BINARY_PREFIX
+        )
+        self.assertEqual(result, SpanExportResult.SUCCESS)
+
+    @patch("amazon.opentelemetry.distro.otlp_udp_exporter.encode_spans")
+    @patch("amazon.opentelemetry.distro.otlp_udp_exporter.UdpExporter")
+    def test_export_sampled_span(self, mock_udp_exporter, mock_encode_spans):
+        mock_udp_exporter_instance = mock_udp_exporter.return_value
+        mock_encoded_data = MagicMock()
+        mock_encode_spans.return_value.SerializeToString.return_value = mock_encoded_data
+        exporter = OTLPUdpSpanExporter()
+        result = exporter.export(MagicMock())
+        mock_udp_exporter_instance.send_data.assert_called_once_with(
+            data=mock_encoded_data, signal_format_prefix=FORMAT_OTEL_SAMPLED_TRACES_BINARY_PREFIX
         )
         self.assertEqual(result, SpanExportResult.SUCCESS)
 

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_otlp_udp_exporter.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_otlp_udp_exporter.py
@@ -17,8 +17,6 @@ from amazon.opentelemetry.distro.otlp_udp_exporter import (
 from opentelemetry.sdk.metrics._internal.export import MetricExportResult
 from opentelemetry.sdk.trace.export import SpanExportResult
 
-from build.python.amazon.opentelemetry.distro.otlp_udp_exporter import FORMAT_OTEL_SAMPLED_TRACES_BINARY_PREFIX
-
 
 class TestUdpExporter(TestCase):
 

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_otlp_udp_exporter.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_otlp_udp_exporter.py
@@ -92,6 +92,7 @@ class TestOTLPUdpMetricExporter(unittest.TestCase):
     def test_shutdown(self, mock_udp_exporter):
         mock_udp_exporter_instance = mock_udp_exporter.return_value
         exporter = OTLPUdpMetricExporter()
+        exporter.force_flush()
         exporter.shutdown()
         mock_udp_exporter_instance.shutdown.assert_called_once()
 
@@ -141,4 +142,5 @@ class TestOTLPUdpSpanExporter(unittest.TestCase):
         mock_udp_exporter_instance = mock_udp_exporter.return_value
         exporter = OTLPUdpSpanExporter()
         exporter.shutdown()
+        exporter.force_flush()
         mock_udp_exporter_instance.shutdown.assert_called_once()


### PR DESCRIPTION
*Description of changes:*

When AppSignals is enabled in AWS Lambda, we export both sampled and unsampled spans to X-Ray to generate Application Signals metrics.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

