### PR TITLE
Change _load logging to lowercase

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
@@ -23,6 +23,7 @@ from opentelemetry import propagate
 from opentelemetry.distro import OpenTelemetryDistro
 from opentelemetry.environment_variables import OTEL_PROPAGATORS, OTEL_PYTHON_ID_GENERATOR
 from opentelemetry.instrumentation.auto_instrumentation import _load
+from opentelemetry.instrumentation.logging import LEVELS
 from opentelemetry.instrumentation.logging.environment_variables import OTEL_PYTHON_LOG_LEVEL
 from opentelemetry.sdk.environment_variables import (
     OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION,
@@ -30,8 +31,8 @@ from opentelemetry.sdk.environment_variables import (
 )
 
 _logger: Logger = getLogger(__name__)
-# Suppress configurator warnings from OpenTelemetry auto-instrumentation
-_load._logger.setLevel(os.environ.get(OTEL_PYTHON_LOG_LEVEL, ERROR))
+# Suppress configurator warnings from auto-instrumentation
+_load._logger.setLevel(LEVELS.get(os.environ.get(OTEL_PYTHON_LOG_LEVEL, "error").lower(), ERROR))
 
 
 class AwsOpenTelemetryDistro(OpenTelemetryDistro):


### PR DESCRIPTION
*Description of changes:*
`OTEL_PYTHON_LOG_LEVEL` uses lowercase for log levels. Changing it to fix the uppercase only from this PR:
https://github.com/aws-observability/aws-otel-python-instrumentation/pull/449

**Testing this on Lambda (with default Lambda config setup)**:
<img width="1302" height="200" alt="image" src="https://github.com/user-attachments/assets/4b4070bf-90e6-48ae-a787-1dfee1072512" />
```
START RequestId: 0157a3c0-c584-49bc-b5ba-fd2008335b83 Version: $LATEST
END RequestId: 0157a3c0-c584-49bc-b5ba-fd2008335b83
REPORT RequestId: 0157a3c0-c584-49bc-b5ba-fd2008335b83	Duration: 230.96 ms	Billed Duration: 231 ms	Memory Size: 512 MB	Max Memory Used: 113 MB	Init Duration: 1416.80 ms	
XRAY TraceId: 1-689b663c-01c68093613ed19523fb9c6f	SegmentId: 76d15c82545c2530	Sampled: true	
```

**Testing this on Lambda (with modified Lambda config setup)**:
<img width="1378" height="264" alt="image" src="https://github.com/user-attachments/assets/66a75fb5-77af-49eb-bf23-ad65a4dbdb65" />
```
Configuration of configurator not loaded, aws_configurator already loaded
START RequestId: 16d4902c-527b-4edd-86ef-abd423da365d Version: $LATEST
END RequestId: 16d4902c-527b-4edd-86ef-abd423da365d
REPORT RequestId: 16d4902c-527b-4edd-86ef-abd423da365d	Duration: 166.12 ms	Billed Duration: 167 ms	Memory Size: 512 MB	Max Memory Used: 113 MB	Init Duration: 1467.68 ms	
XRAY TraceId: 1-689b6692-1ea1293937b97276187b0a71	SegmentId: d2ed420726a62b67	Sampled: true	
```

See: https://opentelemetry.io/docs/zero-code/python/configuration/#logging
For valid logging values.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

