### PR TITLE
Updating 3p actions using VersionID to CommitID

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -13,7 +13,7 @@ jobs:
   changelog-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #5.0.0
         with:
           fetch-depth: 0
           
@@ -54,7 +54,7 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Checkout Repo @ SHA - ${{ github.sha }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #5.0.0
 
       - name: Build Wheel and Image Files
         uses: ./.github/actions/artifacts_build
@@ -76,8 +76,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo @ SHA - ${{ github.sha }}
-        uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #5.0.0
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c #v6.0.0
         if: ${{ matrix.language == 'python' }}
         with:
           python-version: '3.x'
@@ -99,7 +99,7 @@ jobs:
         tox-environment: ["spellcheck", "lint"]
     steps:
       - name: Checkout Repo @ SHA - ${{ github.sha }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #5.0.0
 
       - name: Install libsnappy-dev
         if: ${{ matrix.tox-environment == 'lint' }}
@@ -120,19 +120,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo @ SHA - ${{ github.sha }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #5.0.0
 
       - name: Gradle validation
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/actions/wrapper-validation@ed408507eac070d1f99cc633dbcf757c94c7933a #4.4.3
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 #v4.0.3
         with:
           java-version: 17
           distribution: temurin
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/gradle-build-action@ed408507eac070d1f99cc633dbcf757c94c7933a #4.4.3
 
       - name: Build with Gradle
         run: cd performance-tests; ./gradlew spotlessCheck


### PR DESCRIPTION
This PR updates the 3P actions in pr-build using VersionID to CommitID.


References:
https://github.com/actions/checkout
https://github.com/actions/setup-python
https://github.com/gradle/actions/releases/
https://github.com/gradle/wrapper-validation-action
https://github.com/actions/setup-java


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

