### PR TITLE
Update rustc version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN sed -i "/opentelemetry-exporter-otlp-proto-grpc/d" ./aws-opentelemetry-distr
 RUN mkdir workspace && pip install setuptools==75.2.0 urllib3==2.2.3 --target workspace ./aws-opentelemetry-distro
 
 # Stage 2: Build the cp-utility binary
-FROM public.ecr.aws/docker/library/rust:1.81 as builder
+FROM public.ecr.aws/docker/library/rust:1.82 as builder
 
 WORKDIR /usr/src/cp-utility
 COPY ./tools/cp-utility .


### PR DESCRIPTION
*Description of changes:*
PR Builds are failing:

```
#16 ERROR: process "/bin/sh -c if [ $TARGETARCH = \"amd64\" ]; then cargo install cargo-audit && cargo audit ; fi" did not complete successfully: exit code: 101
------
 > [builder 5/6] RUN if [ amd64 = "amd64" ]; then cargo install cargo-audit && cargo audit ; fi:
3.336     icu_properties@2.0.0 requires rustc 1.82
3.336     icu_properties_data@2.0.0 requires rustc 1.82
3.336     icu_properties_data@2.0.0 requires rustc 1.82
3.336     icu_properties_data@2.0.0 requires rustc 1.82
3.336     icu_provider@2.0.0 requires rustc 1.82
3.336     idna_adapter@1.2.1 requires rustc 1.82
3.336     litemap@0.8.0 requires rustc 1.82
3.336     zerotrie@0.2.2 requires rustc 1.82
3.336     zerovec@0.11.2 requires rustc 1.82
3.336   Try re-running `cargo install` with `--locked`
------

 1 warning found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 36)
Dockerfile:54
--------------------
  52 |     
  53 |     # Audit dependencies
  54 | >>> RUN if [ $TARGETARCH = "amd64" ]; then cargo install cargo-audit && cargo audit ; fi
  55 |     
  56 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c if [ $TARGETARCH = \"amd64\" ]; then cargo install cargo-audit && cargo audit ; fi" did not complete successfully: exit code: 101

```


Updating rustc version to `1.82`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

