### PR TITLE
Consolidate LLM I/O Events into Single Event Per Span [WIP]

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
@@ -288,6 +288,30 @@ def _export_unsampled_span_for_lambda(trace_provider: TracerProvider, resource: 
     )
 
 
+def _export_unsampled_span_for_agent_observability(trace_provider: TracerProvider, resource: Resource = None):
+    if not is_agent_observability_enabled():
+        return
+
+    # Get the traces endpoint from environment
+    traces_endpoint = os.environ.get(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT)
+    
+    if not traces_endpoint:
+        # No traces endpoint configured, skip unsampled span export
+        _logger.warning("No traces endpoint configured for agent observability unsampled spans")
+        return
+    
+    # Create the appropriate span exporter based on the endpoint
+    if _is_aws_otlp_endpoint(traces_endpoint, "xray"):
+        span_exporter = OTLPAwsSpanExporter(endpoint=traces_endpoint, logger_provider=get_logger_provider())
+    else:
+        span_exporter = OTLPSpanExporter(endpoint=traces_endpoint)
+    
+    # Add the unsampled span processor
+    trace_provider.add_span_processor(
+        BatchUnsampledSpanProcessor(span_exporter=span_exporter)
+    )
+
+
 def _is_defer_to_workers_enabled():
     return os.environ.get(OTEL_AWS_PYTHON_DEFER_TO_WORKERS_ENABLED_CONFIG, "false").strip().lower() == "true"
 
@@ -425,6 +449,9 @@ def _customize_span_processors(provider: TracerProvider, resource: Resource) -> 
     # Add LambdaSpanProcessor to list of processors regardless of application signals.
     if _is_lambda_environment():
         provider.add_span_processor(AwsLambdaSpanProcessor())
+
+    # Add unsampled span export for agent observability
+    _export_unsampled_span_for_agent_observability(provider, resource)
 
     if not _is_application_signals_enabled():
         return

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/llo_handler.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/llo_handler.py
@@ -215,12 +215,20 @@ class LLOHandler:
         self, span: ReadableSpan, attributes: Dict[str, Any], event_timestamp: Optional[int] = None
     ) -> None:
         """
-        Extract Gen AI Events from LLO attributes and emit them via the event logger.
+        Extract LLO attributes and emit them as a single consolidated Gen AI Event.
 
         This method:
-        1. Collects LLO attributes from multiple frameworks using specialized extractors
-        2. Converts each LLO attribute into appropriate Gen AI Events
-        3. Emits all collected events through the event logger
+        1. Collects all LLO attributes from multiple frameworks
+        2. Consolidates them into a single event body with indexed messages
+        3. Emits one event per span containing all LLO content
+
+        The consolidated event body format:
+        {
+            "user.message.0": {"role": "user", "content": "..."},
+            "user.message.1": {"role": "user", "content": "..."},
+            "assistant.message.0": {"role": "assistant", "content": "..."},
+            "system.message.0": {"role": "system", "content": "..."}
+        }
 
         Supported frameworks:
         - Standard Gen AI: Structured prompt/completion with roles
@@ -234,9 +242,9 @@ class LLOHandler:
             event_timestamp: Optional timestamp to override span timestamps
 
         Returns:
-            None: Events are emitted via the event logger
+            None: Event is emitted via the event logger
         """
-        # Quick check if we have any LLO attributes before running extractors
+        # Quick check if we have any LLO attributes before processing
         has_llo_attrs = False
         for key in attributes:
             if self._is_llo_attribute(key):
@@ -246,16 +254,56 @@ class LLOHandler:
         if not has_llo_attrs:
             return
 
