### PR TITLE
Fix EMF exporter to generate EMF metrics with dimension empty

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/exporter/aws/metrics/aws_cloudwatch_emf_exporter.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/exporter/aws/metrics/aws_cloudwatch_emf_exporter.py
@@ -509,11 +509,13 @@ class AwsCloudWatchEmfExporter(MetricExporter):
         for name, value in all_attributes.items():
             emf_log[name] = str(value)
 
-        # Add the single dimension set to CloudWatch Metrics if we have dimensions and metrics
-        if dimension_names and metric_definitions:
-            emf_log["_aws"]["CloudWatchMetrics"].append(
-                {"Namespace": self.namespace, "Dimensions": [dimension_names], "Metrics": metric_definitions}
-            )
+        # Add CloudWatch Metrics if we have metrics, include dimensions only if they exist
+        if metric_definitions:
+            cloudwatch_metric = {"Namespace": self.namespace, "Metrics": metric_definitions}
+            if dimension_names:
+                cloudwatch_metric["Dimensions"] = [dimension_names]
+
+            emf_log["_aws"]["CloudWatchMetrics"].append(cloudwatch_metric)
 
         return emf_log
 


### PR DESCRIPTION
*Description of changes:*
* Populate the correct `CloudWatchMetrics` in EMF when metrics has empty dimension list

*Test*
```
{
    "_aws": {
        "Timestamp": 1753139679038,
        "CloudWatchMetrics": [
            {
                "Namespace": "MyApplication1",
                "Metrics": [
                    {
                        "Name": "system_cpu_usage_percent",
                        "Unit": "Percent"
                    },
                    {
                        "Name": "http_request_duration_seconds",
                        "Unit": "Seconds"
                    }
                ]
            }
        ]
    },
    "Version": "1",
    "otel.resource.telemetry.sdk.language": "python",
    "otel.resource.telemetry.sdk.name": "opentelemetry",
    "otel.resource.telemetry.sdk.version": "1.33.1",
    "otel.resource.service.name": "my-service",
    "otel.resource.service.version": "0.1.0",
    "otel.resource.deployment.environment": "production",
    "system_cpu_usage_percent": 0.2,
    "http_request_duration_seconds": {
        "Values": [
            0.39614037455626866,
            0.4866507397084614
        ],
        "Counts": [
            1,
            1
        ],
        "Count": 2,
        "Sum": 0.8848342305738114,
        "Max": 0.4877384525234254,
        "Min": 0.397095778050386
    }
}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

