### PR TITLE
pin setuptools version to 75.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,17 +18,7 @@ ADD aws-opentelemetry-distro/ ./aws-opentelemetry-distro/
 # * https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/azure-functions/recover-python-functions.md#troubleshoot-cannot-import-cygrpc
 RUN sed -i "/opentelemetry-exporter-otlp-proto-grpc/d" ./aws-opentelemetry-distro/pyproject.toml
 
-# urllib3 recently made a release that drops support for Python 3.8
-# Our sdk depends on botocore which pulls in the version of urllib3 based Python runtime it detects.
-# The rule is that if current pip command version is > 3.9 botocore will pick up the latest urllib3,
-# otherwise it picks up the older urllib3 that is compatible with Python 3.8.
-# https://github.com/boto/botocore/blob/develop/requirements-docs.txt
-# Since this Dockerfile currently uses the fixed Python 3.11 base image to pull the required dependencies,
-# EKS and ECS applications will encounter a runtime error for Python 3.8 compatibility.
-# Our fix is to temporarily restrict the urllib3 version to one that works for all supported Python versions 
-# that we currently commit to support (notably 3.8). 
-# TODO: Remove this temporary workaround once we deprecate Python 3.8 support since it has reached end-of-life.
-RUN mkdir workspace && pip install urllib3==2.2.3 --target workspace ./aws-opentelemetry-distro
+RUN mkdir workspace && pip install --target workspace ./aws-opentelemetry-distro
 
 # Stage 2: Build the cp-utility binary
 FROM public.ecr.aws/docker/library/rust:1.81 as builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,19 @@ ADD aws-opentelemetry-distro/ ./aws-opentelemetry-distro/
 # * https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/azure-functions/recover-python-functions.md#troubleshoot-cannot-import-cygrpc
 RUN sed -i "/opentelemetry-exporter-otlp-proto-grpc/d" ./aws-opentelemetry-distro/pyproject.toml
 
-RUN mkdir workspace && pip install --target workspace ./aws-opentelemetry-distro
+# urllib3 recently made a release that drops support for Python 3.8
+# Our sdk depends on botocore which pulls in the version of urllib3 based Python runtime it detects.
+# The rule is that if current pip command version is > 3.9 botocore will pick up the latest urllib3,
+# otherwise it picks up the older urllib3 that is compatible with Python 3.8.
+# https://github.com/boto/botocore/blob/develop/requirements-docs.txt
+# Since this Dockerfile currently uses the fixed Python 3.11 base image to pull the required dependencies,
+# EKS and ECS applications will encounter a runtime error for Python 3.8 compatibility.
+# Our fix is to temporarily restrict the urllib3 version to one that works for all supported Python versions 
+# that we currently commit to support (notably 3.8). 
+# We also pin the setuptools version for similar issues with the library dropping 3.8 support.
+# https://github.com/pypa/setuptools/blame/main/pkg_resources/__init__.py#L24
+# TODO: Remove these temporary workarounds once we deprecate Python 3.8 support since it has reached end-of-life.
+RUN mkdir workspace && pip install setuptools==75.2.0 urllib3==2.2.3 --target workspace ./aws-opentelemetry-distro
 
 # Stage 2: Build the cp-utility binary
 FROM public.ecr.aws/docker/library/rust:1.81 as builder

--- a/aws-opentelemetry-distro/pyproject.toml
+++ b/aws-opentelemetry-distro/pyproject.toml
@@ -80,6 +80,20 @@ dependencies = [
   "opentelemetry-instrumentation-urllib3 == 0.48b0",
   "opentelemetry-instrumentation-wsgi == 0.48b0",
   "opentelemetry-instrumentation-cassandra == 0.48b0",
+  # urllib3 recently made a release that drops support for Python 3.8
+  # Our sdk depends on botocore which pulls in the version of urllib3 based Python runtime it detects.
+  # The rule is that if current pip command version is > 3.9 botocore will pick up the latest urllib3,
+  # otherwise it picks up the older urllib3 that is compatible with Python 3.8.
+  # https://github.com/boto/botocore/blob/develop/requirements-docs.txt
+  # Since this Dockerfile currently uses the fixed Python 3.11 base image to pull the required dependencies,
+  # EKS and ECS applications will encounter a runtime error for Python 3.8 compatibility.
+  # Our fix is to temporarily restrict the urllib3 version to one that works for all supported Python versions 
+  # that we currently commit to support (notably 3.8). 
+  # We also pin the setuptools version for similar issues with the library dropping 3.8 support.
+  # https://github.com/pypa/setuptools/blame/main/pkg_resources/__init__.py#L24
+  # TODO: Remove these temporary workarounds once we deprecate Python 3.8 support since it has reached end-of-life.
+  "urllib3 == 2.2.3",
+  "setuptools == 75.2.0",
 ]
 
 [project.optional-dependencies]