-        all_events = []
-        all_events.extend(self._extract_gen_ai_prompt_events(span, attributes, event_timestamp))
-        all_events.extend(self._extract_gen_ai_completion_events(span, attributes, event_timestamp))
-        all_events.extend(self._extract_traceloop_events(span, attributes, event_timestamp))
-        all_events.extend(self._extract_openlit_span_event_attributes(span, attributes, event_timestamp))
-        all_events.extend(self._extract_openinference_attributes(span, attributes, event_timestamp))
+        # Collect all messages from various frameworks
+        all_messages = []
+        all_messages.extend(self._collect_gen_ai_prompt_messages(span, attributes))
+        all_messages.extend(self._collect_gen_ai_completion_messages(span, attributes))
+        all_messages.extend(self._collect_traceloop_messages(span, attributes))
+        all_messages.extend(self._collect_openlit_messages(span, attributes))
+        all_messages.extend(self._collect_openinference_messages(span, attributes))
 
-        for event in all_events:
-            self._event_logger.emit(event)
-            _logger.debug(f"Emitted Gen AI Event: {event.name}")
+        if not all_messages:
+            return
+
+        # Group messages by role and assign indices
+        consolidated_body = {}
+        role_counters = {"system": 0, "user": 0, "assistant": 0}
+
+        for message in all_messages:
+            role = message.get("role", "unknown")
+            content = message.get("content", "")
+
+            # Get the counter for this role, defaulting to 0 for unknown roles
+            if role in role_counters:
+                index = role_counters[role]
+                role_counters[role] += 1
+            else:
+                # For unknown/custom roles, use a separate counter
+                if role not in role_counters:
+                    role_counters[role] = 0
+                index = role_counters[role]
+                role_counters[role] += 1
+
+            key = f"{role}.message.{index}"
+            consolidated_body[key] = {"role": role, "content": content}
+
+        # Create a single consolidated event
+        span_ctx = span.context
+        gen_ai_system = span.attributes.get("gen_ai.system", "unknown")
+
+        # Use span end time as the event timestamp (represents completion)
+        timestamp = event_timestamp if event_timestamp is not None else span.end_time
+
+        event = self._get_gen_ai_event(
+            name="gen_ai.content.consolidated",
+            span_ctx=span_ctx,
+            timestamp=timestamp,
+            attributes={"gen_ai.system": gen_ai_system},
+            body=consolidated_body,
+        )
+
+        self._event_logger.emit(event)
+        _logger.debug("Emitted consolidated Gen AI Event with all LLO content")
 
     def _filter_attributes(self, attributes: Dict[str, Any]) -> Dict[str, Any]:
         """
@@ -322,40 +370,25 @@ class LLOHandler:
 
         return False
 
-    def _extract_gen_ai_prompt_events(
-        self, span: ReadableSpan, attributes: Dict[str, Any], event_timestamp: Optional[int] = None
-    ) -> List[Event]:
+    def _collect_gen_ai_prompt_messages(self, span: ReadableSpan, attributes: Dict[str, Any]) -> List[Dict[str, Any]]:
         """
-        Extract Gen AI Events from structured prompt attributes.
+        Collect message dictionaries from structured prompt attributes.
 
         Processes attributes matching the pattern `gen_ai.prompt.{n}.content` and their
-        associated `gen_ai.prompt.{n}.role` attributes to create appropriate events.
-
-        Event types are determined by the role:
-        1. `system` → `gen_ai.system.message` Event
-        2. `user` → `gen_ai.user.message` Event
-        3. `assistant` → `gen_ai.assistant.message` Event
-        4. `function` → `gen_ai.{gen_ai.system}.message` custom Event
-        5. `unknown` → `gen_ai.{gen_ai.system}.message` custom Event
+        associated `gen_ai.prompt.{n}.role` attributes to create message dictionaries.
 
         Args:
             span: The source ReadableSpan containing the attributes
             attributes: Dictionary of attributes to process
-            event_timestamp: Optional timestamp to override span.start_time
 
         Returns:
