### PR TITLE
Add SigV4 release test to main build

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -228,3 +228,12 @@ jobs:
       aws-region: us-east-1
       python-version: '3.12'
       caller-workflow-name: 'main-build'
+  #
+  # Stand-Alone ADOT/ADOT SigV4 test on EC2
+  adot-sigv4:
+    needs: [ upload-main-build ]
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-ec2-adot-sigv4-test.yml@main
+    secrets: inherit
+    with:
+      caller-workflow-name: 'main-build'
+      staging-wheel-name: ${{ inputs.staging-wheel-name }}


### PR DESCRIPTION
Follow up to https://github.com/aws-observability/aws-application-signals-test-framework/pull/377


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

