### PR TITLE
Add SHA-256 for layer.zip file in SDK and Lambda Layer Release Workflows

### DIFF
--- a/.github/workflows/release-lambda.yml
+++ b/.github/workflows/release-lambda.yml
@@ -212,10 +212,13 @@ jobs:
              layer_arns.tf layer.zip
           echo Removing release_notes.md ...
           rm -f release_notes.md
-      - name: Upload layer.zip to SDK Release Notes (tagged with latest)
+      - name: Upload layer.zip and SHA-256 checksum to SDK Release Notes (tagged with latest)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           LATEST_SDK_VERSION=$(gh release list --repo "aws-observability/aws-otel-python-instrumentation" --json tagName,isLatest -q 'map(select(.isLatest==true)) | .[0].tagName')
-          gh release upload "$LATEST_SDK_VERSION" layer.zip --repo "aws-observability/aws-otel-python-instrumentation" --clobber
+          # Generate SHA-256 checksum for layer.zip
+          shasum -a 256 layer.zip > layer.zip.sha256
+          # Upload layer.zip and its checksum to the latest SDK release note
+          gh release upload "$LATEST_SDK_VERSION" layer.zip layer.zip.sha256 --repo "aws-observability/aws-otel-python-instrumentation" --clobber
           echo "✅ layer.zip successfully uploaded to $LATEST_SDK_VERSION in the upstream repo!"

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -133,9 +133,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         run: |
           # Download layer.zip from existing latest tagged SDK release note
-          LATEST_SDK_VERSION=$(gh release list --repo "aws-observability/aws-otel-java-instrumentation" --json tagName,isLatest -q 'map(select(.isLatest==true)) | .[0].tagName')
+          LATEST_SDK_VERSION=$(gh release list --repo "aws-observability/aws-otel-python-instrumentation" --json tagName,isLatest -q 'map(select(.isLatest==true)) | .[0].tagName')
           mkdir -p layer_artifact
-          gh release download "$LATEST_SDK_VERSION" --repo "aws-observability/aws-otel-java-instrumentation" --pattern "layer.zip" --dir layer_artifact
+          gh release download "$LATEST_SDK_VERSION" --repo "aws-observability/aws-otel-python-instrumentation" --pattern "layer.zip" --dir layer_artifact
+          shasum -a 256 layer_artifact/layer.zip > layer_artifact/layer.zip.sha256
 
           gh release create --target "$GITHUB_REF_NAME" \
              --title "Release v${{ github.event.inputs.version }}" \
@@ -143,4 +144,5 @@ jobs:
              "v${{ github.event.inputs.version }}" \
              dist/${{ env.ARTIFACT_NAME }} \
              ${{ env.ARTIFACT_NAME }}.sha256 \
-             layer_artifact/layer.zip
+             layer_artifact/layer.zip \
+             layer_artifact/layer.zip.sha256


### PR DESCRIPTION
*Issue #, if available:*
We require SHA-256 file for every artifact that we vend. Otherwise, our canaries will not be able to download the artifact and we will receive availability drop alarms.

*Description of changes:*
Add logic to generate and upload a SHA-256 file for `layer.zip` file in our lambda layer and sdk release workflows.

**Test plan:**
Tested `gh` commands in workflow steps work on release notes copy in forked repo.

https://github.com/yiyuan-he/aws-otel-java-instrumentation/releases/tag/v2.0.0


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

