### PR TITLE
Add ECS E2E test into main build

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -41,46 +41,40 @@ jobs:
       - name: Upload main-build adot.whl to s3
         run: aws s3 cp ${{ inputs.staging-wheel-name }} s3://adot-main-build-staging-jar/${{ inputs.staging-wheel-name }}
 
-      - name: Get Python Distro Output
-        id: python_output
-        run: |
-          echo " input image: "
-          echo "${{ inputs.adot-image-name }}"
+  python-ec2-default-e2e-test:
+    needs: [ upload-main-build ]
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-ec2-default-test.yml@main
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      staging-wheel-name: aws_opentelemetry_distro-0.2.0.dev0-07ca0f26-py3-none-any.whl
+      caller-workflow-name: 'main-build'
 
-#  python-ec2-default-e2e-test:
-#    needs: [ upload-main-build ]
-#    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-ec2-default-test.yml@main
-#    secrets: inherit
-#    with:
-#      aws-region: us-east-1
-#      staging-wheel-name: aws_opentelemetry_distro-0.2.0.dev0-07ca0f26-py3-none-any.whl
-#      caller-workflow-name: 'main-build'
-#
-#  python-ec2-asg-e2e-test:
-#    needs: [ upload-main-build ]
-#    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-ec2-asg-test.yml@main
-#    secrets: inherit
-#    with:
-#      aws-region: us-east-1
-#      staging-wheel-name: aws_opentelemetry_distro-0.2.0.dev0-07ca0f26-py3-none-any.whl
-#      caller-workflow-name: 'main-build'
-#
-#  python-eks-e2e-test:
-#    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@main
-#    secrets: inherit
-#    with:
-#      aws-region: us-east-1
-#      test-cluster-name: 'e2e-python-adot-test'
-#      adot-image-name: ${{ inputs.adot-image-name }}
-#      caller-workflow-name: 'main-build'
-#
-#  python-k8s-e2e-test:
-#    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-k8s-test.yml@main
-#    secrets: inherit
-#    with:
-#      aws-region: us-east-1
-#      adot-image-name: ${{ inputs.adot-image-name }}
-#      caller-workflow-name: 'main-build'
+  python-ec2-asg-e2e-test:
+    needs: [ upload-main-build ]
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-ec2-asg-test.yml@main
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      staging-wheel-name: aws_opentelemetry_distro-0.2.0.dev0-07ca0f26-py3-none-any.whl
+      caller-workflow-name: 'main-build'
+
+  python-eks-e2e-test:
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@main
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      test-cluster-name: 'e2e-python-adot-test'
+      adot-image-name: ${{ inputs.adot-image-name }}
+      caller-workflow-name: 'main-build'
+
+  python-k8s-e2e-test:
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-k8s-test.yml@main
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      adot-image-name: ${{ inputs.adot-image-name }}
+      caller-workflow-name: 'main-build'
 
   python-ecs-e2e-test:
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-ecs-test.yml@ecs_entry

--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -41,6 +41,12 @@ jobs:
       - name: Upload main-build adot.whl to s3
         run: aws s3 cp ${{ inputs.staging-wheel-name }} s3://adot-main-build-staging-jar/${{ inputs.staging-wheel-name }}
 
+      - name: Get Python Distro Output
+        id: python_output
+        run: |
+          echo " input image: "
+          echo "${{ inputs.adot-image-name }}"
+
 #  python-ec2-default-e2e-test:
 #    needs: [ upload-main-build ]
 #    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-ec2-default-test.yml@main
@@ -77,7 +83,7 @@ jobs:
 #      caller-workflow-name: 'main-build'
 
   python-ecs-e2e-test:
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-ecs-test.yml@main
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-ecs-test.yml@ecs_entry
     secrets: inherit
     with:
       aws-region: us-east-1

--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -77,7 +77,7 @@ jobs:
       caller-workflow-name: 'main-build'
 
   python-ecs-e2e-test:
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-ecs-test.yml@ecs_entry
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-ecs-test.yml@main
     secrets: inherit
     with:
       aws-region: us-east-1

--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -41,35 +41,43 @@ jobs:
       - name: Upload main-build adot.whl to s3
         run: aws s3 cp ${{ inputs.staging-wheel-name }} s3://adot-main-build-staging-jar/${{ inputs.staging-wheel-name }}
 
