### PR TITLE
Impl shutdown hook and catch the possible exception on exporting path

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/exporter/otlp/aws/traces/otlp_aws_span_exporter.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/exporter/otlp/aws/traces/otlp_aws_span_exporter.py
@@ -65,8 +65,11 @@ class OTLPAwsSpanExporter(OTLPSpanExporter):
         return self._llo_handler is not None
 
     def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
-        if is_agent_observability_enabled() and self._ensure_llo_handler():
-            llo_processed_spans = self._llo_handler.process_spans(spans)
-            return super().export(llo_processed_spans)
+        try:
+            if is_agent_observability_enabled() and self._ensure_llo_handler():
+                llo_processed_spans = self._llo_handler.process_spans(spans)
+                return super().export(llo_processed_spans)
+        except Exception:
+            return SpanExportResult.FAILURE
 
         return super().export(spans)


### PR DESCRIPTION
- Added exception handling in OTLPAwsSpanExporter to prevent "cannot schedule new futures after interpreter shutdown" errors
- Added shutdown method implementations to both log and span exporters for proper cleanup

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

