### PR TITLE
fix: Change Lambda Resource CFN Primary Id to be Lambda Name

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_aws_metric_attribute_generator.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_aws_metric_attribute_generator.py
@@ -460,7 +460,6 @@ def _set_remote_type_and_identifier(span: ReadableSpan, attributes: BoundedAttri
         elif is_key_present(span, AWS_LAMBDA_FUNCTION_NAME):
             remote_resource_type = _NORMALIZED_LAMBDA_SERVICE_NAME + "::Function"
             remote_resource_identifier = _escape_delimiters(span.attributes.get(AWS_LAMBDA_FUNCTION_NAME))
-            cloudformation_primary_identifier = _escape_delimiters(span.attributes.get(AWS_LAMBDA_FUNCTION_ARN))
     elif is_db_span(span):
         remote_resource_type = _DB_CONNECTION_STRING_TYPE
         remote_resource_identifier = _get_db_connection(span)


### PR DESCRIPTION
### *Description of changes:*
Quick change updating the Lambda CFN Primary Id to be its function name instead of its function arn. 

Note: The current logic defaults to assigning `cloudformation_primary_identifier = remote_resource_identifier` if it remains `None` after the branching logic (line 469).

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html

### *Test Plan:*
Verified update in generated span attributes.

<img width="1512" alt="Screenshot 2024-10-02 at 3 59 15 PM" src="https://github.com/user-attachments/assets/ea9d1812-8536-4d9d-a6ea-cfd1adece2fa">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

