### PR TITLE
Changing span unsampled flag to be sampled flag

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_aws_attribute_keys.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_aws_attribute_keys.py
@@ -11,7 +11,7 @@ AWS_REMOTE_RESOURCE_TYPE: str = "aws.remote.resource.type"
 AWS_REMOTE_RESOURCE_IDENTIFIER: str = "aws.remote.resource.identifier"
 AWS_SDK_DESCENDANT: str = "aws.sdk.descendant"
 AWS_CONSUMER_PARENT_SPAN_KIND: str = "aws.consumer.parent.span.kind"
-AWS_TRACE_FLAG_UNSAMPLED: str = "aws.trace.flag.unsampled"
+AWS_TRACE_FLAG_SAMPLED: str = "aws.trace.flag.sampled"
 
 # AWS_#_NAME attributes are not supported in python as they are not part of the Semantic Conventions.
 # TODO：Move to Semantic Conventions when these attributes are added.

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_batch_unsampled_span_processor.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_batch_unsampled_span_processor.py
@@ -3,14 +3,12 @@
 import logging
 from typing import Optional
 
-from amazon.opentelemetry.distro._aws_attribute_keys import AWS_TRACE_FLAG_UNSAMPLED
+from amazon.opentelemetry.distro._aws_attribute_keys import AWS_TRACE_FLAG_SAMPLED
 from opentelemetry.context import Context
 from opentelemetry.sdk.trace import ReadableSpan, Span
 from opentelemetry.sdk.trace.export import BatchSpanProcessor as BaseBatchSpanProcessor
 
 logger = logging.getLogger(__name__)
-
-SPANUNSAMPLED_FLAG = "OTEL_AWS_APP_SIGNALS_ENABLED"
 
 
 class BatchUnsampledSpanProcessor(BaseBatchSpanProcessor):
@@ -18,7 +16,7 @@ class BatchUnsampledSpanProcessor(BaseBatchSpanProcessor):
     # pylint: disable=no-self-use
     def on_start(self, span: Span, parent_context: Optional[Context] = None) -> None:
         if not span.context.trace_flags.sampled:
-            span.set_attribute(AWS_TRACE_FLAG_UNSAMPLED, True)
+            span.set_attribute(AWS_TRACE_FLAG_SAMPLED, False)
 
     def on_end(self, span: ReadableSpan) -> None:
         if span.context.trace_flags.sampled:

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_batch_unsampled_span_processor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_batch_unsampled_span_processor.py
@@ -3,7 +3,7 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
-from amazon.opentelemetry.distro._aws_attribute_keys import AWS_TRACE_FLAG_UNSAMPLED
+from amazon.opentelemetry.distro._aws_attribute_keys import AWS_TRACE_FLAG_SAMPLED
 from amazon.opentelemetry.distro.aws_batch_unsampled_span_processor import BatchUnsampledSpanProcessor
 from opentelemetry.trace import TraceFlags
 
@@ -43,7 +43,7 @@ class TestBatchUnsampledSpanProcessor(TestCase):
         self.processor.on_end(mock_span2)
 
         self.assertEqual(len(self.processor.queue), 1)
-        self.assertIn(AWS_TRACE_FLAG_UNSAMPLED, mock_span1.set_attribute.call_args_list[0][0][0])
+        self.assertIn(AWS_TRACE_FLAG_SAMPLED, mock_span1.set_attribute.call_args_list[0][0][0])
 
         self.processor.shutdown()
         mock_span2 = mock_span_class.return_value

--- a/lambda-layer/README.md
+++ b/lambda-layer/README.md
@@ -47,3 +47,10 @@ cd lambda-layer
 
 Once the script has successfully run, you will see the deployed Lambda sample app in your AWS account. You can trigger the 
 Lambda function and view the traces and metrics through the AWS CloudWatch Console.
+
+## Configuration
+
+By default the layer enable botocore and aws-lambda instrumentation libraries only for better Lambda cold start performance. To 
+enable all opentelemetry python 
+supported libraries you can set environment variable `OTEL_PYTHON_DISABLED_INSTRUMENTATIONS=none`. Refer to details in 
+[OpenTelemetry Python Disabling Specific Instrumentations](Disabling Specific Instrumentations)


### PR DESCRIPTION
*Issue #, if available:*

Previously we use `aws.trace.flag.unsampled` mark the span is unsampled. The change updates this attribute to be `aws.trace.flag.sampled`.


*Description of changes:*


#### span is unsampled:
If span has no span attribute aws.trace.flag.sampled , value type is boolean and value is false.

#### span is sampled:
If span has no span attribute aws.trace.flag.sampled
or span has span attribute aws.trace.flag.sampled , value type is boolean and value is true,
or span has span attribute aws.trace.flag.sampled , value type is NOT boolean

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

