### PR TITLE
feat: Add Publish to PyPI Steps to UDP Exporter Release Workflow

### DIFF
--- a/.github/workflows/release-udp-exporter.yml
+++ b/.github/workflows/release-udp-exporter.yml
@@ -92,6 +92,7 @@ jobs:
         id: pypi_secrets
         with:
           secret-ids: |
+            PROD_PYPI_TOKEN,${{ secrets.PYPI_PROD_TOKEN_SECRET_ARN }}
             TEST_PYPI_TOKEN,${{ secrets.PYPI_TEST_TOKEN_SECRET_ARN }}
           parse-json-secrets: true
 
@@ -106,3 +107,11 @@ jobs:
           TWINE_PASSWORD: ${{ env.TEST_PYPI_TOKEN_API_TOKEN }}
         run: |
           twine upload --repository testpypi --skip-existing --verbose exporters/aws-otel-otlp-udp-exporter/dist/${{ env.ARTIFACT_NAME }}
+
+      # Publish to prod PyPI
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: '__token__'
+          TWINE_PASSWORD: ${{ env.PROD_PYPI_TOKEN_API_TOKEN }}
+        run: |
+          twine upload --skip-existing --verbose exporters/aws-otel-otlp-udp-exporter/dist/${{ env.ARTIFACT_NAME }}

--- a/.github/workflows/release-udp-exporter.yml
+++ b/.github/workflows/release-udp-exporter.yml
@@ -7,6 +7,13 @@ on:
         description: 'Version number for deployment e.g. 0.1.0'
         required: true
         type: string
+env:
+  AWS_DEFAULT_REGION: us-east-1
+  ARTIFACT_NAME: aws_otel_otlp_udp_exporter-${{ github.event.inputs.version }}-py3-none-any.whl
+
+permissions:
+  id-token: write
+  contents: write
 
 jobs:
   build-test-publish:
@@ -74,4 +81,28 @@ jobs:
             exit 1
           fi
 
-      # TODO: Steps to publish to PyPI
+      - name: Configure AWS credentials for PyPI secrets
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_SECRETS_MANAGER }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
+      - name: Get PyPI secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        id: pypi_secrets
+        with:
+          secret-ids: |
+            TEST_PYPI_TOKEN,${{ secrets.PYPI_TEST_TOKEN_SECRET_ARN }}
+          parse-json-secrets: true
+
+      - name: Install twine
+        run: pip install twine
+
+      # The step below publishes to testpypi in order to catch any issues
+      # with the package configuration that would cause a failure to upload to PyPI.
+      - name: Publish to TestPyPI
+        env:
+          TWINE_USERNAME: '__token__'
+          TWINE_PASSWORD: ${{ env.TEST_PYPI_TOKEN_API_TOKEN }}
+        run: |
+          twine upload --repository testpypi --skip-existing --verbose exporters/aws-otel-otlp-udp-exporter/dist/${{ env.ARTIFACT_NAME }}

--- a/exporters/aws-otel-otlp-udp-exporter/pyproject.toml
+++ b/exporters/aws-otel-otlp-udp-exporter/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aws-otel-otlp-udp-exporter"
-version = "0.0.1"
+version = "0.1.0"
 description = "OTLP UDP Exporter for OpenTelemetry"
 readme = "README.rst"
 license = "Apache-2.0"

--- a/exporters/aws-otel-otlp-udp-exporter/pyproject.toml
+++ b/exporters/aws-otel-otlp-udp-exporter/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aws-otel-otlp-udp-exporter"
-version = "0.1.0"
+version = "0.0.1"
 description = "OTLP UDP Exporter for OpenTelemetry"
 readme = "README.rst"
 license = "Apache-2.0"


### PR DESCRIPTION
**Description of changes:**
Setting up PyPI publishing steps in our UDP Exporter release workflow. The changes are largely the same our [workflow steps](https://github.com/aws-observability/aws-otel-python-instrumentation/blob/main/.github/workflows/release_build.yml#L82) used to publish our ADOT package to PyPI.

**Test Plan:**
Test workflow run via feature branch:
- [Successful workflow run](https://github.com/aws-observability/aws-otel-python-instrumentation/actions/runs/13799176618/job/38597855879)
- [Artifact successfully published to Test PyPI](https://test.pypi.org/project/aws-otel-otlp-udp-exporter/0.0.1/)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