-            List[Event]: Events created from prompt attributes
+            List[Dict[str, Any]]: List of message dictionaries with 'content' and 'role' keys
         """
         # Quick check if any prompt content attributes exist
         if not any(self._prompt_content_pattern.match(key) for key in attributes):
             return []
 
-        events = []
-        span_ctx = span.context
-        gen_ai_system = span.attributes.get("gen_ai.system", "unknown")
-
-        # Use helper method to get appropriate timestamp (prompts are inputs)
-        prompt_timestamp = self._get_timestamp(span, event_timestamp, is_input=True)
+        messages = []
 
         # Find all prompt content attributes and their roles
         prompt_content_matches = {}
@@ -365,59 +398,37 @@ class LLOHandler:
                 index = match.group(1)
                 role_key = f"gen_ai.prompt.{index}.role"
                 role = attributes.get(role_key, "unknown")
-                prompt_content_matches[index] = (key, value, role)
+                prompt_content_matches[index] = (value, role)
 
-        # Create events for each content+role pair
-        for index, (key, value, role) in prompt_content_matches.items():
-            event_attributes = {"gen_ai.system": gen_ai_system, "original_attribute": key}
-            body = {"content": value, "role": role}
+        # Create message dictionaries for each content+role pair
+        # Sort by index to maintain order
+        for index in sorted(prompt_content_matches.keys(), key=int):
+            value, role = prompt_content_matches[index]
+            messages.append({"content": value, "role": role})
 
-            # Use helper method to determine event name based on role
-            event_name = self._get_event_name_for_role(role, gen_ai_system)
+        return messages
 
-            event = self._get_gen_ai_event(
-                name=event_name,
-                span_ctx=span_ctx,
-                timestamp=prompt_timestamp,
-                attributes=event_attributes,
-                body=body,
-            )
-
-            events.append(event)
-
-        return events
-
-    def _extract_gen_ai_completion_events(
-        self, span: ReadableSpan, attributes: Dict[str, Any], event_timestamp: Optional[int] = None
-    ) -> List[Event]:
+    def _collect_gen_ai_completion_messages(
+        self, span: ReadableSpan, attributes: Dict[str, Any]
+    ) -> List[Dict[str, Any]]:
         """
-        Extract Gen AI Events from structured completion attributes.
+        Collect message dictionaries from structured completion attributes.
 
         Processes attributes matching the pattern `gen_ai.completion.{n}.content` and their
-        associated `gen_ai.completion.{n}.role` attributes to create appropriate events.
-
-        Event types are determined by the role:
-        1. `assistant` → `gen_ai.assistant.message` Event (most common)
-        2. Other roles → `gen_ai.{gen_ai.system}.message` custom Event
+        associated `gen_ai.completion.{n}.role` attributes to create message dictionaries.
 
         Args:
             span: The source ReadableSpan containing the attributes
             attributes: Dictionary of attributes to process
-            event_timestamp: Optional timestamp to override span.end_time
 
         Returns:
-            List[Event]: Events created from completion attributes
+            List[Dict[str, Any]]: List of message dictionaries with 'content' and 'role' keys
         """
         # Quick check if any completion content attributes exist
         if not any(self._completion_content_pattern.match(key) for key in attributes):
             return []
 
-        events = []
-        span_ctx = span.context
-        gen_ai_system = span.attributes.get("gen_ai.system", "unknown")
-
-        # Use helper method to get appropriate timestamp (completions are outputs)
-        completion_timestamp = self._get_timestamp(span, event_timestamp, is_input=False)
+        messages = []
 
         # Find all completion content attributes and their roles
         completion_content_matches = {}
@@ -427,54 +438,32 @@ class LLOHandler:
                 index = match.group(1)
                 role_key = f"gen_ai.completion.{index}.role"
                 role = attributes.get(role_key, "unknown")
-                completion_content_matches[index] = (key, value, role)
+                completion_content_matches[index] = (value, role)
 
-        # Create events for each content+role pair
-        for index, (key, value, role) in completion_content_matches.items():
-            event_attributes = {"gen_ai.system": gen_ai_system, "original_attribute": key}
-            body = {"content": value, "role": role}
+        # Create message dictionaries for each content+role pair
+        # Sort by index to maintain order
+        for index in sorted(completion_content_matches.keys(), key=int):
+            value, role = completion_content_matches[index]
+            messages.append({"content": value, "role": role})
 
-            # Use helper method to determine event name based on role
-            event_name = self._get_event_name_for_role(role, gen_ai_system)
+        return messages
 
-            event = self._get_gen_ai_event(
-                name=event_name,
-                span_ctx=span_ctx,
-                timestamp=completion_timestamp,
-                attributes=event_attributes,
-                body=body,
-            )
-
-            events.append(event)
-
-        return events
-
-    def _extract_traceloop_events(
-        self, span: ReadableSpan, attributes: Dict[str, Any], event_timestamp: Optional[int] = None
-    ) -> List[Event]:
+    def _collect_traceloop_messages(self, span: ReadableSpan, attributes: Dict[str, Any]) -> List[Dict[str, Any]]:
         """
