### PR TITLE
propagate Lambda span attribute cloud.resource_id to child spans

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_aws_span_processing_util.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_aws_span_processing_util.py
@@ -52,7 +52,7 @@ def get_ingress_operation(__, span: ReadableSpan) -> str:
     """
     operation: str = span.name
     if _AWS_LAMBDA_FUNCTION_NAME in os.environ:
-        operation = os.environ.get(_AWS_LAMBDA_FUNCTION_NAME) + "/Handler"
+        operation = os.environ.get(_AWS_LAMBDA_FUNCTION_NAME) + "/FunctionHandler"
     elif should_use_internal_operation(span):
         operation = INTERNAL_OPERATION
     elif not _is_valid_operation(span, operation):

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/attribute_propagating_span_processor.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/attribute_propagating_span_processor.py
@@ -64,10 +64,10 @@ class AttributePropagatingSpanProcessor(SpanProcessor):
                 span.set_attribute(AWS_CONSUMER_PARENT_SPAN_KIND, parent_span.kind.name)
 
             # Propagate span attribute cloud.resource_id for extracting lambda alias for dependency metrics.
-            _parentResourceId = parent_span.attributes.get(SpanAttributes.CLOUD_RESOURCE_ID)
-            _currentResourceId = span.attributes.get(SpanAttributes.CLOUD_RESOURCE_ID)
-            if _currentResourceId is None and _parentResourceId is not None:
-                span.set_attribute(SpanAttributes.CLOUD_RESOURCE_ID, _parentResourceId)
+            parent_resource_id = parent_span.attributes.get(SpanAttributes.CLOUD_RESOURCE_ID)
+            current_resource_id = span.attributes.get(SpanAttributes.CLOUD_RESOURCE_ID)
+            if current_resource_id is None and parent_resource_id is not None:
+                span.set_attribute(SpanAttributes.CLOUD_RESOURCE_ID, parent_resource_id)
 
         propagation_data: str = None
         if is_local_root(span):

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_span_processing_util.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_span_processing_util.py
@@ -62,7 +62,7 @@ class TestAwsSpanProcessingUtil(TestCase):
         self.span_data_mock.name = valid_name
         self.span_data_mock.kind = SpanKind.SERVER
         actual_operation: str = get_ingress_operation(self, self.span_data_mock)
-        self.assertEqual(actual_operation, "MyLambda/Handler")
+        self.assertEqual(actual_operation, "MyLambda/FunctionHandler")
 
     def test_get_ingress_operation_http_method_name_and_no_fallback(self):
         invalid_name: str = "GET"


### PR DESCRIPTION
*Issue #, if available:*

AppSignals lambda dependency metrics don't show Lambda Alias correctly

*Description of changes:*
Propagate span attribute cloud.resource_id if there is.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

