### PR TITLE
Suppress `http receive/send` spans from Starlette Instrumentor for Agent Observability

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_instrumentation_patch.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_instrumentation_patch.py
@@ -67,7 +67,7 @@ def apply_instrumentation_patches() -> None:
         from amazon.opentelemetry.distro.patches._starlette_patches import _apply_starlette_instrumentation_patches
 
         # Starlette auto-instrumentation v0.54b includes a strict dependency version check
-        # This restriction was removed in v1.34.0/0.55b0. Applying temporary patch for Genesis launch
+        # This restriction was removed in v1.34.0/0.55b0. Applying temporary patch for Bedrock AgentCore launch
         # TODO: Remove patch after syncing with upstream v1.34.0 or later
         _apply_starlette_instrumentation_patches()
 

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_starlette_patches.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_starlette_patches.py
@@ -36,7 +36,8 @@ def _apply_starlette_instrumentation_patches() -> None:
         # this Middleware instrumentation is injected internally by Starlette Instrumentor, see:
         # https://github.com/open-telemetry/opentelemetry-python-contrib/blob/51da0a766e5d3cbc746189e10c9573163198cfcd/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py#L573
         #
-        # Issue for tracking a feature to customize this setting within Starlette: https://github.com/open-telemetry/opentelemetry-python-contrib/issues/3725
+        # Issue for tracking a feature to customize this setting within Starlette:
+        # https://github.com/open-telemetry/opentelemetry-python-contrib/issues/3725
         if is_agent_observability_enabled():
             original_init = OpenTelemetryMiddleware.__init__
 

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_starlette_patches.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_starlette_patches.py
@@ -31,6 +31,7 @@ def _apply_starlette_instrumentation_patches() -> None:
         # Apply the patch
         StarletteInstrumentor.instrumentation_dependencies = patched_instrumentation_dependencies
 
+        # pylint: disable=line-too-long
         # Patch to exclude http receive/send ASGI event spans from Bedrock AgentCore,
         # this Middleware instrumentation is injected internally by Starlette Instrumentor, see:
         # https://github.com/open-telemetry/opentelemetry-python-contrib/blob/51da0a766e5d3cbc746189e10c9573163198cfcd/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py#L573

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_starlette_patches.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_starlette_patches.py
@@ -4,7 +4,7 @@
 from logging import Logger, getLogger
 from typing import Collection
 
-from amazon.opentelemetry.distro._utils import AGENT_OBSERVABILITY_ENABLED
+from amazon.opentelemetry.distro._utils import is_agent_observability_enabled
 
 _logger: Logger = getLogger(__name__)
 
@@ -31,10 +31,12 @@ def _apply_starlette_instrumentation_patches() -> None:
         # Apply the patch
         StarletteInstrumentor.instrumentation_dependencies = patched_instrumentation_dependencies
 
-        # Patch to exclude http receive/send ASGI event spans, this Middleware instrumentation is injected
-        # internally by Starlette Instrumentor, see:
+        # Patch to exclude http receive/send ASGI event spans from Bedrock AgentCore,
+        # this Middleware instrumentation is injected internally by Starlette Instrumentor, see:
         # https://github.com/open-telemetry/opentelemetry-python-contrib/blob/51da0a766e5d3cbc746189e10c9573163198cfcd/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py#L573
-        if AGENT_OBSERVABILITY_ENABLED:
+        #
+        # Issue for tracking a feature to customize this setting within Starlette: https://github.com/open-telemetry/opentelemetry-python-contrib/issues/3725
+        if is_agent_observability_enabled():
             original_init = OpenTelemetryMiddleware.__init__
 
             def patched_init(self, app, **kwargs):

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_starlette_patches.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_starlette_patches.py
@@ -31,7 +31,7 @@ def _apply_starlette_instrumentation_patches() -> None:
         # Apply the patch
         StarletteInstrumentor.instrumentation_dependencies = patched_instrumentation_dependencies
 
-        # Patch to exclude http recieve/send ASGI event spans, this Middleware instrumentation is injected
+        # Patch to exclude http receive/send ASGI event spans, this Middleware instrumentation is injected
         # internally by Starlette Instrumentor, see:
         # https://github.com/open-telemetry/opentelemetry-python-contrib/blob/51da0a766e5d3cbc746189e10c9573163198cfcd/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py#L573
         if AGENT_OBSERVABILITY_ENABLED:

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/patches/test_starlette_patches.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/patches/test_starlette_patches.py
@@ -9,63 +9,66 @@ from amazon.opentelemetry.distro.patches._starlette_patches import _apply_starle
 class TestStarlettePatch(TestCase):
     """Test the Starlette instrumentation patches."""
 
-    @patch("amazon.opentelemetry.distro.patches._starlette_patches.AGENT_OBSERVABILITY_ENABLED", True)
     @patch("amazon.opentelemetry.distro.patches._starlette_patches._logger")
     def test_starlette_patch_applied_successfully(self, mock_logger):
         """Test that the Starlette instrumentation patch is applied successfully."""
-        # Create a mock StarletteInstrumentor class
-        mock_instrumentor_class = MagicMock()
-        mock_instrumentor_class.__name__ = "StarletteInstrumentor"
+        for agent_enabled in [True, False]:
+            with self.subTest(agent_enabled=agent_enabled):
+                with patch.dict("os.environ", {"AGENT_OBSERVABILITY_ENABLED": "true" if agent_enabled else "false"}):
+                    # Create a mock StarletteInstrumentor class
+                    mock_instrumentor_class = MagicMock()
+                    mock_instrumentor_class.__name__ = "StarletteInstrumentor"
 
