### PR TITLE
pin urllib3 version in docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ADD aws-opentelemetry-distro/ ./aws-opentelemetry-distro/
 # * https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/azure-functions/recover-python-functions.md#troubleshoot-cannot-import-cygrpc
 RUN sed -i "/opentelemetry-exporter-otlp-proto-grpc/d" ./aws-opentelemetry-distro/pyproject.toml
 
-RUN mkdir workspace && pip install --target workspace ./aws-opentelemetry-distro
+RUN mkdir workspace && pip install urllib3==2.2.3 --target workspace ./aws-opentelemetry-distro
 
 # Stage 2: Build the cp-utility binary
 FROM public.ecr.aws/docker/library/rust:1.81 as builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,16 @@ ADD aws-opentelemetry-distro/ ./aws-opentelemetry-distro/
 # * https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/azure-functions/recover-python-functions.md#troubleshoot-cannot-import-cygrpc
 RUN sed -i "/opentelemetry-exporter-otlp-proto-grpc/d" ./aws-opentelemetry-distro/pyproject.toml
 
+# urllib3 recently made a release that drops support for Python 3.8
+# Our sdk depends on botocore which pulls in the version of urllib3 based Python runtime it detects.
+# The rule is that if current pip command version is > 3.9 botocore will pick up the latest urllib3,
+# otherwise it picks up the older urllib3 that is compatible with Python 3.8.
+# https://github.com/boto/botocore/blob/develop/requirements-docs.txt
+# Since this Dockerfile currently uses the fixed Python 3.11 base image to pull the required dependencies,
+# EKS and ECS applications will encounter a runtime error for Python 3.8 compatability.
+# Our fix is to temporarily restrict the urllib3 version to one that works for all supported Python versions 
+# that we currently commit to support (notably 3.8). 
+# TODO: Remove this temporary workaround once we deprecate Python 3.8 support since it has reached end-of-life.
 RUN mkdir workspace && pip install urllib3==2.2.3 --target workspace ./aws-opentelemetry-distro
 
 # Stage 2: Build the cp-utility binary

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN sed -i "/opentelemetry-exporter-otlp-proto-grpc/d" ./aws-opentelemetry-distr
 # otherwise it picks up the older urllib3 that is compatible with Python 3.8.
 # https://github.com/boto/botocore/blob/develop/requirements-docs.txt
 # Since this Dockerfile currently uses the fixed Python 3.11 base image to pull the required dependencies,
-# EKS and ECS applications will encounter a runtime error for Python 3.8 compatability.
+# EKS and ECS applications will encounter a runtime error for Python 3.8 compatibility.
 # Our fix is to temporarily restrict the urllib3 version to one that works for all supported Python versions 
 # that we currently commit to support (notably 3.8). 
 # TODO: Remove this temporary workaround once we deprecate Python 3.8 support since it has reached end-of-life.


### PR DESCRIPTION
*Issue #, if available:*
Attempt to pin urllib3 version to fix python 3.8 runtime issue.

```
Defaulted container "my-container" out of: my-container, opentelemetry-auto-instrumentation-python (init)
Error in sitecustomize; set PYTHONVERBOSE for traceback:
RuntimeError: Python 3.9 or later is required
Traceback (most recent call last):
  File "manage.py", line 23, in <module>
    main()
  File "manage.py", line 19, in main
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.8/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
.
.
.
 File "/usr/local/lib/python3.8/site-packages/botocore/compat.py", line 32, in <module>
    from urllib3 import exceptions
  File "/otel-auto-instrumentation-python/urllib3/__init__.py", line 14, in <module>
    from . import exceptions
  File "/otel-auto-instrumentation-python/urllib3/exceptions.py", line 26, in <module>
    _TYPE_REDUCE_RESULT = tuple[typing.Callable[..., object], tuple[object, ...]]
TypeError: 'type' object is not subscriptable
```

*Test plan:*
Tested locally on playground EKS cluster and validated the change fixes the startup runtime issue. Will monitor EK2 workflow after PR is merged to ensure it passes there as well. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.