### PR TITLE
Updating aws-otel-python-instrumentation VID to CSHA 2/2

### DIFF
--- a/.github/workflows/daily-scan.yml
+++ b/.github/workflows/daily-scan.yml
@@ -44,7 +44,7 @@ jobs:
           less aws-opentelemetry-distro/requirements.txt
 
       - name: Install java for dependency scan
-        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 #v4.7.1
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 #v5.0.0
         with:
           java-version: 17
           distribution: 'temurin'

--- a/.github/workflows/post-release-version-bump.yml
+++ b/.github/workflows/post-release-version-bump.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
         with:
           ref: main
           fetch-depth: 0
@@ -63,13 +63,13 @@ jobs:
     needs: check-version
     steps:
       - name: Configure AWS credentials for BOT secrets
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_SECRETS_MANAGER }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
       - name: Get Bot secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 #v2.0.10
         id: bot_secrets
         with:
           secret-ids: |
@@ -77,7 +77,7 @@ jobs:
           parse-json-secrets: true
 
       - name: Setup Git
-        uses: actions/checkout@v2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
         with:
           fetch-depth: 0
           token: ${{ env.BOT_TOKEN_GITHUB_RW_PATOKEN }}

--- a/.github/workflows/pre-release-prepare.yml
+++ b/.github/workflows/pre-release-prepare.yml
@@ -25,13 +25,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials for BOT secrets
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_SECRETS_MANAGER }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
       - name: Get Bot secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 #v2.0.10
         id: bot_secrets
         with:
           secret-ids: |
@@ -39,7 +39,7 @@ jobs:
           parse-json-secrets: true
 
       - name: Checkout main branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
         with:
           ref: 'main'
           token: ${{ env.BOT_TOKEN_GITHUB_RW_PATOKEN }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo @ SHA - ${{ github.sha }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
 
       - name: Check main build status
         env:
@@ -61,13 +61,13 @@ jobs:
       # https://github.com/aws-observability/aws-otel-java-instrumentation/tree/93870a550ac30988fbdd5d3bf1e8f9f1b37916f5/smoke-tests
 
       - name: Configure AWS credentials for PyPI secrets
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_SECRETS_MANAGER }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
       
       - name: Get PyPI secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 #v2.0.10
         id: pypi_secrets
         with:
           secret-ids: |
@@ -76,24 +76,24 @@ jobs:
           parse-json-secrets: true
 
       - name: Configure AWS credentials for private ECR
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_ECR_RELEASE }}
           aws-region: ${{ env.AWS_PRIVATE_ECR_REGION }}
 
       - name: Log in to AWS private ECR
-        uses: docker/login-action@v3
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 #v3.5.0
         with:
           registry: ${{ env.RELEASE_PRIVATE_REGISTRY }}
 
       - name: Configure AWS credentials for public ECR
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_ECR_RELEASE }}
           aws-region: ${{ env.AWS_PUBLIC_ECR_REGION }}
 
       - name: Log in to AWS public ECR
-        uses: docker/login-action@v3
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 #v3.5.0
         with:
           registry: public.ecr.aws
 
@@ -119,7 +119,7 @@ jobs:
 
       # Publish to public ECR
       - name: Build and push public ECR image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
         with:
           push: true
           context: .
@@ -130,7 +130,7 @@ jobs:
 
       # Publish to private ECR
       - name: Build and push private ECR image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
         with:
           push: true
           context: .

--- a/.github/workflows/release-lambda.yml
+++ b/.github/workflows/release-lambda.yml
@@ -40,8 +40,8 @@ jobs:
           echo ${MATRIX}
           echo "aws_regions_json=${MATRIX}" >> $GITHUB_OUTPUT
       - name: Checkout Repo @ SHA - ${{ github.sha }}
-        uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c #v6.0.0
         with:
           python-version: '3.x'
       - name: Build layers
@@ -51,7 +51,7 @@ jobs:
           pip install tox
           tox
       - name: upload layer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         with:
           name: layer.zip
           path: lambda-layer/src/build/aws-opentelemetry-python-layer.zip
@@ -83,7 +83,7 @@ jobs:
           fi
           SECRET_KEY=${SECRET_KEY//-/_}
           echo "SECRET_KEY=${SECRET_KEY}" >> $GITHUB_ENV
-      - uses: aws-actions/configure-aws-credentials@v4.0.2
+      - uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
         with:
           role-to-assume: ${{ secrets[env.SECRET_KEY] }}
           role-duration-seconds: 1200
@@ -92,7 +92,7 @@ jobs:
         run: |
           echo BUCKET_NAME=python-lambda-layer-${{ github.run_id }}-${{ matrix.aws_region }} | tee --append $GITHUB_ENV
       - name: download layer.zip
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
         with:
           name: layer.zip
       - name: publish
@@ -130,7 +130,7 @@ jobs:
             --action lambda:GetLayerVersion
       - name: upload layer arn artifact
         if: ${{ success() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         with:
           name: ${{ env.LAYER_NAME }}-${{ matrix.aws_region }}
           path: ${{ env.LAYER_NAME }}/${{ matrix.aws_region }}
@@ -143,10 +143,10 @@ jobs:
     needs: publish-prod
     steps:
       - name: Checkout Repo @ SHA - ${{ github.sha }}
-        uses: actions/checkout@v4
-      - uses: hashicorp/setup-terraform@v2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd #v3.1.2
       - name: download layerARNs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
         with:
           pattern: ${{ env.LAYER_NAME }}-*
           path: ${{ env.LAYER_NAME }}
@@ -195,7 +195,7 @@ jobs:
           echo "}" >> ../layer_cdk
           cat ../layer_cdk
       - name: download layer.zip
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
         with:
           name: layer.zip
       - name: Rename layer file


### PR DESCRIPTION
This pr updates all release files from Version ID tags on 3p actions to Commit SHA.

References:
https://github.com/actions/checkout
https://github.com/actions/setup-python
https://github.com/actions/setup-java
https://github.com/actions/cache
https://github.com/actions/upload-artifact
https://github.com/aws-actions/configure-aws-credentials  
https://github.com/actions/download-artifact
https://github.com/aws-actions/aws-secretsmanager-get-secrets
https://github.com/docker/login-action
https://github.com/docker/setup-buildx-action
https://github.com/docker/build-push-action
https://github.com/docker/setup-qemu-action
https://github.com/gradle/actions/blob/f8140229023a7015c7ce4df6f7c390a3cace8f83/docs/deprecation-upgrade-guide.md#using-the-action-to-execute-gradle-via-the-arguments-parameter-is-deprecated
https://github.com/github/codeql-action
https://github.com/hashicorp/setup-terraform

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