-  python-ec2-default-e2e-test:
-    needs: [ upload-main-build ]
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-ec2-default-test.yml@main
-    secrets: inherit
-    with:
-      aws-region: us-east-1
-      staging-wheel-name: aws_opentelemetry_distro-0.2.0.dev0-07ca0f26-py3-none-any.whl
-      caller-workflow-name: 'main-build'
+#  python-ec2-default-e2e-test:
+#    needs: [ upload-main-build ]
+#    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-ec2-default-test.yml@main
+#    secrets: inherit
+#    with:
+#      aws-region: us-east-1
+#      staging-wheel-name: aws_opentelemetry_distro-0.2.0.dev0-07ca0f26-py3-none-any.whl
+#      caller-workflow-name: 'main-build'
+#
+#  python-ec2-asg-e2e-test:
+#    needs: [ upload-main-build ]
+#    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-ec2-asg-test.yml@main
+#    secrets: inherit
+#    with:
+#      aws-region: us-east-1
+#      staging-wheel-name: aws_opentelemetry_distro-0.2.0.dev0-07ca0f26-py3-none-any.whl
+#      caller-workflow-name: 'main-build'
+#
+#  python-eks-e2e-test:
+#    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@main
+#    secrets: inherit
+#    with:
+#      aws-region: us-east-1
+#      test-cluster-name: 'e2e-python-adot-test'
+#      adot-image-name: ${{ inputs.adot-image-name }}
+#      caller-workflow-name: 'main-build'
+#
+#  python-k8s-e2e-test:
+#    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-k8s-test.yml@main
+#    secrets: inherit
+#    with:
+#      aws-region: us-east-1
+#      adot-image-name: ${{ inputs.adot-image-name }}
+#      caller-workflow-name: 'main-build'
 
-  python-ec2-asg-e2e-test:
-    needs: [ upload-main-build ]
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-ec2-asg-test.yml@main
-    secrets: inherit
-    with:
-      aws-region: us-east-1
-      staging-wheel-name: aws_opentelemetry_distro-0.2.0.dev0-07ca0f26-py3-none-any.whl
-      caller-workflow-name: 'main-build'
-
-  python-eks-e2e-test:
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@main
-    secrets: inherit
-    with:
-      aws-region: us-east-1
-      test-cluster-name: 'e2e-python-adot-test'
-      adot-image-name: ${{ inputs.adot-image-name }}
-      caller-workflow-name: 'main-build'
-
-  python-k8s-e2e-test:
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-k8s-test.yml@main
+  python-ecs-e2e-test:
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-ecs-test.yml@main
     secrets: inherit
     with:
       aws-region: us-east-1

--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - "release/v*"
-      - ecs-entry
   workflow_dispatch: # be able to run the workflow on demand
 env:
   AWS_DEFAULT_REGION: us-east-1
@@ -43,13 +42,11 @@ jobs:
           shortsha="$(git rev-parse --short HEAD)"
           echo "SHORT_SHA=$shortsha" >> $GITHUB_ENV
           python_distro_tag=$pkg_version-$shortsha
-          echo "$python_distro_tag"
           echo "awsDefaultRegion=${{ env.AWS_DEFAULT_REGION }}" >> $GITHUB_OUTPUT
           echo "python_image_tag=$python_distro_tag" >> $GITHUB_OUTPUT
           echo "stagingRegistry=${{ env.STAGING_ECR_REGISTRY }}" >> $GITHUB_OUTPUT
           echo "stagingRepository=${{ env.STAGING_ECR_REPOSITORY }}" >> $GITHUB_OUTPUT
           echo "stagingImage=${{ env.STAGING_ECR_REGISTRY }}/${{ env.STAGING_ECR_REPOSITORY }}:$python_distro_tag" >> $GITHUB_OUTPUT
-          echo "${{ env.STAGING_ECR_REGISTRY }}/${{ env.STAGING_ECR_REPOSITORY }}:$python_distro_tag"
 
       - name: Build and Push Wheel and Image Files
         uses: ./.github/actions/artifacts_build

--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - "release/v*"
+      - ecs-entry
   workflow_dispatch: # be able to run the workflow on demand
 env:
   AWS_DEFAULT_REGION: us-east-1
