### PR TITLE
Updated LambdaSpanProcessor to run outside of Application Signals

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
@@ -331,6 +331,10 @@ def _customize_exporter(span_exporter: SpanExporter, resource: Resource) -> Span
 
 
 def _customize_span_processors(provider: TracerProvider, resource: Resource) -> None:
+    # Export 100% spans and not export Application-Signals metrics if on Lambda.
+    if _is_lambda_environment():
+        provider.add_span_processor(AwsLambdaSpanProcessor())
+
     if not _is_application_signals_enabled():
         return
 
@@ -344,7 +348,6 @@ def _customize_span_processors(provider: TracerProvider, resource: Resource) -> 
     # Export 100% spans and not export Application-Signals metrics if on Lambda.
     if _is_lambda_environment():
         _export_unsampled_span_for_lambda(provider, resource)
-        provider.add_span_processor(AwsLambdaSpanProcessor())
         return
 
     # Construct meterProvider

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
@@ -331,7 +331,7 @@ def _customize_exporter(span_exporter: SpanExporter, resource: Resource) -> Span
 
 
 def _customize_span_processors(provider: TracerProvider, resource: Resource) -> None:
-    # Export 100% spans and not export Application-Signals metrics if on Lambda.
+    # Add LambdaSpanProcessor to list of processors regardless of application signals.
     if _is_lambda_environment():
         provider.add_span_processor(AwsLambdaSpanProcessor())
 

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 from amazon.opentelemetry.distro.always_record_sampler import AlwaysRecordSampler
 from amazon.opentelemetry.distro.attribute_propagating_span_processor import AttributePropagatingSpanProcessor
 from amazon.opentelemetry.distro.aws_batch_unsampled_span_processor import BatchUnsampledSpanProcessor
+from amazon.opentelemetry.distro.aws_lambda_span_processor import AwsLambdaSpanProcessor
 from amazon.opentelemetry.distro.aws_metric_attributes_span_exporter import AwsMetricAttributesSpanExporter
 from amazon.opentelemetry.distro.aws_opentelemetry_configurator import (
     LAMBDA_SPAN_EXPORT_BATCH_SIZE,
@@ -320,10 +321,12 @@ class TestAwsOpenTelemetryConfigurator(TestCase):
         _customize_span_processors(mock_tracer_provider, Resource.get_empty())
         self.assertEqual(mock_tracer_provider.add_span_processor.call_count, 3)
         first_processor: SpanProcessor = mock_tracer_provider.add_span_processor.call_args_list[0].args[0]
-        self.assertIsInstance(first_processor, AttributePropagatingSpanProcessor)
+        self.assertIsInstance(first_processor, AwsLambdaSpanProcessor)
         second_processor: SpanProcessor = mock_tracer_provider.add_span_processor.call_args_list[1].args[0]
-        self.assertIsInstance(second_processor, BatchUnsampledSpanProcessor)
-        self.assertEqual(second_processor.max_export_batch_size, LAMBDA_SPAN_EXPORT_BATCH_SIZE)
+        self.assertIsInstance(second_processor, AttributePropagatingSpanProcessor)
+        third_processor: SpanProcessor = mock_tracer_provider.add_span_processor.call_args_list[2].args[0]
+        self.assertIsInstance(third_processor, BatchUnsampledSpanProcessor)
+        self.assertEqual(third_processor.max_export_batch_size, LAMBDA_SPAN_EXPORT_BATCH_SIZE)
         os.environ.pop("OTEL_AWS_APPLICATION_SIGNALS_ENABLED", None)
         os.environ.pop("AWS_LAMBDA_FUNCTION_NAME", None)
 


### PR DESCRIPTION
*Description of changes:*
Updated LambdaSpanProcessor to run outside of Application Signals. This allows customers to still have the same behavior in lambda even if they opt to disable application signals. 

Testing:
Updated unit tests and made sure they are passing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

