### PR TITLE
Update tox.ini to match the supported python versions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ skipsdist = True
 skip_missing_interpreters = True
 envlist =
     ; aws-opentelemetry-distro
-    3.{7,8,9,10,11}-test-aws-opentelemetry-distro
+    3.{9,10,11,12,13}-test-aws-opentelemetry-distro
     ; intentionally excluded from pypy3 since we use grpc in aws-opentelemetry-distro, but pypy3 doesn't support grpc
 
     lint
@@ -26,7 +26,7 @@ changedir =
 
 commands_pre =
 ; Install without -e to test the actual installation
-  3.{7,8,9,10,11}: python -m pip install -U pip setuptools wheel
+  3.{9,10,11,12,13}: python -m pip install -U pip setuptools wheel
 ; Install common packages for all the tests. These are not needed in all the
 ; cases but it saves a lot of boilerplate in this file.
   test: pip install botocore


### PR DESCRIPTION
The tox.ini file was missed in this update: https://github.com/aws-observability/aws-otel-python-instrumentation/commit/779e89b586bc9caf4a41d2a118a398d1a47975db


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