@@ -81,11 +82,11 @@ jobs:
           name: ${{ steps.staging_wheel_output.outputs.STAGING_WHEEL}}
           path: dist/${{ steps.staging_wheel_output.outputs.STAGING_WHEEL}}
 
-      - name: Set up and run contract tests with pytest
-        run: |
-          bash scripts/set-up-contract-tests.sh
-          pip install pytest
-          pytest contract-tests/tests
+#      - name: Set up and run contract tests with pytest
+#        run: |
+#          bash scripts/set-up-contract-tests.sh
+#          pip install pytest
+#          pytest contract-tests/tests
 
   application-signals-e2e-test:
     name: "Application Signals E2E Test"

--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -100,5 +100,4 @@ jobs:
       contents: read
     with:
       staging-wheel-name: ${{ needs.build.outputs.staging_wheel_file }}
-      adot-image-name: 637423224110.dkr.ecr.us-east-1.amazonaws.com/aws-observability/adot-autoinstrumentation-python-staging:${{ needs.build.outputs.python_image_tag }}
-#      adot-image-name: ${{ needs.build.outputs.staging_registry }}/aws-observability/adot-autoinstrumentation-python-staging:${{ needs.build.outputs.python_image_tag }}
+      adot-image-name: ${{ needs.build.outputs.staging_registry }}/aws-observability/adot-autoinstrumentation-python-staging:${{ needs.build.outputs.python_image_tag }}

--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -43,11 +43,13 @@ jobs:
           shortsha="$(git rev-parse --short HEAD)"
           echo "SHORT_SHA=$shortsha" >> $GITHUB_ENV
           python_distro_tag=$pkg_version-$shortsha
+          echo "$python_distro_tag"
           echo "awsDefaultRegion=${{ env.AWS_DEFAULT_REGION }}" >> $GITHUB_OUTPUT
           echo "python_image_tag=$python_distro_tag" >> $GITHUB_OUTPUT
           echo "stagingRegistry=${{ env.STAGING_ECR_REGISTRY }}" >> $GITHUB_OUTPUT
           echo "stagingRepository=${{ env.STAGING_ECR_REPOSITORY }}" >> $GITHUB_OUTPUT
           echo "stagingImage=${{ env.STAGING_ECR_REGISTRY }}/${{ env.STAGING_ECR_REPOSITORY }}:$python_distro_tag" >> $GITHUB_OUTPUT
+          echo "${{ env.STAGING_ECR_REGISTRY }}/${{ env.STAGING_ECR_REPOSITORY }}:$python_distro_tag"
 
       - name: Build and Push Wheel and Image Files
         uses: ./.github/actions/artifacts_build
@@ -98,4 +100,5 @@ jobs:
       contents: read
     with:
       staging-wheel-name: ${{ needs.build.outputs.staging_wheel_file }}
-      adot-image-name: ${{ needs.build.outputs.staging_registry }}/aws-observability/adot-autoinstrumentation-python-staging:${{ needs.build.outputs.python_image_tag }}
+      adot-image-name: 637423224110.dkr.ecr.us-east-1.amazonaws.com/aws-observability/adot-autoinstrumentation-python-staging:${{ needs.build.outputs.python_image_tag }}
+#      adot-image-name: ${{ needs.build.outputs.staging_registry }}/aws-observability/adot-autoinstrumentation-python-staging:${{ needs.build.outputs.python_image_tag }}

--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -84,11 +84,11 @@ jobs:
           name: ${{ steps.staging_wheel_output.outputs.STAGING_WHEEL}}
           path: dist/${{ steps.staging_wheel_output.outputs.STAGING_WHEEL}}
 
-#      - name: Set up and run contract tests with pytest
-#        run: |
-#          bash scripts/set-up-contract-tests.sh
-#          pip install pytest
-#          pytest contract-tests/tests
+      - name: Set up and run contract tests with pytest
+        run: |
+          bash scripts/set-up-contract-tests.sh
+          pip install pytest
+          pytest contract-tests/tests
 
   application-signals-e2e-test:
     name: "Application Signals E2E Test"


### PR DESCRIPTION
*Description of changes:*
Add ECS E2E test entry point into main build.

An example of succeed test workflow:
https://github.com/aws-observability/aws-otel-python-instrumentation/actions/runs/10926973971/job/30332749849

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

