### PR TITLE
Remove Lambda:Function:Name resource type support

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_aws_metric_attribute_generator.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_aws_metric_attribute_generator.py
@@ -13,7 +13,6 @@ from amazon.opentelemetry.distro._aws_attribute_keys import (
     AWS_BEDROCK_KNOWLEDGE_BASE_ID,
     AWS_CLOUDFORMATION_PRIMARY_IDENTIFIER,
     AWS_KINESIS_STREAM_NAME,
-    AWS_LAMBDA_FUNCTION_NAME,
     AWS_LAMBDA_RESOURCEMAPPING_ID,
     AWS_LOCAL_OPERATION,
     AWS_LOCAL_SERVICE,
@@ -458,9 +457,6 @@ def _set_remote_type_and_identifier(span: ReadableSpan, attributes: BoundedAttri
         elif is_key_present(span, AWS_LAMBDA_RESOURCEMAPPING_ID):
             remote_resource_type = _NORMALIZED_LAMBDA_SERVICE_NAME + "::EventSourceMapping"
             remote_resource_identifier = _escape_delimiters(span.attributes.get(AWS_LAMBDA_RESOURCEMAPPING_ID))
-        elif is_key_present(span, AWS_LAMBDA_FUNCTION_NAME):
-            remote_resource_type = _NORMALIZED_LAMBDA_SERVICE_NAME + "::Function"
-            remote_resource_identifier = _escape_delimiters(span.attributes.get(AWS_LAMBDA_FUNCTION_NAME))
     elif is_db_span(span):
         remote_resource_type = _DB_CONNECTION_STRING_TYPE
         remote_resource_identifier = _get_db_connection(span)

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_metric_attribute_generator.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_metric_attribute_generator.py
@@ -14,7 +14,6 @@ from amazon.opentelemetry.distro._aws_attribute_keys import (
     AWS_BEDROCK_KNOWLEDGE_BASE_ID,
     AWS_CONSUMER_PARENT_SPAN_KIND,
     AWS_KINESIS_STREAM_NAME,
-    AWS_LAMBDA_FUNCTION_NAME,
     AWS_LAMBDA_RESOURCEMAPPING_ID,
     AWS_LOCAL_OPERATION,
     AWS_LOCAL_SERVICE,
@@ -1137,26 +1136,21 @@ class TestAwsMetricAttributeGenerator(TestCase):
         self._validate_remote_resource_attributes("AWS::StepFunctions::Activity", "testActivity")
         self._mock_attribute([AWS_STEPFUNCTIONS_ACTIVITY_ARN], [None])
 
-        # Validate behaviour of AWS_LAMBDA_FUNCTION_NAME attribute, then remove it.
-        self._mock_attribute([AWS_LAMBDA_FUNCTION_NAME], ["aws_lambda_function_name"], keys, values)
-        self._validate_remote_resource_attributes("AWS::Lambda::Function", "aws_lambda_function_name")
-        self._mock_attribute([AWS_LAMBDA_FUNCTION_NAME], [None])
-
         # Validate behaviour of AWS_LAMBDA_RESOURCEMAPPING_ID attribute, then remove it.
         self._mock_attribute([AWS_LAMBDA_RESOURCEMAPPING_ID], ["aws_event_source_mapping_id"], keys, values)
         self._validate_remote_resource_attributes("AWS::Lambda::EventSourceMapping", "aws_event_source_mapping_id")
         self._mock_attribute([AWS_LAMBDA_RESOURCEMAPPING_ID], [None])
 
-        # Validate behaviour of both AWS_LAMBDA_FUNCTION_NAME and AWS_LAMBDA_RESOURCE_MAPPING_ID,
+        # Validate behaviour of AWS_LAMBDA_RESOURCE_MAPPING_ID,
         # then remove it.
         self._mock_attribute(
-            [AWS_LAMBDA_FUNCTION_NAME, AWS_LAMBDA_RESOURCEMAPPING_ID],
-            ["aws_lambda_function_name", "aws_event_source_mapping_id"],
+            [AWS_LAMBDA_RESOURCEMAPPING_ID],
+            ["aws_event_source_mapping_id"],
             keys,
             values,
         )
         self._validate_remote_resource_attributes("AWS::Lambda::EventSourceMapping", "aws_event_source_mapping_id")
-        self._mock_attribute([AWS_LAMBDA_FUNCTION_NAME, AWS_LAMBDA_RESOURCEMAPPING_ID], [None, None])
+        self._mock_attribute([AWS_LAMBDA_RESOURCEMAPPING_ID], [None])
 
         self._mock_attribute([SpanAttributes.RPC_SYSTEM], [None])
 


### PR DESCRIPTION
*Description of changes:*
Remove `RemoteResourceTargetIdentifier` attribute which will treat Lambda Function as a regular AWS resource. It may conflict with the current concept that have Lambda function defined as a service.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
