### PR TITLE
Get Sha256 Checksum for Release Artifacts

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -120,6 +120,14 @@ jobs:
           tags: |
             ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ github.event.inputs.version }}
 
+      - name: Get SHA256 checksum of wheel file
+        id: get_sha256
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          filename="aws_opentelemetry_distro-${{ github.event.inputs.version }}-py3-none-any.whl"
+          shasum -a 256 dist/$filename | awk '{print $1}' > $filename.sha256
+
       # Publish to GitHub releases
       - name: Create GH release
         id: create_release
@@ -130,4 +138,5 @@ jobs:
              --title "Release v${{ github.event.inputs.version }}" \
              --draft \
              "v${{ github.event.inputs.version }}" \
-             dist/aws_opentelemetry_distro-${{ github.event.inputs.version }}-py3-none-any.whl
+             dist/aws_opentelemetry_distro-${{ github.event.inputs.version }}-py3-none-any.whl \
+             aws_opentelemetry_distro-${{ github.event.inputs.version }}-py3-none-any.whl.sha256

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -14,6 +14,7 @@ env:
   RELEASE_PRIVATE_REPOSITORY: 020628701572.dkr.ecr.us-west-2.amazonaws.com/adot-autoinstrumentation-python
   RELEASE_PRIVATE_REGISTRY: 020628701572.dkr.ecr.us-west-2.amazonaws.com
   PACKAGE_NAME: aws-opentelemetry-distro
+  ARTIFACT_NAME: aws_opentelemetry_distro-${{ github.event.inputs.version }}-py3-none-any.whl
 
 permissions:
   id-token: write
@@ -88,7 +89,7 @@ jobs:
           TWINE_USERNAME: '__token__'
           TWINE_PASSWORD: ${{ env.TEST_PYPI_TOKEN_API_TOKEN }}
         run: |
-          twine upload --repository testpypi --skip-existing --verbose dist/aws_opentelemetry_distro-${{ github.event.inputs.version }}-py3-none-any.whl
+          twine upload --repository testpypi --skip-existing --verbose dist/${{ env.ARTIFACT_NAME }}
 
       # Publish to prod PyPI
       - name: Publish to PyPI
@@ -96,7 +97,7 @@ jobs:
           TWINE_USERNAME: '__token__'
           TWINE_PASSWORD: ${{ env.PROD_PYPI_TOKEN_API_TOKEN }}
         run: |
-          twine upload --skip-existing --verbose dist/aws_opentelemetry_distro-${{ github.event.inputs.version }}-py3-none-any.whl
+          twine upload --skip-existing --verbose dist/${{ env.ARTIFACT_NAME }}
 
       # Publish to public ECR
       - name: Build and push public ECR image
@@ -122,11 +123,8 @@ jobs:
 
       - name: Get SHA256 checksum of wheel file
         id: get_sha256
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          filename="aws_opentelemetry_distro-${{ github.event.inputs.version }}-py3-none-any.whl"
-          shasum -a 256 dist/$filename | awk '{print $1}' > $filename.sha256
+          shasum -a 256 dist/${{ env.ARTIFACT_NAME }} | sed "s|dist/||" > ${{ env.ARTIFACT_NAME }}.sha256
 
       # Publish to GitHub releases
       - name: Create GH release
@@ -138,5 +136,5 @@ jobs:
              --title "Release v${{ github.event.inputs.version }}" \
              --draft \
              "v${{ github.event.inputs.version }}" \
-             dist/aws_opentelemetry_distro-${{ github.event.inputs.version }}-py3-none-any.whl \
-             aws_opentelemetry_distro-${{ github.event.inputs.version }}-py3-none-any.whl.sha256
+             dist/${{ env.ARTIFACT_NAME }} \
+             ${{ env.ARTIFACT_NAME }}.sha256

--- a/README.md
+++ b/README.md
@@ -39,3 +39,8 @@ This project ensures compatibility with the following supported Python versions:
 
 ### Note on Amazon CloudWatch Application Signals
 [Amazon CloudWatch Application Signals](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Application-Monitoring-Sections.html) components are designed to seamlessly work with all library instrumentations offered by [OpenTelemetry Python auto-instrumentation](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/instrumentation/README.md). While upstream OpenTelemetry Python instrumentations are in beta, Application Signals components are stable, production ready and have also been tested for popular libraries/frameworks such as [Django, Boto3, and others](https://github.com/aws-observability/aws-otel-python-instrumentation/tree/main/contract-tests/images/applications). We will prioritize backward compatibility for Application Signals components, striving to ensure that they remain functional even in the face of potential breaking changes introduced by OpenTelemetry upstream libraries. Please [raise an issue](https://github.com/aws-observability/aws-otel-python-instrumentation/blob/main/CONTRIBUTING.md#reporting-bugsfeature-requests) if you notice Application Signals doesn't work for a particular OpenTelemetry supported library.
+
+## Checksum Verification
+Artifacts released will include a `.sha256` file for checksum verification starting from v0.7.0
+To verify, run the command `shasum -a 256 -c <artifact_name>.sha256` 
+It should return the output `<artifact_name>: OK` if the validation is successful


### PR DESCRIPTION
*Issue #, if available:*
We want to provide the checksum of release artifact to customers.

*Description of changes:*
When new artifact is released through `release_build.yml`, get the sha256 checksum of the artifact then attach it to the release note as a `.sha256` file

Example: [Release Note](https://github.com/harrryr/aws-otel-python-instrumentation/releases/tag/v)

*Testing*
Workflow run: https://github.com/harrryr/aws-otel-python-instrumentation/actions/runs/12384286607
Verified that the .sha256 has the correct content and running `shasum -a 256 -c <artifact_name>.sha256` returns the output `<artifact_name>: OK`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

