### PR TITLE
Add Lambda Layer Release Workflow Step to Upload layer.zip to Latest SDK Release Note 

### DIFF
--- a/.github/workflows/release-lambda.yml
+++ b/.github/workflows/release-lambda.yml
@@ -212,3 +212,10 @@ jobs:
              layer_arns.tf layer.zip
           echo Removing release_notes.md ...
           rm -f release_notes.md
+      - name: Upload layer.zip to SDK Release Notes (tagged with latest)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LATEST_SDK_VERSION=$(gh release list --repo "aws-observability/aws-otel-python-instrumentation" --json tagName,isLatest -q 'map(select(.isLatest==true)) | .[0].tagName')
+          gh release upload "$LATEST_SDK_VERSION" layer.zip --repo "aws-observability/aws-otel-python-instrumentation" --clobber
+          echo "✅ layer.zip successfully uploaded to $LATEST_SDK_VERSION in the upstream repo!"

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -132,9 +132,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         run: |
+          # Download layer.zip from existing latest tagged SDK release note
+          LATEST_SDK_VERSION=$(gh release list --repo "aws-observability/aws-otel-java-instrumentation" --json tagName,isLatest -q 'map(select(.isLatest==true)) | .[0].tagName')
+          mkdir -p layer_artifact
+          gh release download "$LATEST_SDK_VERSION" --repo "aws-observability/aws-otel-java-instrumentation" --pattern "layer.zip" --dir layer_artifact
+
           gh release create --target "$GITHUB_REF_NAME" \
              --title "Release v${{ github.event.inputs.version }}" \
              --draft \
              "v${{ github.event.inputs.version }}" \
              dist/${{ env.ARTIFACT_NAME }} \
-             ${{ env.ARTIFACT_NAME }}.sha256
+             ${{ env.ARTIFACT_NAME }}.sha256 \
+             layer_artifact/layer.zip


### PR DESCRIPTION
*Description of changes:*
Adding step to our Lambda Layer release workflow to upload `layer.zip` file to SDK release notes tagged with "latest"

**Test plan:**
Ran the `gh` commands locally and tested on release note in my forked repo for ADOT Java:

Upload `layer.zip` to existing release note: 
https://github.com/yiyuan-he/aws-otel-java-instrumentation/releases/tag/v2.0.0
Create new release note with `layer.zip`: 
https://github.com/yiyuan-he/aws-otel-java-instrumentation/releases/tag/untagged-bfc0e9c6ba6bdc461832

<img width="1512" alt="Screenshot 2025-03-07 at 10 49 42 AM" src="https://github.com/user-attachments/assets/7a558efb-c80f-43be-ae52-fd2bc17d0598" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