-        Extract Gen AI Events from Traceloop attributes.
+        Collect message dictionaries from Traceloop attributes.
 
         Processes Traceloop-specific attributes:
-        - `traceloop.entity.input`: Input data (uses span.start_time)
-        - `traceloop.entity.output`: Output data (uses span.end_time)
-        - `traceloop.entity.name`: Used as the gen_ai.system value when gen_ai.system isn't available
-        - `crewai.crew.tasks_output`: Tasks output data from CrewAI (uses span.end_time)
-        - `crewai.crew.result`: Final result from CrewAI crew (uses span.end_time)
-
-        Creates generic `gen_ai.{entity_name}.message` events for both input and output,
-        and assistant message events for CrewAI outputs.
-
-        For CrewAI-specific attributes (crewai.crew.tasks_output and crewai.crew.result),
-        uses span's gen_ai.system attribute if available, otherwise falls back to traceloop.entity.name.
+        - `traceloop.entity.input`: Input data (role: user)
+        - `traceloop.entity.output`: Output data (role: assistant)
+        - `crewai.crew.tasks_output`: Tasks output data from CrewAI (role: assistant)
+        - `crewai.crew.result`: Final result from CrewAI crew (role: assistant)
 
         Args:
             span: The source ReadableSpan containing the attributes
             attributes: Dictionary of attributes to process
-            event_timestamp: Optional timestamp to override span timestamps
 
         Returns:
