### PR TITLE
remove lambda remote service override configuration

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_aws_metric_attribute_generator.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_aws_metric_attribute_generator.py
@@ -457,13 +457,11 @@ def _set_remote_type_and_identifier(span: ReadableSpan, attributes: BoundedAttri
             # This addresses a Lambda topology issue in Application Signals.
             # More context in PR: https://github.com/aws-observability/aws-otel-python-instrumentation/pull/319
             #
-            # NOTE: The env vars LAMBDA_APPLICATION_SIGNALS_REMOTE_SERVICE and
-            # LAMBDA_APPLICATION_SIGNALS_REMOTE_ENVIRONMENT were introduced as part of this fix.
-            # They are optional and allow users to override the default values if needed.
+            # NOTE: The env var LAMBDA_APPLICATION_SIGNALS_REMOTE_ENVIRONMENT was introduced as part of this fix.
+            # It is optional and allows users to override the default value if needed.
             if span.attributes.get(_RPC_METHOD) == "Invoke":
-                attributes[AWS_REMOTE_SERVICE] = os.environ.get(
-                    "LAMBDA_APPLICATION_SIGNALS_REMOTE_SERVICE", span.attributes.get(AWS_LAMBDA_FUNCTION_NAME)
-                )
+                attributes[AWS_REMOTE_SERVICE] = _escape_delimiters(span.attributes.get(AWS_LAMBDA_FUNCTION_NAME))
+
                 attributes[AWS_REMOTE_ENVIRONMENT] = (
                     f'lambda:{os.environ.get("LAMBDA_APPLICATION_SIGNALS_REMOTE_ENVIRONMENT", "default")}'
                 )

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_metric_attribute_generator.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_metric_attribute_generator.py
@@ -1195,26 +1195,6 @@ class TestAwsMetricAttributeGenerator(TestCase):
         self._mock_attribute([AWS_LAMBDA_FUNCTION_NAME, SpanAttributes.RPC_METHOD], [None, None])
         os.environ.pop("LAMBDA_APPLICATION_SIGNALS_REMOTE_ENVIRONMENT", None)
 
-        # Test AWS Lambda Invoke scenario with user-configured lambda remote service
-        os.environ["LAMBDA_APPLICATION_SIGNALS_REMOTE_SERVICE"] = "test_downstream_lambda2"
-        self.span_mock.kind = SpanKind.CLIENT
-        self._mock_attribute(
-            [AWS_LAMBDA_FUNCTION_NAME, SpanAttributes.RPC_METHOD],
-            ["testLambdaFunction", "Invoke"],
-            keys,
-            values,
-        )
-        dependency_attributes = _GENERATOR.generate_metric_attributes_dict_from_span(self.span_mock, self.resource).get(
-            DEPENDENCY_METRIC
-        )
-        self.assertEqual(dependency_attributes.get(AWS_REMOTE_SERVICE), "test_downstream_lambda2")
-        self.assertEqual(dependency_attributes.get(AWS_REMOTE_ENVIRONMENT), "lambda:default")
-        self.assertNotIn(AWS_REMOTE_RESOURCE_TYPE, dependency_attributes)
-        self.assertNotIn(AWS_REMOTE_RESOURCE_IDENTIFIER, dependency_attributes)
-        self.assertNotIn(AWS_CLOUDFORMATION_PRIMARY_IDENTIFIER, dependency_attributes)
-        self._mock_attribute([AWS_LAMBDA_FUNCTION_NAME, SpanAttributes.RPC_METHOD], [None, None])
-        os.environ.pop("LAMBDA_APPLICATION_SIGNALS_REMOTE_SERVICE", None)
-
         # Test AWS Lambda non-Invoke scenario
         self.span_mock.kind = SpanKind.CLIENT
         lambda_arn = "arn:aws:lambda:us-east-1:123456789012:function:testLambda"


### PR DESCRIPTION
**Issue #, if available:**
If user decides to override `RemoteService value`, the Lambda Topology issue solution will not be able to support multiple downstream Lambdas.

For example, consider lambdaA calls both lambdaB and lambdaC. If the user overrides `LAMBDA_APPLICATION_SIGNALS_REMOTE_SERVICE`, it will effectively hardcode the `RemoteService` value. As a result, we are left with an either/or situation where only one node will be connected to lambdaA in the topology depending on the hardcoded value. This issue is not present when the user does not override this `RemoteService` value because that attribute will dynamically take on whatever the lambda function name is.


My proposal is we remove the `LAMBDA_APPLICATION_SIGNALS_REMOTE_SERVICE` env var. That is, we do not allow customers to override the `RemoteService` attribute value. This should not cause issues for customers to lose this configuration option. If the customer needs to change the downstream lambda service name, they can change the lambda function name itself rather than having to use an env var. 

**Description of changes:**
Removing option to override `RemoteService` attribute value.

**Test plan:**
Sanity e2e test by building custom lambda layer and ensuring the correct EMF Logs are still generated after change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