-        class MockMiddleware:
-            def __init__(self, app, **kwargs):
-                pass
+                    def create_middleware_class():
+                        class MockMiddleware:
+                            def __init__(self, app, **kwargs):
+                                pass
 
-        mock_middleware_class = MockMiddleware
-        original_init = mock_middleware_class.__init__
+                        return MockMiddleware
 
-        # Create mock modules
-        mock_starlette_module = MagicMock()
-        mock_starlette_module.StarletteInstrumentor = mock_instrumentor_class
+                    mock_middleware_class = create_middleware_class()
 
-        mock_asgi_module = MagicMock()
-        mock_asgi_module.OpenTelemetryMiddleware = mock_middleware_class
+                    mock_starlette_module = MagicMock()
+                    mock_starlette_module.StarletteInstrumentor = mock_instrumentor_class
 
-        # Mock the imports
-        with patch.dict(
-            "sys.modules",
-            {
-                "opentelemetry.instrumentation.starlette": mock_starlette_module,
-                "opentelemetry.instrumentation.asgi": mock_asgi_module,
-            },
-        ):
-            # Apply the patch
-            _apply_starlette_instrumentation_patches()
+                    mock_asgi_module = MagicMock()
+                    mock_asgi_module.OpenTelemetryMiddleware = mock_middleware_class
 
-            # Verify the instrumentation_dependencies method was replaced
-            self.assertTrue(hasattr(mock_instrumentor_class, "instrumentation_dependencies"))
+                    with patch.dict(
+                        "sys.modules",
+                        {
+                            "opentelemetry.instrumentation.starlette": mock_starlette_module,
+                            "opentelemetry.instrumentation.asgi": mock_asgi_module,
+                        },
+                    ):
+                        # Apply the patch
+                        _apply_starlette_instrumentation_patches()
 
-            # Test the patched method returns the expected value
-            mock_instance = MagicMock()
-            result = mock_instrumentor_class.instrumentation_dependencies(mock_instance)
-            self.assertEqual(result, ("starlette >= 0.13",))
+                        # Verify the instrumentation_dependencies method was replaced
+                        self.assertTrue(hasattr(mock_instrumentor_class, "instrumentation_dependencies"))
 
-            self.assertNotEqual(mock_middleware_class.__init__, original_init)
+                        # Test the patched method returns the expected value
+                        mock_instance = MagicMock()
+                        result = mock_instrumentor_class.instrumentation_dependencies(mock_instance)
+                        self.assertEqual(result, ("starlette >= 0.13",))
 
-            # Test middleware patching sets exclude flags
-            mock_middleware_instance = MagicMock()
-            mock_middleware_instance.exclude_receive_span = False
-            mock_middleware_instance.exclude_send_span = False
+                        mock_middleware_instance = MagicMock()
+                        mock_middleware_instance.exclude_receive_span = False
+                        mock_middleware_instance.exclude_send_span = False
+                        mock_middleware_class.__init__(mock_middleware_instance, "app")
 
-            mock_middleware_class.__init__(mock_middleware_instance, "app")
+                        # Test middleware patching sets exclude flags
+                        if agent_enabled:
+                            self.assertTrue(mock_middleware_instance.exclude_receive_span)
+                            self.assertTrue(mock_middleware_instance.exclude_send_span)
+                        else:
+                            self.assertFalse(mock_middleware_instance.exclude_receive_span)
+                            self.assertFalse(mock_middleware_instance.exclude_send_span)
 
-            self.assertTrue(mock_middleware_instance.exclude_receive_span)
-            self.assertTrue(mock_middleware_instance.exclude_send_span)
-
-            # Verify logging
-            mock_logger.debug.assert_called_once_with(
-                "Successfully patched Starlette instrumentation_dependencies method"
-            )
+                        # Verify logging
+                        mock_logger.debug.assert_called_with(
+                            "Successfully patched Starlette instrumentation_dependencies method"
+                        )
 
     @patch("amazon.opentelemetry.distro.patches._starlette_patches._logger")
     def test_starlette_patch_handles_import_error(self, mock_logger):


### PR DESCRIPTION
*Description of changes:*
`Starlette Instrumentor` utilizes the `OpenTelemetryMiddleware` instrumentation to capture all events generated by [ASGI](https://asgi.readthedocs.io/en/latest/implementations.html#starlette) `Request received, Response headers sent (http.response.start), Response body sent (http.response.body)` which leads to a lot of span noises for streaming events: 
<img width="1149" height="595" alt="image" src="https://github.com/user-attachments/assets/8076586e-5e09-46cc-ba94-772d81a18824" />

Luckily, the upstream `OpenTelemetryMiddleware` provides a configuration in the constructor to suppress these instrumentations: https://github.com/open-telemetry/opentelemetry-python-contrib/blob/51da0a766e5d3cbc746189e10c9573163198cfcd/instrumentation/opentelemetry-instrumentation-asgi/src/opentelemetry/instrumentation/asgi/__init__.py#L573

Enabling this for Agent Observability to help filter out noise.
<img width="1685" height="481" alt="image" src="https://github.com/user-attachments/assets/e639969f-af2a-4559-bec7-c84962a243ad" />

Related issue for removing the need for this patch in the long term, using the proposed `OTEL_PYTHON_STARLETTE_EXCLUDED_SPANS` environment variable:
https://github.com/open-telemetry/opentelemetry-python-contrib/issues/3725

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