-            List[Event]: Events created from Traceloop attributes
+            List[Dict[str, Any]]: List of message dictionaries with 'content' and 'role' keys
         """
         # Define the Traceloop attributes we're looking for
         traceloop_keys = {
@@ -488,89 +477,47 @@ class LLOHandler:
         if not any(key in attributes for key in traceloop_keys):
             return []
 
-        events = []
-        span_ctx = span.context
-        # Use traceloop.entity.name for the gen_ai.system value
-        gen_ai_system = span.attributes.get("traceloop.entity.name", "unknown")
-
-        # Use helper methods to get appropriate timestamps
-        input_timestamp = self._get_timestamp(span, event_timestamp, is_input=True)
-        output_timestamp = self._get_timestamp(span, event_timestamp, is_input=False)
+        messages = []
 
         # Standard Traceloop entity attributes
         traceloop_attrs = [
-            (TRACELOOP_ENTITY_INPUT, input_timestamp, ROLE_USER),  # Treat input as user role
-            (TRACELOOP_ENTITY_OUTPUT, output_timestamp, ROLE_ASSISTANT),  # Treat output as assistant role
+            (TRACELOOP_ENTITY_INPUT, ROLE_USER),  # Treat input as user role
+            (TRACELOOP_ENTITY_OUTPUT, ROLE_ASSISTANT),  # Treat output as assistant role
         ]
 
-        for attr_key, timestamp, role in traceloop_attrs:
+        for attr_key, role in traceloop_attrs:
             if attr_key in attributes:
-                event_attributes = {"gen_ai.system": gen_ai_system, "original_attribute": attr_key}
-                body = {"content": attributes[attr_key], "role": role}
-
-                # Custom event name for Traceloop (always use system-specific format)
-                event_name = f"gen_ai.{gen_ai_system}.message"
-
-                event = self._get_gen_ai_event(
-                    name=event_name,
-                    span_ctx=span_ctx,
-                    timestamp=timestamp,
-                    attributes=event_attributes,
-                    body=body,
-                )
-                events.append(event)
+                messages.append({"content": attributes[attr_key], "role": role})
 
         # CrewAI-specific Traceloop attributes
-        # For CrewAI attributes, prefer gen_ai.system if available, otherwise use traceloop.entity.name
-        crewai_gen_ai_system = span.attributes.get("gen_ai.system", gen_ai_system)
-
         crewai_attrs = [
-            (TRACELOOP_CREW_TASKS_OUTPUT, output_timestamp, ROLE_ASSISTANT),
-            (TRACELOOP_CREW_RESULT, output_timestamp, ROLE_ASSISTANT),
+            (TRACELOOP_CREW_TASKS_OUTPUT, ROLE_ASSISTANT),
+            (TRACELOOP_CREW_RESULT, ROLE_ASSISTANT),
         ]
 
-        for attr_key, timestamp, role in crewai_attrs:
+        for attr_key, role in crewai_attrs:
             if attr_key in attributes:
-                event_attributes = {"gen_ai.system": crewai_gen_ai_system, "original_attribute": attr_key}
-                body = {"content": attributes[attr_key], "role": role}
+                messages.append({"content": attributes[attr_key], "role": role})
 
-                # For CrewAI outputs, use the assistant message event
-                event_name = GEN_AI_ASSISTANT_MESSAGE
+        return messages
 
-                event = self._get_gen_ai_event(
-                    name=event_name,
-                    span_ctx=span_ctx,
-                    timestamp=timestamp,
-                    attributes=event_attributes,
-                    body=body,
-                )
-                events.append(event)
-
-        return events
-
-    def _extract_openlit_span_event_attributes(
-        self, span: ReadableSpan, attributes: Dict[str, Any], event_timestamp: Optional[int] = None
-    ) -> List[Event]:
+    def _collect_openlit_messages(self, span: ReadableSpan, attributes: Dict[str, Any]) -> List[Dict[str, Any]]:
         """
-        Extract Gen AI Events from OpenLit direct attributes.
+        Collect message dictionaries from OpenLit direct attributes.
 
         OpenLit uses direct key-value pairs for LLO attributes:
         - `gen_ai.prompt`: Direct prompt text (treated as user message)
         - `gen_ai.completion`: Direct completion text (treated as assistant message)
         - `gen_ai.content.revised_prompt`: Revised prompt text (treated as system message)
         - `gen_ai.agent.actual_output`: Output from CrewAI agent (treated as assistant message)
-
-        The event timestamps are set based on attribute type:
-        - Prompt and revised prompt: span.start_time
-        - Completion and agent output: span.end_time
+        - `gen_ai.agent.human_input`: Human input to agent (treated as user message)
 
         Args:
             span: The source ReadableSpan containing the attributes
             attributes: Dictionary of attributes to process
-            event_timestamp: Optional timestamp to override span timestamps
 
         Returns:
-            List[Event]: Events created from OpenLit attributes
+            List[Dict[str, Any]]: List of message dictionaries with 'content' and 'role' keys
         """
         # Define the OpenLit attributes we're looking for
         openlit_keys = {
@@ -585,55 +532,25 @@ class LLOHandler:
         if not any(key in attributes for key in openlit_keys):
             return []
 
-        events = []
-        span_ctx = span.context
-        gen_ai_system = span.attributes.get("gen_ai.system", "unknown")
+        messages = []
 
-        # Use helper methods to get appropriate timestamps
-        prompt_timestamp = self._get_timestamp(span, event_timestamp, is_input=True)
-        completion_timestamp = self._get_timestamp(span, event_timestamp, is_input=False)
-
-        openlit_event_attrs = [
-            (OPENLIT_PROMPT, prompt_timestamp, ROLE_USER),  # Assume user role for direct prompts
-            (OPENLIT_COMPLETION, completion_timestamp, ROLE_ASSISTANT),  # Assume assistant role for completions
-            (OPENLIT_REVISED_PROMPT, prompt_timestamp, ROLE_SYSTEM),  # Assume system role for revised prompts
-            (
-                OPENLIT_AGENT_ACTUAL_OUTPUT,
-                completion_timestamp,
-                ROLE_ASSISTANT,
-            ),  # Assume assistant role for agent output
-            (
-                OPENLIT_AGENT_HUMAN_INPUT,
-                prompt_timestamp,
-                ROLE_USER,
-            ),  # Assume user role for agent human input
+        openlit_attrs = [
+            (OPENLIT_PROMPT, ROLE_USER),  # Assume user role for direct prompts
+            (OPENLIT_COMPLETION, ROLE_ASSISTANT),  # Assume assistant role for completions
+            (OPENLIT_REVISED_PROMPT, ROLE_SYSTEM),  # Assume system role for revised prompts
+            (OPENLIT_AGENT_ACTUAL_OUTPUT, ROLE_ASSISTANT),  # Assume assistant role for agent output
+            (OPENLIT_AGENT_HUMAN_INPUT, ROLE_USER),  # Assume user role for agent human input
         ]
 
-        for attr_key, timestamp, role in openlit_event_attrs:
+        for attr_key, role in openlit_attrs:
             if attr_key in attributes:
-                event_attributes = {"gen_ai.system": gen_ai_system, "original_attribute": attr_key}
-                body = {"content": attributes[attr_key], "role": role}
+                messages.append({"content": attributes[attr_key], "role": role})
 
-                # Use helper method to determine event name based on role
-                event_name = self._get_event_name_for_role(role, gen_ai_system)
+        return messages
 
-                event = self._get_gen_ai_event(
-                    name=event_name,
-                    span_ctx=span_ctx,
-                    timestamp=timestamp,
-                    attributes=event_attributes,
-                    body=body,
-                )
-
-                events.append(event)
-
-        return events
-
-    def _extract_openinference_attributes(
-        self, span: ReadableSpan, attributes: Dict[str, Any], event_timestamp: Optional[int] = None
-    ) -> List[Event]:
+    def _collect_openinference_messages(self, span: ReadableSpan, attributes: Dict[str, Any]) -> List[Dict[str, Any]]:
         """
-        Extract Gen AI Events from OpenInference attributes.
+        Collect message dictionaries from OpenInference attributes.
 
         OpenInference uses two patterns for LLO attributes:
         1. Direct values:
@@ -646,20 +563,12 @@ class LLOHandler:
            - `llm.output_messages.{n}.message.content`: Individual output messages
            - `llm.output_messages.{n}.message.role`: Role for output message
 
-        The LLM model name is extracted from the `llm.model_name` attribute
-        instead of `gen_ai.system` which other frameworks use.
-
-        Event timestamps are set based on message type:
-        - Input messages: span.start_time
-        - Output messages: span.end_time
-
         Args:
             span: The source ReadableSpan containing the attributes
             attributes: Dictionary of attributes to process
-            event_timestamp: Optional timestamp to override span timestamps
 
         Returns:
