### PR TITLE
Fix log race condition

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/exporter/otlp/aws/logs/aws_batch_log_record_processor.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/exporter/otlp/aws/logs/aws_batch_log_record_processor.py
@@ -165,3 +165,12 @@ class AwsBatchLogRecordProcessor(BatchLogRecordProcessor):
         }
 
         return log.instrumentation_scope.name in gen_ai_instrumentations
+    
+    # Only export the logs once to avoid the race condition of the worker thread and force flush thread
+    # https://github.com/open-telemetry/opentelemetry-python/issues/3193
+    # https://github.com/open-telemetry/opentelemetry-python/blob/main/opentelemetry-sdk/src/opentelemetry/sdk/_shared_internal/__init__.py#L199
+    def force_flush(self, timeout_millis: Optional[int] = None) -> bool:
+        if self._shutdown:
+            return False 
+        self._export(BatchLogExportStrategy.EXPORT_AT_LEAST_ONE_BATCH)
+        return True


### PR DESCRIPTION
*Issue #, if available:*
It is an existing issue from upstream that only exists in certain cases
1. Application using [ASGI](https://asgi.readthedocs.io/en/latest/) framework like FastAPI, it will always fork another thread from main thread to handle the traffic
2. Application has tried to log something during the initialization phase and failed.

This explains all our confusions thatWhy it happens only on FastAPI application but not Flask in our test, because the latter one is not a ASGI framework It happens on TraceLoop SDK but not in OpenLLMetry, because TraceLoop will log a warning message during initialization but the latter one does not 

*Fixes:*
The race condition is cause because the default LogProcessor using trying to export data with a blocking call, which blocked the worker thread in ASGI framework. I am changing it to non-blocking call so it will not run into race condition issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

