### PR TITLE
Add OtlpAwsLogExporter and OtlpAwsSpanExporter

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
@@ -21,13 +21,13 @@ from amazon.opentelemetry.distro.aws_metric_attributes_span_exporter_builder imp
     AwsMetricAttributesSpanExporterBuilder,
 )
 from amazon.opentelemetry.distro.aws_span_metrics_processor_builder import AwsSpanMetricsProcessorBuilder
-from amazon.opentelemetry.distro.exporter.otlp.aws.common.aws_auth_session import AwsAuthSession
+from amazon.opentelemetry.distro.exporter.otlp.aws.logs.otlp_aws_logs_exporter import OTLPAwsLogExporter
+from amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter import OTLPAwsSpanExporter
 from amazon.opentelemetry.distro.otlp_udp_exporter import OTLPUdpSpanExporter
 from amazon.opentelemetry.distro.sampler.aws_xray_remote_sampler import AwsXRayRemoteSampler
 from amazon.opentelemetry.distro.scope_based_exporter import ScopeBasedPeriodicExportingMetricReader
 from amazon.opentelemetry.distro.scope_based_filtering_view import ScopeBasedRetainingView
 from opentelemetry._logs import set_logger_provider
-from opentelemetry.exporter.otlp.proto.http import Compression
 from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
 from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter as OTLPHttpOTLPMetricExporter
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
@@ -359,10 +359,7 @@ def _customize_span_exporter(span_exporter: SpanExporter, resource: Resource) ->
         _logger.info("Detected using AWS OTLP Traces Endpoint.")
 
         if isinstance(span_exporter, OTLPSpanExporter):