-            List[Event]: Events created from OpenInference attributes
+            List[Dict[str, Any]]: List of message dictionaries with 'content' and 'role' keys
         """
         # Define the OpenInference keys/patterns we're looking for
         openinference_direct_keys = {OPENINFERENCE_INPUT_VALUE, OPENINFERENCE_OUTPUT_VALUE}
@@ -672,33 +581,17 @@ class LLOHandler:
         if not (has_direct_attrs or has_input_msgs or has_output_msgs):
             return []
 
-        events = []
-        span_ctx = span.context
-        gen_ai_system = span.attributes.get("llm.model_name", "unknown")
-
-        # Use helper methods to get appropriate timestamps
-        input_timestamp = self._get_timestamp(span, event_timestamp, is_input=True)
-        output_timestamp = self._get_timestamp(span, event_timestamp, is_input=False)
+        messages = []
 
         # Process direct value attributes
         openinference_direct_attrs = [
-            (OPENINFERENCE_INPUT_VALUE, input_timestamp, ROLE_USER),
-            (OPENINFERENCE_OUTPUT_VALUE, output_timestamp, ROLE_ASSISTANT),
+            (OPENINFERENCE_INPUT_VALUE, ROLE_USER),
+            (OPENINFERENCE_OUTPUT_VALUE, ROLE_ASSISTANT),
         ]
 
-        for attr_key, timestamp, role in openinference_direct_attrs:
+        for attr_key, role in openinference_direct_attrs:
             if attr_key in attributes:
-                event_attributes = {"gen_ai.system": gen_ai_system, "original_attribute": attr_key}
-                body = {"content": attributes[attr_key], "role": role}
-
-                # Use helper method to determine event name based on role
-                event_name = self._get_event_name_for_role(role, gen_ai_system)
-
-                event = self._get_gen_ai_event(
-                    name=event_name, span_ctx=span_ctx, timestamp=timestamp, attributes=event_attributes, body=body
-                )
-
-                events.append(event)
+                messages.append({"content": attributes[attr_key], "role": role})
 
         # Process input messages
         input_messages = {}
@@ -708,21 +601,12 @@ class LLOHandler:
                 index = match.group(1)
                 role_key = f"llm.input_messages.{index}.message.role"
                 role = attributes.get(role_key, ROLE_USER)  # Default to user if role not specified
-                input_messages[index] = (key, value, role)
+                input_messages[index] = (value, role)
 
-        # Create events for input messages
-        for index, (key, value, role) in input_messages.items():
-            event_attributes = {"gen_ai.system": gen_ai_system, "original_attribute": key}
-            body = {"content": value, "role": role}
-
-            # Use helper method to determine event name based on role
-            event_name = self._get_event_name_for_role(role, gen_ai_system)
-
-            event = self._get_gen_ai_event(
-                name=event_name, span_ctx=span_ctx, timestamp=input_timestamp, attributes=event_attributes, body=body
-            )
-
-            events.append(event)
+        # Create messages for input messages (sorted by index)
+        for index in sorted(input_messages.keys(), key=int):
+            value, role = input_messages[index]
+            messages.append({"content": value, "role": role})
 
         # Process output messages
         output_messages = {}
@@ -732,23 +616,14 @@ class LLOHandler:
                 index = match.group(1)
                 role_key = f"llm.output_messages.{index}.message.role"
                 role = attributes.get(role_key, ROLE_ASSISTANT)  # Default to assistant if role not specified
-                output_messages[index] = (key, value, role)
+                output_messages[index] = (value, role)
 
-        # Create events for output messages
-        for index, (key, value, role) in output_messages.items():
-            event_attributes = {"gen_ai.system": gen_ai_system, "original_attribute": key}
-            body = {"content": value, "role": role}
+        # Create messages for output messages (sorted by index)
+        for index in sorted(output_messages.keys(), key=int):
+            value, role = output_messages[index]
+            messages.append({"content": value, "role": role})
 
-            # Use helper method to determine event name based on role
-            event_name = self._get_event_name_for_role(role, gen_ai_system)
-
-            event = self._get_gen_ai_event(
-                name=event_name, span_ctx=span_ctx, timestamp=output_timestamp, attributes=event_attributes, body=body
-            )
-
-            events.append(event)
-
-        return events
+        return messages
 
     def _get_event_name_for_role(self, role: str, gen_ai_system: str) -> str:
         """


### PR DESCRIPTION
### What does this pull request do?
PoC for LLM I/O event emission in our ADOT SDK to emit a single consolidated event per span instead of multiple individual events per I/O attribute.

**Note:** The design is still in-progress and in-review with CWL team.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

