### PR TITLE
Fix no attributes returned with un-sampled case.

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/always_record_sampler.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/always_record_sampler.py
@@ -52,7 +52,7 @@ class AlwaysRecordSampler(Sampler):
             parent_context, trace_id, name, kind, attributes, links, trace_state
         )
         if result.decision is Decision.DROP:
-            result = _wrap_result_with_record_only_result(result)
+            result = _wrap_result_with_record_only_result(result, attributes)
         return result
 
     @override
@@ -60,9 +60,9 @@ class AlwaysRecordSampler(Sampler):
         return "AlwaysRecordSampler{" + self._root_sampler.get_description() + "}"
 
 
-def _wrap_result_with_record_only_result(result: SamplingResult) -> SamplingResult:
+def _wrap_result_with_record_only_result(result: SamplingResult, attributes: Attributes) -> SamplingResult:
     return SamplingResult(
         Decision.RECORD_ONLY,
-        result.attributes,
+        attributes,
         result.trace_state,
     )

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_always_record_sampler.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_always_record_sampler.py
@@ -38,7 +38,7 @@ class TestAlwaysRecordSampler(TestCase):
             trace_id=0,
             name="name",
             kind=SpanKind.CLIENT,
-            attributes={},
+            attributes={"key": root_decision.name},
             trace_state=TraceState(),
         )
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix the bug: When trace is not sampled, the span attributes is None, `RemoteOperation` and `RemoteService` becomes Unknown.

Testing:
**Before the change**:
`OTEL_TRACES_SAMPLER=traceidratio  OTEL_TRACES_SAMPLER_ARG="0.0":`
![Screenshot 2024-09-10 at 11 40 22 AM](https://github.com/user-attachments/assets/a0108dc2-ff82-4c5d-9ce6-d21f32678ead)

`OTEL_TRACES_SAMPLER=xray OTEL_TRACES_SAMPLER_ARG="endpoint=http://localhost:2000" ` with more than 1 segments per second:
![Screenshot 2024-09-10 at 12 41 34 PM](https://github.com/user-attachments/assets/41260bb0-2e0d-4c05-8866-9aad25e3db6d)

**After the change**:
`OTEL_TRACES_SAMPLER=traceidratio  OTEL_TRACES_SAMPLER_ARG="0.0":`
![Screenshot 2024-09-10 at 12 02 07 PM](https://github.com/user-attachments/assets/fe86ea7a-e147-4a8c-8e0a-f0494e0a0f0e)

`OTEL_TRACES_SAMPLER=xray OTEL_TRACES_SAMPLER_ARG="endpoint=http://localhost:2000" ` with more than 1 segments per second:
![Screenshot 2024-09-10 at 12 22 58 PM](https://github.com/user-attachments/assets/c85f9fda-4c54-4f01-9738-ed1aa5667e61)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