--- a/aws-opentelemetry-distro/pyproject.toml
+++ b/aws-opentelemetry-distro/pyproject.toml
@@ -80,20 +80,6 @@ dependencies = [
   "opentelemetry-instrumentation-urllib3 == 0.48b0",
   "opentelemetry-instrumentation-wsgi == 0.48b0",
   "opentelemetry-instrumentation-cassandra == 0.48b0",
-  # urllib3 recently made a release that drops support for Python 3.8
-  # Our sdk depends on botocore which pulls in the version of urllib3 based Python runtime it detects.
-  # The rule is that if current pip command version is > 3.9 botocore will pick up the latest urllib3,
-  # otherwise it picks up the older urllib3 that is compatible with Python 3.8.
-  # https://github.com/boto/botocore/blob/develop/requirements-docs.txt
-  # Since this Dockerfile currently uses the fixed Python 3.11 base image to pull the required dependencies,
-  # EKS and ECS applications will encounter a runtime error for Python 3.8 compatibility.
-  # Our fix is to temporarily restrict the urllib3 version to one that works for all supported Python versions 
-  # that we currently commit to support (notably 3.8). 
-  # We also pin the setuptools version for similar issues with the library dropping 3.8 support.
-  # https://github.com/pypa/setuptools/blame/main/pkg_resources/__init__.py#L24
-  # TODO: Remove these temporary workarounds once we deprecate Python 3.8 support since it has reached end-of-life.
-  "urllib3 == 2.2.3",
-  "setuptools == 75.2.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
*Issue #, if available:*
We found another issue with a dependency (`setuptools`) dropping Python 3.8 support. 

[Dependency issue with urllib3 PR](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/310).

```
  File "/otel-auto-instrumentation-python/opentelemetry/instrumentation/auto_instrumentation/__init__.py", line 22, in <module>
    from pkg_resources import iter_entry_points
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 843, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/otel-auto-instrumentation-python/pkg_resources/__init__.py", line 25, in <module>
    raise RuntimeError("Python 3.9 or later is required")
RuntimeError: Python 3.9 or later is required
```

https://github.com/pypa/setuptools/blame/main/pkg_resources/__init__.py#L24

*Description of changes:*
Pinned most recent compatible version of `setuptools` in our `pyproject.toml`.

*Test plan:*
Pushed this fixed version of SDK to an ECR repo and tested in the playground cluster to confirm the runtime errors are resolved.
```
❯ kubectl get pods

NAME                      READY   STATUS        RESTARTS   AGE
my-app-5c5c6b949f-htjj2   1/1     Running       0          7s
my-app-5c5c6b949f-zk9nn   1/1     Running       0          7s
my-app-76fbfbd7fc-mb4ft   1/1     Terminating   0          7m12s
my-app-76fbfbd7fc-tpql7   1/1     Terminating   0          7m12s

appsignals_django_uwsgi_sample/myproject on  main [?] via  desktop-linux via  v3.8.18 on   (us-east-1)
❯ kubectl logs my-app-5c5c6b949f-htjj2
Defaulted container "my-container" out of: my-container, opentelemetry-auto-instrumentation-python (init)
AwsEcsResourceDetector failed: Missing ECS_CONTAINER_METADATA_URI therefore process is not on ECS.
AwsEksResourceDetector failed: HTTP Error 403: Forbidden
Configuration of configurator not loaded, aws_configurator already loaded
('Could not find the ORIG_HANDLER or _HANDLER in the environment variables. ', 'This instrumentation requires the OpenTelemetry Lambda extension installed.')
Operations to perform:
  Apply all migrations: admin, auth, contenttypes, sessions
Running migrations:
  Applying contenttypes.0001_initial... OK
  Applying auth.0001_initial... OK
  Applying admin.0001_initial... OK
  Applying admin.0002_logentry_remove_auto_add... OK
  Applying admin.0003_logentry_add_action_flag_choices... OK
  Applying contenttypes.0002_remove_content_type_name... OK
  Applying auth.0002_alter_permission_name_max_length... OK
  Applying auth.0003_alter_user_email_max_length... OK
  Applying auth.0004_alter_user_username_opts... OK
  Applying auth.0005_alter_user_last_login_null... OK
  Applying auth.0006_require_contenttypes_0002... OK
  Applying auth.0007_alter_validators_add_error_messages... OK
  Applying auth.0008_alter_user_username_max_length... OK
  Applying auth.0009_alter_user_last_name_max_length... OK
  Applying auth.0010_alter_group_name_max_length... OK
  Applying auth.0011_update_proxy_permissions... OK
  Applying auth.0012_alter_user_first_name_max_length... OK
  Applying sessions.0001_initial... OK
AwsEcsResourceDetector failed: Missing ECS_CONTAINER_METADATA_URI therefore process is not on ECS.
AwsEksResourceDetector failed: HTTP Error 403: Forbidden
Configuration of configurator not loaded, aws_configurator already loaded
('Could not find the ORIG_HANDLER or _HANDLER in the environment variables. ', 'This instrumentation requires the OpenTelemetry Lambda extension installed.')

125 static files copied to '/django_frontend_app/static'.
AwsEcsResourceDetector failed: Missing ECS_CONTAINER_METADATA_URI therefore process is not on ECS.
AwsEksResourceDetector failed: HTTP Error 403: Forbidden
Configuration of configurator not loaded, aws_configurator already loaded
('Could not find the ORIG_HANDLER or _HANDLER in the environment variables. ', 'This instrumentation requires the OpenTelemetry Lambda extension installed.')
Performing system checks...

System check identified no issues (0 silenced).
January 09, 2025 - 19:28:09
Django version 4.2.16, using settings 'django_frontend_service.settings'
Starting development server at http://0.0.0.0:8000/
Quit the server with CONTROL-C.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

