### PR TITLE
Decouple SigV4 from Application Signals

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
@@ -349,10 +349,6 @@ def _customize_span_processors(provider: TracerProvider, resource: Resource) -> 
     # Construct and set local and remote attributes span processor
     provider.add_span_processor(AttributePropagatingSpanProcessorBuilder().build())
 
-    # Do not export Application-Signals metrics if it's XRay OTLP endpoint
-    if is_xray_otlp_endpoint():
-        return
-
     # Export 100% spans and not export Application-Signals metrics if on Lambda.
     if _is_lambda_environment():
         _export_unsampled_span_for_lambda(provider, resource)


### PR DESCRIPTION
*Description of changes:*
We do not want to automatically disable Application Signals if SigV4 is enabled. This PR allows Application Signals to run normally with SigV4.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

