### PR TITLE
Update dependency version - dependabot alert

### DIFF
--- a/contract-tests/images/applications/django/requirements.txt
+++ b/contract-tests/images/applications/django/requirements.txt
@@ -1,4 +1,4 @@
 opentelemetry-distro==0.46b0
 opentelemetry-exporter-otlp-proto-grpc==1.25.0
 typing-extensions==4.9.0
-django==5.0.9
+django==5.0.10

--- a/contract-tests/images/applications/mysql-connector/requirements.txt
+++ b/contract-tests/images/applications/mysql-connector/requirements.txt
@@ -1,4 +1,4 @@
 opentelemetry-distro==0.46b0
 opentelemetry-exporter-otlp-proto-grpc==1.25.0
 typing-extensions==4.9.0
-mysql-connector-python~=8.0
+mysql-connector-python~=9.1.0


### PR DESCRIPTION
*Issue #, if available:*
Dependant bot is giving the following security alert but it is unable to create a PR for it automatically and throwing an error
- https://github.com/aws-observability/aws-otel-python-instrumentation/security/dependabot/21
- https://github.com/aws-observability/aws-otel-python-instrumentation/security/dependabot/19
- https://github.com/aws-observability/aws-otel-python-instrumentation/security/dependabot/20

This PR will manually update the version.

*Description of changes:*
Updated dependencies to the version with security issue patched

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

