### PR TITLE
Disable warning messages from OTel auto instrumentation

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
@@ -93,8 +93,6 @@ class AwsOpenTelemetryDistro(OpenTelemetryDistro):
         )
 
         if is_agent_observability_enabled():
-            # Disable unnecessary
-            _load._logger.setLevel(logging.ERROR)
             # "otlp" is already native OTel default, but we set them here to be explicit
             # about intended configuration for agent observability
             os.environ.setdefault(OTEL_TRACES_EXPORTER, "otlp")

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 import importlib
+import logging
 import os
 import sys
 from logging import Logger, getLogger
@@ -22,12 +23,15 @@ from amazon.opentelemetry.distro.patches._instrumentation_patch import apply_ins
 from opentelemetry import propagate
 from opentelemetry.distro import OpenTelemetryDistro
 from opentelemetry.environment_variables import OTEL_PROPAGATORS, OTEL_PYTHON_ID_GENERATOR
+from opentelemetry.instrumentation.auto_instrumentation import _load
 from opentelemetry.sdk.environment_variables import (
     OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION,
     OTEL_EXPORTER_OTLP_PROTOCOL,
 )
 
 _logger: Logger = getLogger(__name__)
+# Suppress configurator warnings from OpenTelemetry auto-instrumentation
+_load._logger.setLevel(logging.ERROR)
 
 
 class AwsOpenTelemetryDistro(OpenTelemetryDistro):
@@ -89,6 +93,8 @@ class AwsOpenTelemetryDistro(OpenTelemetryDistro):
         )
 
         if is_agent_observability_enabled():
+            # Disable unnecessary
+            _load._logger.setLevel(logging.ERROR)
             # "otlp" is already native OTel default, but we set them here to be explicit
             # about intended configuration for agent observability
             os.environ.setdefault(OTEL_TRACES_EXPORTER, "otlp")


### PR DESCRIPTION
*Description of changes:*
When setting `OTEL_PYTHON_CONFIGURATOR=aws_configurator`, users see a verbose warning message:

`Configuration of configurator not loaded because aws_configurator is set by OTEL_PYTHON_CONFIGURATOR`

These warnings appear when multiple OpenTelemetry configurators are installed (e.g., default upstream configurators alongside the AWS configurator). While the behavior is correct, the warnings create noise in application logs.

Disabling this log message from showing up by default.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

