### PR TITLE
Add Additional Defaults for Genesis ADOT SDK

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
@@ -68,6 +68,21 @@ class AwsOpenTelemetryDistro(OpenTelemetryDistro):
             # Set GenAI capture content default
             os.environ.setdefault("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "true")
 
+            # Set sampler default
+            os.environ.setdefault("OTEL_TRACES_SAMPLER", "parentbased_always_on")
+
+            # Set disabled instrumentations default
+            os.environ.setdefault(
+                "OTEL_PYTHON_DISABLED_INSTRUMENTATIONS",
+                "http,sqlalchemy,psycopg2,pymysql,sqlite3,aiopg,asyncpg,mysql_connector,botocore,boto3,urllib3,requests,starlette",
+            )
+
+            # Set logging auto instrumentation default
+            os.environ.setdefault("OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED", "true")
+
+            # Disable AWS Application Signals by default
+            os.environ.setdefault("OTEL_AWS_APPLICATION_SIGNALS_ENABLED", "false")
+
             # Set OTLP endpoints with AWS region if not already set
             region = get_aws_region()
             if region:

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelemetry_distro.py
@@ -74,3 +74,84 @@ class TestAwsOpenTelemetryDistro(TestCase):
         self.assertEqual(
             os.environ.get("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"), "https://logs.us-west-2.amazonaws.com/v1/logs"
         )
+
+    @patch("amazon.opentelemetry.distro.aws_opentelemetry_distro.get_aws_region")
+    def test_agent_observability_all_defaults(self, mock_get_aws_region):
+        # Set up mock to return a valid region
+        mock_get_aws_region.return_value = "us-east-1"
+
+        # Enable agent observability
+        os.environ["AGENT_OBSERVABILITY_ENABLED"] = "true"
+
+        # Clear any pre-existing settings to test defaults
+        keys_to_clear = [
+            "OTEL_TRACES_EXPORTER",
+            "OTEL_LOGS_EXPORTER",
+            "OTEL_METRICS_EXPORTER",
+            "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT",
+            "OTEL_TRACES_SAMPLER",
+            "OTEL_PYTHON_DISABLED_INSTRUMENTATIONS",
+            "OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED",
+            "OTEL_AWS_APPLICATION_SIGNALS_ENABLED",
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+            "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+        ]
+        for key in keys_to_clear:
+            os.environ.pop(key, None)
+
+        # Create distro and configure
+        distro = AwsOpenTelemetryDistro()
+        distro._configure(apply_patches=False)
+
+        # Verify all defaults were set correctly
+        self.assertEqual(os.environ.get("OTEL_TRACES_EXPORTER"), "otlp")
+        self.assertEqual(os.environ.get("OTEL_LOGS_EXPORTER"), "otlp")
+        self.assertEqual(os.environ.get("OTEL_METRICS_EXPORTER"), "awsemf")
+        self.assertEqual(os.environ.get("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"), "true")
+        self.assertEqual(os.environ.get("OTEL_TRACES_SAMPLER"), "parentbased_always_on")
+        self.assertEqual(
+            os.environ.get("OTEL_PYTHON_DISABLED_INSTRUMENTATIONS"),
+            "http,sqlalchemy,psycopg2,pymysql,sqlite3,aiopg,asyncpg,mysql_connector,botocore,boto3,urllib3,requests,starlette",
+        )
+        self.assertEqual(os.environ.get("OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED"), "true")
+        self.assertEqual(os.environ.get("OTEL_AWS_APPLICATION_SIGNALS_ENABLED"), "false")
+        self.assertEqual(
+            os.environ.get("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"), "https://xray.us-east-1.amazonaws.com/v1/traces"
+        )
+        self.assertEqual(
+            os.environ.get("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"), "https://logs.us-east-1.amazonaws.com/v1/logs"
+        )
+
+    def test_agent_observability_disabled_respects_user_settings(self):
+        # Ensure agent observability is disabled
+        os.environ.pop("AGENT_OBSERVABILITY_ENABLED", None)
+
+        # Set custom values for some environment variables
+        os.environ["OTEL_TRACES_SAMPLER"] = "traceidratio"
+        os.environ["OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED"] = "false"
+
+        # Create distro and configure
+        distro = AwsOpenTelemetryDistro()
+        distro._configure(apply_patches=False)
+
+        # Verify user settings were not overridden
+        self.assertEqual(os.environ.get("OTEL_TRACES_SAMPLER"), "traceidratio")
+        self.assertEqual(os.environ.get("OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED"), "false")
+
+    def test_agent_observability_enabled_respects_user_settings(self):
+        # Enable agent observability
+        os.environ["AGENT_OBSERVABILITY_ENABLED"] = "true"
+
+        # Set custom values for some environment variables
+        os.environ["OTEL_TRACES_SAMPLER"] = "traceidratio"
+        os.environ["OTEL_PYTHON_DISABLED_INSTRUMENTATIONS"] = "django,flask"
+        os.environ["OTEL_AWS_APPLICATION_SIGNALS_ENABLED"] = "true"
+
+        # Create distro and configure
+        distro = AwsOpenTelemetryDistro()
+        distro._configure(apply_patches=False)
+
+        # Verify user settings were not overridden
+        self.assertEqual(os.environ.get("OTEL_TRACES_SAMPLER"), "traceidratio")
+        self.assertEqual(os.environ.get("OTEL_PYTHON_DISABLED_INSTRUMENTATIONS"), "django,flask")
+        self.assertEqual(os.environ.get("OTEL_AWS_APPLICATION_SIGNALS_ENABLED"), "true")


### PR DESCRIPTION
## What does this pull request do?
Adds additional defaults for the following env vars to streamline Genesis ADOT SDK enablement experience:
- `OTEL_TRACES_SAMPLER`
- `OTEL_PYTHON_DISABLED_INSTRUMENTATIONS`
- `OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED`
- `OTEL_AWS_APPLICATION_SIGNALS_ENABLED`

## Test strategy
Tested e2e data flow with this run command to validate defaults:
```
docker run -p 8000:8000 \
             -e "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
             -e "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
             -e "AWS_REGION=$AWS_REGION" \
             -e "OTEL_PYTHON_DISTRO=aws_distro" \
             -e "OTEL_PYTHON_CONFIGURATOR=aws_configurator" \
             -e "OTEL_RESOURCE_ATTRIBUTES=service.name=ticketing-agent,aws.log.group.names=test/genesis,cloud.resource_id=agent_arn" \
             -e "OTEL_EXPORTER_OTLP_LOGS_HEADERS=x-aws-log-group=test/genesis,x-aws-log-stream=default,x-aws-metric-namespace=genesis" \
             -e "AGENT_OBSERVABILITY_ENABLED=true" \
             genesis-poc
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

