### PR TITLE
Update to Dockerfile to Use Rust 1.87

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN sed -i "/opentelemetry-exporter-otlp-proto-grpc/d" ./aws-opentelemetry-distr
 RUN mkdir workspace && pip install --target workspace ./aws-opentelemetry-distro
 
 # Stage 2: Build the cp-utility binary
-FROM public.ecr.aws/docker/library/rust:1.82 as builder
+FROM public.ecr.aws/docker/library/rust:1.87 as builder
 
 WORKDIR /usr/src/cp-utility
 COPY ./tools/cp-utility .


### PR DESCRIPTION
## What does this pull request do?
Updates the Rust version used in our Dockerfile to support `edition2024`. At least [1.85 is required](https://doc.rust-lang.org/edition-guide/rust-2024/index.html), so went ahead and bumped to latest available version 1.87.

```
#16 3.449 error: failed to compile `cargo-audit v0.21.2`, intermediate artifacts can be found at `/tmp/cargo-installyA5rTL`.
#16 3.449 To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
#16 3.449 
#16 3.449 Caused by:
#16 3.449   failed to parse manifest at `/usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/cvss-2.1.0/Cargo.toml`
#16 3.449 
#16 3.449 Caused by:
#16 3.449   feature `edition2024` is required
#16 3.449 
#16 3.449   The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.82.0 (8f40fc59f 2024-08-21)).
#16 3.449   Consider trying a newer version of Cargo (this may require the nightly release).
#16 3.449   See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.
#16 ERROR: process "/bin/sh -c if [ $TARGETARCH = \"amd64\" ]; then cargo install cargo-audit && cargo audit ; fi" did not complete successfully: exit code: 101
```




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

