### PR TITLE
Add aws.pulse.over.midlina attribute for lambda spans

### DIFF
--- a/lambda-layer/src/otel-instrument
+++ b/lambda-layer/src/otel-instrument
@@ -107,6 +107,7 @@ if [ "${OTEL_AWS_APPLICATION_SIGNALS_ENABLED}" = "true" ]; then
     if [ -z "${OTEL_METRICS_EXPORTER}" ]; then
         export OTEL_METRICS_EXPORTER="none";
     fi
+    export LAMBDA_RESOURCE_ATTRIBUTES="aws.pulse.over.midlina=true,${LAMBDA_RESOURCE_ATTRIBUTES}"
 fi
 
 # - If Application Signals is disabled


### PR DESCRIPTION
*Description of changes:*

Add `aws.pulse.over.midlina` for lambda spans when AppSignals is enabled, so server side can use it to determine whether it should generate EMF metrics

```

2024-09-27T15:19:32.789-07:00 | 'faas.name': 'aws-opentelemetry-distro-nodejs', | 2024/09/27/[$LATEST]af2cea6e28a94c24aa098ed39567d85b
-- | -- | --
  | 2024-09-27T15:19:32.789-07:00 | 'faas.version': '$LATEST', | 2024/09/27/[$LATEST]af2cea6e28a94c24aa098ed39567d85b
  | 2024-09-27T15:19:32.789-07:00 | 'faas.instance': '2024/09/27/[$LATEST]af2cea6e28a94c24aa098ed39567d85b', | 2024/09/27/[$LATEST]af2cea6e28a94c24aa098ed39567d85b
  | 2024-09-27T15:19:32.789-07:00 | 'aws.log.group.names': '/aws/lambda/aws-opentelemetry-distro-nodejs', | 2024/09/27/[$LATEST]af2cea6e28a94c24aa098ed39567d85b
  | 2024-09-27T15:19:32.789-07:00 | 'aws.pulse.over.midlina': 'true'

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

