### PR TITLE
[Doc] Add Python 3.12 as a supported version

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This project is licensed under the Apache-2.0 License.
 ## Notices
 
 ### Python Version Support
-This project ensures compatibility with the following supported Python versions: 3.8, 3.9, 3.10, 3.11
+This project ensures compatibility with the following supported Python versions: 3.8, 3.9, 3.10, 3.11, 3.12
 
 ### Note on Amazon CloudWatch Application Signals
 [Amazon CloudWatch Application Signals](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Application-Monitoring-Sections.html) components are designed to seamlessly work with all library instrumentations offered by [OpenTelemetry Python auto-instrumentation](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/instrumentation/README.md). While upstream OpenTelemetry Python instrumentations are in beta, Application Signals components are stable, production ready and have also been tested for popular libraries/frameworks such as [Django, Boto3, and others](https://github.com/aws-observability/aws-otel-python-instrumentation/tree/main/contract-tests/images/applications). We will prioritize backward compatibility for Application Signals components, striving to ensure that they remain functional even in the face of potential breaking changes introduced by OpenTelemetry upstream libraries. Please [raise an issue](https://github.com/aws-observability/aws-otel-python-instrumentation/blob/main/CONTRIBUTING.md#reporting-bugsfeature-requests) if you notice Application Signals doesn't work for a particular OpenTelemetry supported library.


### PR DESCRIPTION
Evidence:
- https://github.com/aws-observability/aws-otel-python-instrumentation/blob/fab436ce218251de5c854c985f7257a76ee9849d/.github/workflows/application-signals-e2e-test.yml#L100
- https://github.com/aws-observability/aws-application-signals-test-framework/blob/173ea69426d29832f2e7f16eee2dcdc206229664/.github/workflows/python-ec2-default-test.yml#L18


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

