### PR TITLE
Add Contract Tests for SNS

### DIFF
--- a/contract-tests/images/applications/botocore/botocore_server.py
+++ b/contract-tests/images/applications/botocore/botocore_server.py
@@ -381,9 +381,7 @@ class RequestHandler(BaseHTTPRequestHandler):
                     "before-call.sns.GetTopicAttributes",
                     lambda **kwargs: inject_500_error("GetTopicAttributes", **kwargs),
                 )
-                fault_client.get_topic_attributes(
-                    TopicArn="arn:aws:sns:us-west-2:000000000000:invalid-topic"
-                )
+                fault_client.get_topic_attributes(TopicArn="arn:aws:sns:us-west-2:000000000000:invalid-topic")
             except Exception as exception:
                 print("Expected exception occurred", exception)
         elif self.in_path("gettopicattributes/test-topic"):
@@ -583,9 +581,7 @@ def prepare_aws_server() -> None:
             )
 
         # Set up SNS so tests can access a topic.
-        sns_client: BaseClient = boto3.client(
-            "sns", endpoint_url=_AWS_SDK_ENDPOINT, region_name=_AWS_REGION
-        )
+        sns_client: BaseClient = boto3.client("sns", endpoint_url=_AWS_SDK_ENDPOINT, region_name=_AWS_REGION)
         create_topic_response = sns_client.create_topic(Name="test-topic")
         print("Created topic successfully:", create_topic_response)
 

--- a/contract-tests/tests/test/amazon/botocore/botocore_test.py
+++ b/contract-tests/tests/test/amazon/botocore/botocore_test.py
@@ -766,15 +766,13 @@ class BotocoreTest(ContractTestBase):
             remote_resource_type="AWS::SNS::Topic",
             remote_resource_identifier="test-topic",
             cloudformation_primary_identifier="arn:aws:sns:us-west-2:000000000000:test-topic",
-            request_specific_attributes={
-                _AWS_SNS_TOPIC_ARN: "arn:aws:sns:us-west-2:000000000000:test-topic"
-            },
-            span_name="SNS.GetTopicAttributes"
+            request_specific_attributes={_AWS_SNS_TOPIC_ARN: "arn:aws:sns:us-west-2:000000000000:test-topic"},
+            span_name="SNS.GetTopicAttributes",
         )
 
-    # TODO: Add error case for sns - our test setup is not setting the http status code properly 
+    # TODO: Add error case for sns - our test setup is not setting the http status code properly
     # for this resource
-        
+
     def test_sns_fault(self):
         self.do_test_requests(
             "sns/fault",


### PR DESCRIPTION
*Description of changes:*
Set up SNS contract tests cases for `AWS::SNS::Topic` resource.

Note: Was not able to get the `error` path to work so added a `TODO` comment for now. It seems boto3 handles the response code for this resource in a special way compared to the other resources. Will need to investigate further to figure out how we can add this case.

*Test Plan:*

![Screenshot 2024-11-27 at 10 52 37 AM](https://github.com/user-attachments/assets/121a5829-e960-4292-b3c5-8ceb9c6f9d6c)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

