### PR TITLE
Fix Create Release Notes Workflow Step

### DIFF
--- a/.github/workflows/release-lambda.yml
+++ b/.github/workflows/release-lambda.yml
@@ -197,7 +197,7 @@ jobs:
           echo "" >> release_notes.md
           echo "See new Lambda Layer ARNs:" >> release_notes.md
           echo "" >> release_notes.md
-          cat layer-note >> release_notes.md
+          cat ${{ env.LAYER_NAME }}/layer-note >> release_notes.md
           echo "" >> release_notes.md
           echo "Notes:" >> release_notes.md
       - name: Create GH release


### PR DESCRIPTION
*Issue #, if available:*
Lambda Release workflow step is failing due to:

```
Run echo "AWS OpenTelemetry Lambda Layer for Python version 0.8.0-e902760" > release_notes.md
cat: layer-note: No such file or directory
```

This is because the `layer-note` is created in a different working directory:

https://github.com/aws-observability/aws-otel-python-instrumentation/blob/main/.github/workflows/release-lambda.yml#L159

*Description of changes:*
Update command to use the correct working directory.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

