### PR TITLE
update actions/cache version to v3 in gh workflow

### DIFF
--- a/.github/actions/set_up/action.yml
+++ b/.github/actions/set_up/action.yml
@@ -31,7 +31,7 @@ runs:
 
     - name: Cache tox environment
       # Preserves .tox directory between runs for faster installs
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: |
           .tox


### PR DESCRIPTION
**Issue #, if available:**

Github workflows are failing because we are using a deprecated version for `actions/cache`

```
Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: v1`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down
```

Link: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down

**Description of changes:**

Changed version of `actions/cache` from v1 to v3.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

