### PR TITLE
Upgrade opentelemetry-sdk-extension-aws to 2.0.2.

### DIFF
--- a/aws-opentelemetry-distro/pyproject.toml
+++ b/aws-opentelemetry-distro/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "opentelemetry-propagator-b3 == 1.25.0",
   "opentelemetry-propagator-jaeger == 1.25.0",
   "opentelemetry-exporter-otlp-proto-common == 1.25.0",
-  "opentelemetry-sdk-extension-aws == 2.0.1",
+  "opentelemetry-sdk-extension-aws == 2.0.2",
   "opentelemetry-propagator-aws-xray == 1.0.1",
   "opentelemetry-distro == 0.46b0",
   "opentelemetry-propagator-ot-trace == 0.46b0",


### PR DESCRIPTION
Upgrade opentelemetry-sdk-extension-aws to 2.0.2 to utilize the latest AwsEcsResourceDetector code: https://github.com/open-telemetry/opentelemetry-python-contrib/commit/bf9a8e87a074d045ac8433e9fc4996aad6f17b0e


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