-            span_exporter = OTLPSpanExporter(
-                endpoint=traces_endpoint,
-                session=AwsAuthSession(traces_endpoint.split(".")[1], "xray"),
-            )
+            span_exporter = OTLPAwsSpanExporter(endpoint=traces_endpoint)
 
         else:
             _logger.warning(
@@ -386,11 +383,7 @@ def _customize_logs_exporter(log_exporter: LogExporter, resource: Resource) -> L
             # Setting default compression mode to Gzip as this is the behavior in upstream's
             # collector otlp http exporter:
             # https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter
-            return OTLPLogExporter(
-                endpoint=logs_endpoint,
-                compression=Compression.Gzip,
-                session=AwsAuthSession(logs_endpoint.split(".")[1], "logs"),
-            )
+            return OTLPAwsLogExporter(endpoint=logs_endpoint)
 
         _logger.warning(
             "Improper configuration see: please export/set "

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/exporter/otlp/aws/logs/otlp_aws_logs_exporter.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/exporter/otlp/aws/logs/otlp_aws_logs_exporter.py
@@ -1,0 +1,36 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Dict, Optional
+
+from amazon.opentelemetry.distro.exporter.otlp.aws.common.aws_auth_session import AwsAuthSession
+from opentelemetry.exporter.otlp.proto.http import Compression
+from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+
+
+class OTLPAwsLogExporter(OTLPLogExporter):
+    def __init__(
+        self,
+        endpoint: Optional[str] = None,
+        certificate_file: Optional[str] = None,
+        client_key_file: Optional[str] = None,
+        client_certificate_file: Optional[str] = None,
+        headers: Optional[Dict[str, str]] = None,
+        timeout: Optional[int] = None,
+    ):
+        self._aws_region = None
+
+        if endpoint:
+            self._aws_region = endpoint.split(".")[1]
+
+        OTLPLogExporter.__init__(
+            self,
+            endpoint,
+            certificate_file,
+            client_key_file,
+            client_certificate_file,
+            headers,
+            timeout,
+            compression=Compression.Gzip,
+            session=AwsAuthSession(aws_region=self._aws_region, service="logs"),
+        )

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/exporter/otlp/aws/traces/otlp_aws_span_exporter.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/exporter/otlp/aws/traces/otlp_aws_span_exporter.py
@@ -1,0 +1,37 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Dict, Optional
+
+from amazon.opentelemetry.distro.exporter.otlp.aws.common.aws_auth_session import AwsAuthSession
+from opentelemetry.exporter.otlp.proto.http import Compression
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
+
+class OTLPAwsSpanExporter(OTLPSpanExporter):
+    def __init__(
+        self,
+        endpoint: Optional[str] = None,
+        certificate_file: Optional[str] = None,
+        client_key_file: Optional[str] = None,
+        client_certificate_file: Optional[str] = None,
+        headers: Optional[Dict[str, str]] = None,
+        timeout: Optional[int] = None,
+        compression: Optional[Compression] = None,
+    ):
+        self._aws_region = None
+
+        if endpoint:
+            self._aws_region = endpoint.split(".")[1]
+
+        OTLPSpanExporter.__init__(
+            self,
+            endpoint,
+            certificate_file,
+            client_key_file,
+            client_certificate_file,
+            headers,
+            timeout,
+            compression,
+            session=AwsAuthSession(aws_region=self._aws_region, service="xray"),
+        )

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py
@@ -35,6 +35,8 @@ from amazon.opentelemetry.distro.aws_opentelemetry_configurator import (
 from amazon.opentelemetry.distro.aws_opentelemetry_distro import AwsOpenTelemetryDistro
 from amazon.opentelemetry.distro.aws_span_metrics_processor import AwsSpanMetricsProcessor
 from amazon.opentelemetry.distro.exporter.otlp.aws.common.aws_auth_session import AwsAuthSession
+from amazon.opentelemetry.distro.exporter.otlp.aws.logs.otlp_aws_logs_exporter import OTLPAwsLogExporter
+from amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter import OTLPAwsSpanExporter
 from amazon.opentelemetry.distro.otlp_udp_exporter import OTLPUdpSpanExporter
 from amazon.opentelemetry.distro.sampler._aws_xray_sampling_client import _AwsXRaySamplingClient
 from amazon.opentelemetry.distro.sampler.aws_xray_remote_sampler import _AwsXRayRemoteSampler
@@ -377,7 +379,7 @@ class TestAwsOpenTelemetryConfigurator(TestCase):
                 config,
                 _customize_span_exporter,
                 OTLPSpanExporter(),
-                OTLPSpanExporter,
+                OTLPAwsSpanExporter,
                 AwsAuthSession,
                 Compression.NoCompression,
             )
@@ -480,7 +482,12 @@ class TestAwsOpenTelemetryConfigurator(TestCase):
 
         for config in good_configs:
             self.customize_exporter_test(
-                config, _customize_logs_exporter, OTLPLogExporter(), OTLPLogExporter, AwsAuthSession, Compression.Gzip
+                config,
+                _customize_logs_exporter,
+                OTLPLogExporter(),
+                OTLPAwsLogExporter,
+                AwsAuthSession,
+                Compression.Gzip,
             )
 
         for config in bad_configs:


### PR DESCRIPTION
*Background:*
https://github.com/aws-observability/aws-otel-python-instrumentation/pull/358
The above PR got rid of OtlpAwsSpanExporter and OtlpAwsLogExporter as to use the default upstream exporters as that was a cleaner approach.

However, we need the OtlpAwsSpanExporter and OtlpAwsLogExporter classes to support later requirements for Gen AI as we need to override the export method. 

*Description of changes:*
This PR reintroduces the OtlpAwsSpanExporter and OtlpAwsLogExporter classes to support later requirements for Gen AI as we need to override the export method. 

This change does not introduce anything new and the Sigv4 span + logs exporter still work as intended:

Logs:
```
{
    "resource": {
        "attributes": {
            "aws.local.service": "test",
            "service.name": "test",
            "cloud.region": "us-west-2",
            "host.type": "c5.4xlarge",
            "cloud.availability_zone": "us-west-2c",
            "telemetry.sdk.name": "opentelemetry",
            "telemetry.sdk.language": "python",
            "cloud.provider": "aws",
            "cloud.account.id": "571600841604",
            "telemetry.sdk.version": "1.27.0",
            "host.name": "ip-172-31-7-29.us-west-2.compute.internal",
            "cloud.platform": "aws_ec2",
            "host.id": "i-0b04d6affbae7d629",
            "telemetry.auto.version": "0.9.0.dev0-aws"
        }
    },
    "scope": {
        "name": "opentelemetry.sdk._logs._internal"
    },
    "timeUnixNano": 1747074906326769664,
    "observedTimeUnixNano": 1747074906326822815,
    "severityNumber": 9,
    "severityText": "INFO",
    "body": "127.0.0.1 - - [12/May/2025 18:35:06] \"GET /server_request HTTP/1.1\" 200 -",
    "attributes": {
        "code.filepath": "/home/ec2-user/.local/lib/python3.9/site-packages/werkzeug/_internal.py",
        "otelTraceSampled": false,
        "code.function": "_log",
        "code.lineno": 97,
        "otelTraceID": "0",
        "otelSpanID": "0",
        "otelServiceName": "test"
    },
    "traceId": "",
    "spanId": ""
}
```

Spans:

```



{     "resource": {         "attributes": {             "aws.local.service": "test",             "service.name": "test",             "cloud.region": "us-west-2",             "host.type": "c5.4xlarge",             "cloud.availability_zone": "us-west-2c",             "telemetry.sdk.name": "opentelemetry",             "telemetry.sdk.language": "python",             "cloud.provider": "aws",             "cloud.account.id": "571600841604",             "telemetry.sdk.version": "1.27.0",             "host.name": "ip-172-31-7-29.us-west-2.compute.internal",             "cloud.platform": "aws_ec2",             "host.id": "i-0b04d6affbae7d629",             "telemetry.auto.version": "0.9.0.dev0-aws"         }     },     "scope": {         "name": "opentelemetry.instrumentation.flask",         "version": "0.48b0"     },     "traceId": "68223f2d375733237e24512171012437",     "spanId": "34dd5a89d7a21fdf",     "flags": 256,     "name": "GET /",     "kind": "SERVER",     "startTimeUnixNano": 1747074861988123056,     "endTimeUnixNano": 1747074861988911516,     "durationNano": 788460,     "attributes": {         "net.host.name": "localhost:8082",         "aws.local.service": "test",         "net.peer.port": 57356,         "telemetry.extended": "true",         "http.target": "/",         "http.flavor": "1.1",         "net.peer.ip": "127.0.0.1",         "http.host": "localhost:8082",         "aws.local.environment": "ec2:default",         "http.status_code": 404,         "aws.local.operation": "GET /",         "aws.span.kind": "LOCAL_ROOT",         "http.server_name": "127.0.0.1",         "http.user_agent": "curl/8.5.0",         "net.host.port": 8082,         "PlatformType": "AWS::EC2",         "http.method": "GET",         "http.response.status_code": 404,         "http.scheme": "http"     },     "status": {         "code": "UNSET"     } } | {"resource":{"attributes":{"aws.local.service":"test","service.name":"test","cloud.region":"us-west-2","host.type":"c5.4xlarge","cloud.availability_zone":"us-west-2c","telemetry.sdk.name":"opentelemetry","telemetry.sdk.language":"python","cloud.provider":"aws","cloud.account.id":"571600841604","telemetry.sdk.version":"1.27.0","host.name":"ip-172-31-7-29.us-west-2.compute.internal","cloud.platform":"aws_ec2","host.id":"i-0b04d6affbae7d629","telemetry.auto.version":"0.9.0.dev0-aws"}},"scope":{"name":"opentelemetry.instrumentation.flask","version":"0.48b0"},"traceId":"68223f2d375733237e24512171012437","spanId":"34dd5a89d7a21fdf","flags":256,"name":"GET /","kind":"SERVER","startTimeUnixNano":1747074861988123056,"endTimeUnixNano":1747074861988911516,"durationNano":788460,"attributes":{"net.host.name":"localhost:8082","aws.local.service":"test","net.peer.port":57356,"telemetry.extended":"true","http.target":"/","http.flavor":"1.1","net.peer.ip":"127.0.0.1","http.host":"localhost:8082","aws.local.environment":"ec2:default","http.status_code":404,"aws.local.operation":"GET /","aws.span.kind":"LOCAL_ROOT","http.server_name":"127.0.0.1","http.user_agent":"curl/8.5.0","net.host.port":8082,"PlatformType":"AWS::EC2","http.method":"GET","http.response.status_code":404,"http.scheme":"http"},"status":{"code":"UNSET"}}
  |  

<br class="Apple-interchange-newline">

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

