### PR TITLE
Remove dependency calls from EmfExporter init

### DIFF
--- a/aws-opentelemetry-distro/pyproject.toml
+++ b/aws-opentelemetry-distro/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
   "opentelemetry-sdk-extension-aws == 2.0.2",
   "opentelemetry-propagator-aws-xray == 1.0.1",
   "opentelemetry-distro == 0.54b0",
+  "opentelemetry-processor-baggage == 0.54b0",
   "opentelemetry-propagator-ot-trace == 0.54b0",
   "opentelemetry-instrumentation == 0.54b0",
   "opentelemetry-instrumentation-aws-lambda == 0.54b0",

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
@@ -35,6 +35,7 @@ from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
 from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter as OTLPHttpOTLPMetricExporter
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.metrics import set_meter_provider
+from opentelemetry.processor.baggage import BaggageSpanProcessor
 from opentelemetry.sdk._configuration import (
     _get_exporter_names,
     _get_id_generator,
@@ -425,6 +426,15 @@ def _customize_span_processors(provider: TracerProvider, resource: Resource) -> 
     # Add LambdaSpanProcessor to list of processors regardless of application signals.
     if _is_lambda_environment():
         provider.add_span_processor(AwsLambdaSpanProcessor())
+
+    # Add session.id baggage attribute to span attributes to support AI Agent use cases
+    # enabling session ID tracking in spans.
+    if is_agent_observability_enabled():
+
+        def session_id_predicate(baggage_key: str) -> bool:
+            return baggage_key == "session.id"
+
+        provider.add_span_processor(BaggageSpanProcessor(session_id_predicate))
 
     if not _is_application_signals_enabled():
         return


### PR DESCRIPTION
*Issue #, if available:*
1. Move CW Log group creation initialization phase to lazy creation, so it will not potential fail application and align with OTel Collector EMF exporter behavor
2. Add Baggage support in beta version



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

