### PR TITLE
Add Gen AI release test to main build

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -238,3 +238,12 @@ jobs:
     with:
       caller-workflow-name: 'main-build'
       staging-wheel-name: ${{ inputs.staging-wheel-name }}
+  
+  # Stand-Alone ADOT/ADOT Gen AI test on EC2
+  adot-genai:
+    needs: [ upload-main-build ]
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-ec2-genai-test.yml@main
+    secrets: inherit
+    with:
+      caller-workflow-name: 'main-build'
+      staging-wheel-name: ${{ inputs.staging-wheel-name }}

--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -240,7 +240,7 @@ jobs:
       staging-wheel-name: ${{ inputs.staging-wheel-name }}
   
   # Stand-Alone ADOT/ADOT Genesis test on EC2
-  adot-genai:
+  adot-genesis:
     needs: [ upload-main-build ]
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-ec2-genesis-test.yml@main
     secrets: inherit

--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -242,7 +242,7 @@ jobs:
   # Stand-Alone ADOT/ADOT Gen AI test on EC2
   adot-genai:
     needs: [ upload-main-build ]
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-ec2-genai-test.yml@main
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-ec2-genesis-test.yml@main
     secrets: inherit
     with:
       caller-workflow-name: 'main-build'

--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -239,7 +239,7 @@ jobs:
       caller-workflow-name: 'main-build'
       staging-wheel-name: ${{ inputs.staging-wheel-name }}
   
-  # Stand-Alone ADOT/ADOT Gen AI test on EC2
+  # Stand-Alone ADOT/ADOT Genesis test on EC2
   adot-genai:
     needs: [ upload-main-build ]
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-ec2-genesis-test.yml@main


### PR DESCRIPTION
*Description of changes:*
Adding Gen AI release test to main build, follow up to:

https://github.com/aws-observability/aws-application-signals-test-framework/pull/425
https://github.com/aws-observability/aws-application-signals-test-framework/pull/426


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

