### PR TITLE
Init Python Layer e2e workflow in main-build

### DIFF
--- a/.github/actions/lambda_artifacts_build/action.yml
+++ b/.github/actions/lambda_artifacts_build/action.yml
@@ -1,0 +1,50 @@
+name: Build and Push aws-opentelemetry-python-distro Layer
+description: |
+  This action assumes that the repo was checked out. Builds and push Lambda Layer and sample app to S3 bucket for 
+  the further end to end tests.
+
+inputs:
+  aws-region:
+    required: false
+    description: "AWS Region, required only if push_image is true"
+  snapshot-ecr-role:
+    required: false
+    description: "IAM Role used for pushing to snapshot ecr, required only if push_image is true"
+  python_version:
+    required: true
+    description: "The python version used in actions"
+  layer_directory:
+    required: true
+    description: 'The role use to publish lambda layer'
+  staging_s3_bucket:
+    required: true
+    description: 'S3 bucket holds SDK artifact tarball'
+  os:
+    required: true
+    description: "The os"
+
+
+runs:
+  using: "composite"
+  steps:
+    - name: Build sample lambda function
+      shell: bash
+      working-directory: ${{ inputs.layer_directory }}/sample-apps
+      run: ./package-lambda-function.sh
+    - name: Build layers
+      shell: bash
+      working-directory: ${{ inputs.layer_directory }}/src
+      run: |
+        ./build-lambda-layer.sh
+        pip install tox
+        tox
+    - name: Upload Layer to S3
+      shell: bash
+      run: |
+        aws s3 cp ./build/aws-opentelemetry-python-layer.zip s3://${{ inputs.staging_s3_bucket }}/layer-${{ github.run_id }}.zip
+      working-directory: ${{ inputs.layer_directory }}/src
+    - name: Upload Sample App to S3
+      shell: bash
+      run: |
+        aws s3 cp ./build/function.zip s3://${{ inputs.staging_s3_bucket }}/function-${{ github.run_id }}.zip
+      working-directory: ${{ inputs.layer_directory }}/sample-apps

--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -100,7 +100,7 @@ jobs:
       python-version: '3.12'
       cpu-architecture: 'x86_64'
       staging-wheel-name: ${{ inputs.staging-wheel-name }}
-      
+
   #
   # DOCKER DISTRIBUTION LANGUAGE VERSION COVERAGE
   # DEFAULT SETTING: {Python Version}, EKS, AMD64, AL2
@@ -174,7 +174,7 @@ jobs:
       caller-workflow-name: 'main-build'
       python-version: '3.9'
       staging-wheel-name: ${{ inputs.staging-wheel-name }}
-      
+
   #
   # DOCKER DISTRIBUTION PLATFORM COVERAGE
   # DEFAULT SETTING: Python 3.10, {Platform}, AMD64, AL2
@@ -215,5 +215,12 @@ jobs:
       cpu-architecture: 'arm64'
       staging-wheel-name: ${{ inputs.staging-wheel-name }}
 
-
-
+  #
+  # Lambda layer integration tests
+  lambda:
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-lambda-test.yml@main
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      python-version: '3.12'
+      caller-workflow-name: 'main-build'

--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - "release/v*"
+      - ci-workflow
   workflow_dispatch: # be able to run the workflow on demand
 env:
   AWS_DEFAULT_REGION: us-east-1
@@ -70,6 +71,16 @@ jobs:
           echo "STAGING_WHEEL=$staging_wheel" >> $GITHUB_OUTPUT
           cd ./dist
           cp aws_opentelemetry_distro-${{ steps.python_output.outputs.ADOT_PYTHON_VERSION}}-py3-none-any.whl $staging_wheel
+
+      - name: Build and Publish Lambda Staging Layer
+        uses: ./.github/actions/lambda_artifacts_build
+        with:
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+          snapshot-ecr-role: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          python_version: "3.12"
+          layer_directory: lambda-layer
+          staging_s3_bucket: ${{ env.STAGING_S3_BUCKET }}
+          os: ubuntu-latest
 
       - name: Upload wheel to S3
         run: |


### PR DESCRIPTION
*Description of changes:*
Setup Python Lambda layer E2E tests. Current the data validation steps are failing due to the known quality issue. This changes are mainly for `main-build` validation in https://github.com/aws-observability/aws-otel-python-instrumentation . it will not trigger any alarm or block anything.

#### Test workflow
* https://github.com/mxiamxia/aws-otel-python-instrumentation/actions/runs/11228192500/job/31212383995
EMF validation failed as expected due to the known EMF data quality issue WIP.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
