### PR TITLE
support code attributes for starlette, fastapi, flask and aws lambda

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -24,3 +24,6 @@ exclude =
   mock_collector_service_pb2.py
   mock_collector_service_pb2.pyi
   mock_collector_service_pb2_grpc.py
+  lambda-layer/terraform/lambda/.terraform
+  lambda-layer/sample-apps/build
+  samples

--- a/.flake8
+++ b/.flake8
@@ -24,5 +24,3 @@ exclude =
   mock_collector_service_pb2.py
   mock_collector_service_pb2.pyi
   mock_collector_service_pb2_grpc.py
-  lambda-layer/terraform/lambda/.terraform
-  lambda-layer/sample-apps/build

--- a/.flake8
+++ b/.flake8
@@ -26,4 +26,3 @@ exclude =
   mock_collector_service_pb2_grpc.py
   lambda-layer/terraform/lambda/.terraform
   lambda-layer/sample-apps/build
-  samples

--- a/.pylintrc
+++ b/.pylintrc
@@ -7,7 +7,7 @@ extension-pkg-whitelist=cassandra
 
 # Add list of files or directories to be excluded. They should be base names, not
 # paths.
-ignore=CVS,gen,Dockerfile,docker-compose.yml,README.md,requirements.txt,mock_collector_service_pb2.py,mock_collector_service_pb2.pyi,mock_collector_service_pb2_grpc.py
+ignore=CVS,gen,Dockerfile,docker-compose.yml,README.md,requirements.txt,mock_collector_service_pb2.py,mock_collector_service_pb2.pyi,mock_collector_service_pb2_grpc.py,pyproject.toml,db.sqlite3
 
 # Add files or directories matching the regex patterns to be excluded. The
 # regex matches against base names, not paths.

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
@@ -616,7 +616,7 @@ def _is_application_signals_runtime_enabled():
     )
 
 
-def _get_code_correlation_enabled_status() -> Optional[bool]:
+def get_code_correlation_enabled_status() -> Optional[bool]:
     """
     Get the code correlation enabled status from environment variable.
 

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/code_correlation/__init__.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/code_correlation/__init__.py
@@ -21,7 +21,7 @@ CODE_FILE_PATH = "code.file.path"
 CODE_LINE_NUMBER = "code.line.number"
 
 
-def _add_code_attributes_to_span(span, func: Callable[..., Any]) -> None:
+def add_code_attributes_to_span(span, func: Callable[..., Any]) -> None:
     """
     Add code-related attributes to a span based on a Python function.
 
@@ -68,7 +68,7 @@ def _add_code_attributes_to_span(span, func: Callable[..., Any]) -> None:
         pass
 
 
-def add_code_attributes_to_span(func: Callable[..., Any]) -> Callable[..., Any]:
+def record_code_attributes(func: Callable[..., Any]) -> Callable[..., Any]:
     """
     Decorator to automatically add code attributes to the current OpenTelemetry span.
 
@@ -81,12 +81,12 @@ def add_code_attributes_to_span(func: Callable[..., Any]) -> Callable[..., Any]:
     This decorator supports both synchronous and asynchronous functions.
 
     Usage:
-        @add_code_attributes_to_span
+        @record_code_attributes
         def my_sync_function():
             # Sync function implementation
             pass
 
-        @add_code_attributes_to_span
+        @record_code_attributes
         async def my_async_function():
             # Async function implementation
             pass
@@ -109,7 +109,7 @@ def add_code_attributes_to_span(func: Callable[..., Any]) -> Callable[..., Any]:
             try:
                 current_span = trace.get_current_span()
                 if current_span:
-                    _add_code_attributes_to_span(current_span, func)
+                    add_code_attributes_to_span(current_span, func)
             except Exception:  # pylint: disable=broad-exception-caught
                 # Silently handle any unexpected errors
                 pass
@@ -126,7 +126,7 @@ def add_code_attributes_to_span(func: Callable[..., Any]) -> Callable[..., Any]:
         try:
             current_span = trace.get_current_span()
             if current_span:
-                _add_code_attributes_to_span(current_span, func)
+                add_code_attributes_to_span(current_span, func)
         except Exception:  # pylint: disable=broad-exception-caught
             # Silently handle any unexpected errors
             pass

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_fastapi_patches.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_fastapi_patches.py
@@ -36,10 +36,12 @@ def _apply_fastapi_code_attributes_patch() -> None:
     """
     try:
         # Import FastAPI instrumentation classes and AWS decorator
-        from fastapi import routing
+        from fastapi import routing  # pylint: disable=import-outside-toplevel
 
-        from amazon.opentelemetry.distro.code_correlation import record_code_attributes
-        from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+        from amazon.opentelemetry.distro.code_correlation import (  # pylint: disable=import-outside-toplevel
+            record_code_attributes,
+        )
+        from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor  # pylint: disable=import-outside-toplevel
 
         # Store the original _instrument and _uninstrument methods
         original_instrument = FastAPIInstrumentor._instrument

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_fastapi_patches.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_fastapi_patches.py
@@ -13,7 +13,7 @@ def _apply_fastapi_instrumentation_patches() -> None:
     """FastAPI instrumentation patches
 
     Applies patches to provide code attributes support for FastAPI instrumentation.
-    This patches the Flask instrumentation to automatically add code attributes
+    This patches the FastAPI instrumentation to automatically add code attributes
     to spans by decorating view functions with record_code_attributes.
     """
     if get_code_correlation_enabled_status() is True:

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_fastapi_patches.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_fastapi_patches.py
@@ -14,7 +14,7 @@ def _apply_fastapi_instrumentation_patches() -> None:
 
     Applies patches to provide code attributes support for FastAPI instrumentation.
     This patches the Flask instrumentation to automatically add code attributes
-    to spans by decorating view functions with current_span_code_attributes.
+    to spans by decorating view functions with record_code_attributes.
     """
     if get_code_correlation_enabled_status() is True:
         _apply_fastapi_code_attributes_patch()

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_fastapi_patches.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_fastapi_patches.py
@@ -1,0 +1,117 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+# Modifications Copyright The OpenTelemetry Authors. Licensed under the Apache License 2.0 License.
+
+from logging import getLogger
+
+from amazon.opentelemetry.distro.aws_opentelemetry_configurator import get_code_correlation_enabled_status
+
+_logger = getLogger(__name__)
+
+
+def _apply_fastapi_instrumentation_patches() -> None:
+    """FastAPI instrumentation patches
+
+    Applies patches to provide code attributes support for FastAPI instrumentation.
+    This patches the Flask instrumentation to automatically add code attributes
+    to spans by decorating view functions with current_span_code_attributes.
+    """
+    if get_code_correlation_enabled_status() is True:
+        _apply_fastapi_code_attributes_patch()
+
+
+def _apply_fastapi_code_attributes_patch() -> None:
+    """FastAPI instrumentation patch for code attributes
+
+    This patch modifies the FastAPI instrumentation to automatically apply
+    the current_span_code_attributes decorator to all endpoint functions when
+    the FastAPI app is instrumented.
+
+    The patch:
+    1. Imports current_span_code_attributes decorator from AWS distro utils
+    2. Hooks FastAPI's APIRouter.add_api_route method during instrumentation
+    3. Automatically decorates endpoint functions as they are registered
+    4. Adds code.function.name, code.file.path, and code.line.number to spans
+    5. Provides cleanup during uninstrumentation
+    """
+    try:
+        # Import FastAPI instrumentation classes and AWS decorator
+        from fastapi import routing
+
+        from amazon.opentelemetry.distro.code_correlation import record_code_attributes
+        from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+
+        # Store the original _instrument and _uninstrument methods
+        original_instrument = FastAPIInstrumentor._instrument
+        original_uninstrument = FastAPIInstrumentor._uninstrument
+
+        def _wrapped_add_api_route(original_add_api_route_method):
+            """Wrapper for APIRouter.add_api_route method."""
+
+            def wrapper(self, *args, **kwargs):
+                # Apply current_span_code_attributes decorator to endpoint function
+                try:
+                    # Get endpoint function from args or kwargs
+                    endpoint = None
+                    if len(args) >= 2:
+                        endpoint = args[1]
+                    else:
+                        endpoint = kwargs.get("endpoint")
+
+                    if endpoint and callable(endpoint):
+                        # Check if function is already decorated (avoid double decoration)
+                        if not hasattr(endpoint, "_current_span_code_attributes_decorated"):
+                            # Apply decorator
+                            decorated_endpoint = record_code_attributes(endpoint)
+                            # Mark as decorated to avoid double decoration
+                            decorated_endpoint._current_span_code_attributes_decorated = True
+                            decorated_endpoint._original_endpoint = endpoint
+
+                            # Replace endpoint in args or kwargs
+                            if len(args) >= 2:
+                                args = list(args)
+                                args[1] = decorated_endpoint
+                                args = tuple(args)
+                            elif "endpoint" in kwargs:
+                                kwargs["endpoint"] = decorated_endpoint
+
+                except Exception as exc:  # pylint: disable=broad-exception-caught
+                    _logger.warning("Failed to apply code attributes decorator to endpoint: %s", exc)
+
+                return original_add_api_route_method(self, *args, **kwargs)
+
+            return wrapper
+
+        def patched_instrument(self, **kwargs):
+            """Patched _instrument method with APIRouter.add_api_route wrapping"""
+            # Store original add_api_route method if not already stored
+            if not hasattr(self, "_original_apirouter"):
+                self._original_apirouter = routing.APIRouter.add_api_route
+
+            # Wrap APIRouter.add_api_route with code attributes decoration
+            routing.APIRouter.add_api_route = _wrapped_add_api_route(self._original_apirouter)
+
+            # Call the original _instrument method
+            original_instrument(self, **kwargs)
+
+        def patched_uninstrument(self, **kwargs):
+            """Patched _uninstrument method with APIRouter.add_api_route restoration"""
+            # Call the original _uninstrument method first
+            original_uninstrument(self, **kwargs)
+
+            # Restore original APIRouter.add_api_route method if it exists
+            if hasattr(self, "_original_apirouter"):
+                try:
+                    routing.APIRouter.add_api_route = self._original_apirouter
+                    delattr(self, "_original_apirouter")
+                except Exception as exc:  # pylint: disable=broad-exception-caught
+                    _logger.warning("Failed to restore original APIRouter.add_api_route method: %s", exc)
+
+        # Apply the patches to FastAPIInstrumentor
+        FastAPIInstrumentor._instrument = patched_instrument
+        FastAPIInstrumentor._uninstrument = patched_uninstrument
+
+        _logger.debug("FastAPI instrumentation code attributes patch applied successfully")
+
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        _logger.warning("Failed to apply FastAPI code attributes patch: %s", exc)

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_flask_patches.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_flask_patches.py
@@ -20,7 +20,7 @@ def _apply_flask_instrumentation_patches() -> None:
         _apply_flask_code_attributes_patch()
 
 
-def _apply_flask_code_attributes_patch() -> None:
+def _apply_flask_code_attributes_patch() -> None:  # pylint: disable=too-many-statements
     """Flask instrumentation patch for code attributes
 
     This patch modifies the Flask instrumentation to automatically apply
@@ -37,10 +37,12 @@ def _apply_flask_code_attributes_patch() -> None:
     """
     try:
         # Import Flask instrumentation classes and AWS decorator
-        import flask
+        import flask  # pylint: disable=import-outside-toplevel
 
-        from amazon.opentelemetry.distro.code_correlation import record_code_attributes
-        from opentelemetry.instrumentation.flask import FlaskInstrumentor
+        from amazon.opentelemetry.distro.code_correlation import (  # pylint: disable=import-outside-toplevel
+            record_code_attributes,
+        )
+        from opentelemetry.instrumentation.flask import FlaskInstrumentor  # pylint: disable=import-outside-toplevel
 
         # Store the original _instrument and _uninstrument methods
         original_instrument = FlaskInstrumentor._instrument
@@ -79,7 +81,7 @@ def _apply_flask_code_attributes_patch() -> None:
             """Wrapped Flask.dispatch_request method to handle deferred view function binding."""
             try:
                 # Get the current request context
-                from flask import request
+                from flask import request  # pylint: disable=import-outside-toplevel
 
                 # Check if there's an endpoint for this request
                 endpoint = request.endpoint

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_flask_patches.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_flask_patches.py
@@ -1,0 +1,143 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+# Modifications Copyright The OpenTelemetry Authors. Licensed under the Apache License 2.0 License.
+
+from logging import getLogger
+
+from amazon.opentelemetry.distro.aws_opentelemetry_configurator import get_code_correlation_enabled_status
+
+_logger = getLogger(__name__)
+
+
+def _apply_flask_instrumentation_patches() -> None:
+    """Flask instrumentation patches
+
+    Applies patches to provide code attributes support for Flask instrumentation.
+    This patches the Flask instrumentation to automatically add code attributes
+    to spans by decorating view functions with current_span_code_attributes.
+    """
+    if get_code_correlation_enabled_status() is True:
+        _apply_flask_code_attributes_patch()
+
+
+def _apply_flask_code_attributes_patch() -> None:
+    """Flask instrumentation patch for code attributes
+
+    This patch modifies the Flask instrumentation to automatically apply
+    the current_span_code_attributes decorator to all view functions when
+    the Flask app is instrumented.
+
+    The patch:
+    1. Imports current_span_code_attributes decorator from AWS distro utils
+    2. Hooks Flask's add_url_rule method during _instrument by patching Flask class
+    3. Hooks Flask's dispatch_request method to handle deferred view function binding
+    4. Automatically decorates view functions as they are registered or at request time
+    5. Adds code.function.name, code.file.path, and code.line.number to spans
+    6. Provides cleanup during _uninstrument
+    """
+    try:
+        # Import Flask instrumentation classes and AWS decorator
+        import flask
+
+        from amazon.opentelemetry.distro.code_correlation import record_code_attributes
+        from opentelemetry.instrumentation.flask import FlaskInstrumentor
+
+        # Store the original _instrument and _uninstrument methods
+        original_instrument = FlaskInstrumentor._instrument
+        original_uninstrument = FlaskInstrumentor._uninstrument
+
+        # Store reference to original Flask methods
+        original_flask_add_url_rule = flask.Flask.add_url_rule
+        original_flask_dispatch_request = flask.Flask.dispatch_request
+
+        def _decorate_view_func(view_func, endpoint=None):
+            """Helper function to decorate a view function with code attributes."""
+            try:
+                if view_func and callable(view_func):
+                    # Check if function is already decorated (avoid double decoration)
+                    if not hasattr(view_func, "_current_span_code_attributes_decorated"):
+                        # Apply decorator
+                        decorated_view_func = record_code_attributes(view_func)
+                        # Mark as decorated to avoid double decoration
+                        decorated_view_func._current_span_code_attributes_decorated = True
+                        decorated_view_func._original_view_func = view_func
+                        return decorated_view_func
+                return view_func
+            except Exception as e:
+                _logger.warning("Failed to apply code attributes decorator to view function %s: %s", endpoint, e)
+                return view_func
+
+        def _wrapped_add_url_rule(self, rule, endpoint=None, view_func=None, **options):
+            """Wrapped Flask.add_url_rule method with code attributes decoration."""
+            # Apply decorator to view function if available
+            if view_func:
+                view_func = _decorate_view_func(view_func, endpoint)
+
+            return original_flask_add_url_rule(self, rule, endpoint, view_func, **options)
+
+        def _wrapped_dispatch_request(self):
+            """Wrapped Flask.dispatch_request method to handle deferred view function binding."""
+            try:
+                # Get the current request context
+                from flask import request
+
+                # Check if there's an endpoint for this request
+                endpoint = request.endpoint
+                if endpoint and endpoint in self.view_functions:
+                    view_func = self.view_functions[endpoint]
+
+                    # Check if the view function needs decoration
+                    if view_func and callable(view_func):
+                        if not hasattr(view_func, "_current_span_code_attributes_decorated"):
+                            # Decorate the view function and replace it in view_functions
+                            decorated_view_func = _decorate_view_func(view_func, endpoint)
+                            if decorated_view_func != view_func:
+                                self.view_functions[endpoint] = decorated_view_func
+                                _logger.debug(
+                                    "Applied code attributes decorator to deferred view function for endpoint: %s",
+                                    endpoint,
+                                )
+
+            except Exception as e:
+                _logger.warning("Failed to process deferred view function decoration: %s", e)
+
+            # Call the original dispatch_request method
+            return original_flask_dispatch_request(self)
+
+        def patched_instrument(self, **kwargs):
+            """Patched _instrument method with Flask method wrapping"""
+            # Store original methods if not already stored
+            if not hasattr(self, "_original_flask_add_url_rule"):
+                self._original_flask_add_url_rule = flask.Flask.add_url_rule
+                self._original_flask_dispatch_request = flask.Flask.dispatch_request
+
+                # Wrap Flask methods with code attributes decoration
+                flask.Flask.add_url_rule = _wrapped_add_url_rule
+                flask.Flask.dispatch_request = _wrapped_dispatch_request
+
+            # Call the original _instrument method
+            original_instrument(self, **kwargs)
+
+        def patched_uninstrument(self, **kwargs):
+            """Patched _uninstrument method with Flask method restoration"""
+            # Call the original _uninstrument method first
+            original_uninstrument(self, **kwargs)
+
+            # Restore original Flask methods if they exist
+            if hasattr(self, "_original_flask_add_url_rule"):
+                try:
+                    flask.Flask.add_url_rule = self._original_flask_add_url_rule
+                    flask.Flask.dispatch_request = self._original_flask_dispatch_request
+                    delattr(self, "_original_flask_add_url_rule")
+                    delattr(self, "_original_flask_dispatch_request")
+                except Exception as e:
+                    _logger.warning("Failed to restore original Flask methods: %s", e)
+
+        # Apply the patches to FlaskInstrumentor
+        FlaskInstrumentor._instrument = patched_instrument
+        FlaskInstrumentor._uninstrument = patched_uninstrument
+
+        _logger.debug("Flask instrumentation code attributes patch applied successfully")
+
+    except Exception as e:
+        _logger.warning("Failed to apply Flask code attributes patch: %s", e)

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_flask_patches.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_flask_patches.py
@@ -14,7 +14,7 @@ def _apply_flask_instrumentation_patches() -> None:
 
     Applies patches to provide code attributes support for Flask instrumentation.
     This patches the Flask instrumentation to automatically add code attributes
-    to spans by decorating view functions with current_span_code_attributes.
+    to spans by decorating view functions with record_code_attributes.
     """
     if get_code_correlation_enabled_status() is True:
         _apply_flask_code_attributes_patch()

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_flask_patches.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_flask_patches.py
@@ -63,8 +63,8 @@ def _apply_flask_code_attributes_patch() -> None:
                         decorated_view_func._original_view_func = view_func
                         return decorated_view_func
                 return view_func
-            except Exception as e:
-                _logger.warning("Failed to apply code attributes decorator to view function %s: %s", endpoint, e)
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                _logger.warning("Failed to apply code attributes decorator to view function %s: %s", endpoint, exc)
                 return view_func
 
         def _wrapped_add_url_rule(self, rule, endpoint=None, view_func=None, **options):
@@ -98,8 +98,8 @@ def _apply_flask_code_attributes_patch() -> None:
                                     endpoint,
                                 )
 
-            except Exception as e:
-                _logger.warning("Failed to process deferred view function decoration: %s", e)
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                _logger.warning("Failed to process deferred view function decoration: %s", exc)
 
             # Call the original dispatch_request method
             return original_flask_dispatch_request(self)
@@ -130,8 +130,8 @@ def _apply_flask_code_attributes_patch() -> None:
                     flask.Flask.dispatch_request = self._original_flask_dispatch_request
                     delattr(self, "_original_flask_add_url_rule")
                     delattr(self, "_original_flask_dispatch_request")
-                except Exception as e:
-                    _logger.warning("Failed to restore original Flask methods: %s", e)
+                except Exception as exc:  # pylint: disable=broad-exception-caught
+                    _logger.warning("Failed to restore original Flask methods: %s", exc)
 
         # Apply the patches to FlaskInstrumentor
         FlaskInstrumentor._instrument = patched_instrument
@@ -139,5 +139,5 @@ def _apply_flask_code_attributes_patch() -> None:
 
         _logger.debug("Flask instrumentation code attributes patch applied successfully")
 
-    except Exception as e:
-        _logger.warning("Failed to apply Flask code attributes patch: %s", e)
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        _logger.warning("Failed to apply Flask code attributes patch: %s", exc)

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_instrumentation_patch.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_instrumentation_patch.py
@@ -78,6 +78,13 @@ def apply_instrumentation_patches() -> None:
 
         _apply_flask_instrumentation_patches()
 
+    if is_installed("fastapi"):
+        # pylint: disable=import-outside-toplevel
+        # Delay import to only occur if patches is safe to apply (e.g. the instrumented library is installed).
+        from amazon.opentelemetry.distro.patches._fastapi_patches import _apply_fastapi_instrumentation_patches
+
+        _apply_fastapi_instrumentation_patches()
+
     # No need to check if library is installed as this patches opentelemetry.sdk,
     # which must be installed for the distro to work at all.
     _apply_resource_detector_patches()

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_instrumentation_patch.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_instrumentation_patch.py
@@ -71,6 +71,13 @@ def apply_instrumentation_patches() -> None:
         # TODO: Remove patch after syncing with upstream v1.34.0 or later
         _apply_starlette_instrumentation_patches()
 
+    if is_installed("flask"):
+        # pylint: disable=import-outside-toplevel
+        # Delay import to only occur if patches is safe to apply (e.g. the instrumented library is installed).
+        from amazon.opentelemetry.distro.patches._flask_patches import _apply_flask_instrumentation_patches
+
+        _apply_flask_instrumentation_patches()
+
     # No need to check if library is installed as this patches opentelemetry.sdk,
     # which must be installed for the distro to work at all.
     _apply_resource_detector_patches()

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_starlette_patches.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_starlette_patches.py
@@ -82,10 +82,14 @@ def _apply_starlette_code_attributes_patch() -> None:
     """
     try:
         # Import Starlette routing classes and AWS decorator
-        from starlette.routing import Route
+        from starlette.routing import Route  # pylint: disable=import-outside-toplevel
 
-        from amazon.opentelemetry.distro.code_correlation import record_code_attributes
-        from opentelemetry.instrumentation.starlette import StarletteInstrumentor
+        from amazon.opentelemetry.distro.code_correlation import (  # pylint: disable=import-outside-toplevel
+            record_code_attributes,
+        )
+        from opentelemetry.instrumentation.starlette import (  # pylint: disable=import-outside-toplevel
+            StarletteInstrumentor,
+        )
 
         # Store the original _instrument and _uninstrument methods
         original_instrument = StarletteInstrumentor._instrument

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_starlette_patches.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_starlette_patches.py
@@ -5,15 +5,26 @@ from logging import Logger, getLogger
 from typing import Collection
 
 from amazon.opentelemetry.distro._utils import is_agent_observability_enabled
+from amazon.opentelemetry.distro.aws_opentelemetry_configurator import get_code_correlation_enabled_status
 
 _logger: Logger = getLogger(__name__)
+
+
+def _apply_starlette_instrumentation_patches() -> None:
+    """Apply patches to the Starlette instrumentation.
+
+    This applies both version compatibility patches and code attributes support.
+    """
+    _apply_starlette_version_patches()
+    if get_code_correlation_enabled_status() is True:
+        _apply_starlette_code_attributes_patch()
 
 
 # Upstream fix available in OpenTelemetry 1.34.0/0.55b0 (2025-06-04)
 # Reference: https://github.com/open-telemetry/opentelemetry-python-contrib/pull/3456
 # TODO: Remove this patch after upgrading to version 1.34.0 or later
-def _apply_starlette_instrumentation_patches() -> None:
-    """Apply patches to the Starlette instrumentation.
+def _apply_starlette_version_patches() -> None:
+    """Apply version compatibility patches to the Starlette instrumentation.
 
     This patch modifies the instrumentation_dependencies method in the starlette
     instrumentation to loose an upper version constraint for auto-instrumentation
@@ -53,3 +64,92 @@ def _apply_starlette_instrumentation_patches() -> None:
         _logger.debug("Successfully patched Starlette instrumentation_dependencies method")
     except Exception as exc:  # pylint: disable=broad-except
         _logger.warning("Failed to apply Starlette instrumentation patches: %s", exc)
+
+
+def _apply_starlette_code_attributes_patch() -> None:
+    """Starlette instrumentation patch for code attributes
+
+    This patch modifies Starlette Route class to automatically apply
+    the record_code_attributes decorator to endpoint functions when
+    routes are created.
+
+    The patch:
+    1. Imports record_code_attributes decorator from AWS distro code correlation
+    2. Hooks Starlette's Route.__init__ method during instrumentation
+    3. Automatically decorates endpoint functions as routes are created
+    4. Adds code.function.name, code.file.path, and code.line.number to spans
+    5. Provides cleanup during uninstrumentation
+    """
+    try:
+        # Import Starlette routing classes and AWS decorator
+        from starlette.routing import Route
+
+        from amazon.opentelemetry.distro.code_correlation import record_code_attributes
+        from opentelemetry.instrumentation.starlette import StarletteInstrumentor
+
+        # Store the original _instrument and _uninstrument methods
+        original_instrument = StarletteInstrumentor._instrument
+        original_uninstrument = StarletteInstrumentor._uninstrument
+
+        # Store reference to original Route.__init__
+        original_route_init = Route.__init__
+
+        def _decorate_endpoint(endpoint):
+            """Helper function to decorate an endpoint function with code attributes."""
+            try:
+                if endpoint and callable(endpoint):
+                    # Check if function is already decorated (avoid double decoration)
+                    if not hasattr(endpoint, "_current_span_code_attributes_decorated"):
+                        # Apply decorator
+                        decorated_endpoint = record_code_attributes(endpoint)
+                        # Mark as decorated to avoid double decoration
+                        decorated_endpoint._current_span_code_attributes_decorated = True
+                        decorated_endpoint._original_endpoint = endpoint
+                        return decorated_endpoint
+                return endpoint
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                _logger.warning("Failed to apply code attributes decorator to endpoint: %s", exc)
+                return endpoint
+
+        def _wrapped_route_init(self, path, endpoint=None, **kwargs):
+            """Wrapped Route.__init__ method with code attributes decoration."""
+            # Decorate endpoint if provided
+            if endpoint:
+                endpoint = _decorate_endpoint(endpoint)
+
+            # Call the original Route.__init__ with decorated endpoint
+            return original_route_init(self, path, endpoint=endpoint, **kwargs)
+
+        def patched_instrument(self, **kwargs):
+            """Patched _instrument method with Route.__init__ wrapping"""
+            # Store original Route.__init__ method if not already stored
+            if not hasattr(self, "_original_route_init"):
+                self._original_route_init = Route.__init__
+
+                # Wrap Route.__init__ with code attributes decoration
+                Route.__init__ = _wrapped_route_init
+
+            # Call the original _instrument method
+            original_instrument(self, **kwargs)
+
+        def patched_uninstrument(self, **kwargs):
+            """Patched _uninstrument method with Route.__init__ restoration"""
+            # Call the original _uninstrument method first
+            original_uninstrument(self, **kwargs)
+
+            # Restore original Route.__init__ method if it exists
+            if hasattr(self, "_original_route_init"):
+                try:
+                    Route.__init__ = self._original_route_init
+                    delattr(self, "_original_route_init")
+                except Exception as exc:  # pylint: disable=broad-exception-caught
+                    _logger.warning("Failed to restore original Route.__init__ method: %s", exc)
+
+        # Apply the patches to StarletteInstrumentor
+        StarletteInstrumentor._instrument = patched_instrument
+        StarletteInstrumentor._uninstrument = patched_uninstrument
+
+        _logger.debug("Starlette instrumentation code attributes patch applied successfully")
+
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        _logger.warning("Failed to apply Starlette code attributes patch: %s", exc)

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/patches/test_fastapi_patches.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/patches/test_fastapi_patches.py
@@ -1,0 +1,229 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import sys
+from unittest.mock import patch
+
+from fastapi import APIRouter, FastAPI
+
+from amazon.opentelemetry.distro.patches._fastapi_patches import _apply_fastapi_instrumentation_patches
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.test.test_base import TestBase
+
+# Store original methods at module level before any patches
+_ORIGINAL_FASTAPI_INSTRUMENTOR_INSTRUMENT = FastAPIInstrumentor._instrument
+_ORIGINAL_FASTAPI_INSTRUMENTOR_UNINSTRUMENT = FastAPIInstrumentor._uninstrument
+_ORIGINAL_APIROUTER_ADD_API_ROUTE = APIRouter.add_api_route
+
+
+class TestFastAPIPatchesRealApp(TestBase):
+    """Test FastAPI patches functionality."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        super().setUp()
+
+        # Restore original methods
+        APIRouter.add_api_route = _ORIGINAL_APIROUTER_ADD_API_ROUTE
+        FastAPIInstrumentor._instrument = _ORIGINAL_FASTAPI_INSTRUMENTOR_INSTRUMENT
+        FastAPIInstrumentor._uninstrument = _ORIGINAL_FASTAPI_INSTRUMENTOR_UNINSTRUMENT
+
+        # Create FastAPI app
+        self.app = FastAPI()
+
+        @self.app.get("/hello/{name}")
+        async def hello(name: str):
+            return {"message": f"Hello {name}!"}
+
+    def tearDown(self):
+        """Clean up after tests."""
+        super().tearDown()
+
+        # Restore original methods
+        APIRouter.add_api_route = _ORIGINAL_APIROUTER_ADD_API_ROUTE
+        FastAPIInstrumentor._instrument = _ORIGINAL_FASTAPI_INSTRUMENTOR_INSTRUMENT
+        FastAPIInstrumentor._uninstrument = _ORIGINAL_FASTAPI_INSTRUMENTOR_UNINSTRUMENT
+
+        # Clean up instrumentor attributes
+        instrumentor_instance = FastAPIInstrumentor()
+        for attr_name in list(vars(FastAPIInstrumentor).keys()):
+            if attr_name.startswith("_original_apirouter"):
+                delattr(FastAPIInstrumentor, attr_name)
+
+        for attr_name in [attr for attr in dir(instrumentor_instance) if attr.startswith("_original_apirouter")]:
+            if hasattr(instrumentor_instance, attr_name):
+                delattr(instrumentor_instance, attr_name)
+
+        try:
+            FastAPIInstrumentor().uninstrument()
+        except Exception:
+            pass
+
+    @patch("amazon.opentelemetry.distro.patches._fastapi_patches.get_code_correlation_enabled_status")
+    def test_fastapi_patches_with_real_app(self, mock_get_status):
+        """Test FastAPI patches core functionality."""
+        mock_get_status.return_value = True
+        original_add_api_route = _ORIGINAL_APIROUTER_ADD_API_ROUTE
+
+        # Apply patches
+        _apply_fastapi_instrumentation_patches()
+        mock_get_status.assert_called_once()
+
+        # Test method wrapping
+        instrumentor = FastAPIInstrumentor()
+        instrumentor._instrument()
+
+        current_add_api_route = APIRouter.add_api_route
+        self.assertNotEqual(current_add_api_route, original_add_api_route)
+
+        # Test app instrumentation
+        instrumentor.instrument_app(self.app)
+        self.assertIsNotNone(self.app)
+
+        # Test uninstrumentation
+        instrumentor._uninstrument()
+        restored_add_api_route = APIRouter.add_api_route
+        self.assertEqual(restored_add_api_route, original_add_api_route)
+
+    @patch("amazon.opentelemetry.distro.patches._fastapi_patches.get_code_correlation_enabled_status")
+    def test_fastapi_patches_disabled(self, mock_get_status):
+        """Test FastAPI patches when disabled."""
+        mock_get_status.return_value = False
+
+        _apply_fastapi_instrumentation_patches()
+        instrumentor = FastAPIInstrumentor()
+        instrumentor.instrument_app(self.app)
+
+        mock_get_status.assert_called_once()
+        self.assertIsNotNone(self.app)
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 0)
+
+    @patch("amazon.opentelemetry.distro.patches._fastapi_patches.get_code_correlation_enabled_status")
+    def test_fastapi_patches_import_error_handling(self, mock_get_status):
+        """Test FastAPI patches with import errors."""
+        mock_get_status.return_value = True
+        original_modules = sys.modules.copy()
+
+        try:
+            # Simulate import error
+            modules_to_remove = [
+                "fastapi.routing",
+                "amazon.opentelemetry.distro.code_correlation",
+                "opentelemetry.instrumentation.fastapi",
+            ]
+            for module in modules_to_remove:
+                if module in sys.modules:
+                    del sys.modules[module]
+
+            _apply_fastapi_instrumentation_patches()
+            mock_get_status.assert_called_once()
+
+        finally:
+            sys.modules.clear()
+            sys.modules.update(original_modules)
+
+    @patch("amazon.opentelemetry.distro.patches._fastapi_patches.get_code_correlation_enabled_status")
+    def test_fastapi_patches_endpoint_decoration(self, mock_get_status):
+        """Test endpoint decoration functionality."""
+        mock_get_status.return_value = True
+
+        instrumentor = FastAPIInstrumentor()
+        instrumentor.instrument_app(self.app)
+        _apply_fastapi_instrumentation_patches()
+        instrumentor._instrument()
+
+        # Test adding routes
+        async def async_endpoint():
+            return {"message": "async endpoint"}
+
+        router = APIRouter()
+        router.add_api_route("/test_async", async_endpoint, methods=["GET"])
+        self.app.include_router(router)
+
+        self.assertTrue(len(self.app.routes) > 0)
+
+    @patch("amazon.opentelemetry.distro.patches._fastapi_patches.get_code_correlation_enabled_status")
+    def test_fastapi_patches_uninstrument_error_handling(self, mock_get_status):
+        """Test uninstrument error handling."""
+        mock_get_status.return_value = True
+
+        instrumentor = FastAPIInstrumentor()
+        _apply_fastapi_instrumentation_patches()
+        instrumentor._instrument()
+
+        # Break stored references to trigger error handling
+        if hasattr(instrumentor, "_original_apirouter"):
+            instrumentor._original_apirouter = None
+
+        try:
+            instrumentor._uninstrument()
+        except Exception:
+            pass  # Expected to handle gracefully
+
+    @patch("amazon.opentelemetry.distro.patches._fastapi_patches.get_code_correlation_enabled_status")
+    def test_fastapi_patches_code_correlation_import_error(self, mock_get_status):
+        """Test code correlation import error handling."""
+        mock_get_status.return_value = True
+        original_modules = sys.modules.copy()
+
+        try:
+            # Remove code_correlation module to simulate import error
+            modules_to_remove = [
+                "amazon.opentelemetry.distro.code_correlation",
+                "amazon.opentelemetry.distro.code_correlation.record_code_attributes",
+            ]
+            for module in modules_to_remove:
+                if module in sys.modules:
+                    del sys.modules[module]
+
+            instrumentor = FastAPIInstrumentor()
+            _apply_fastapi_instrumentation_patches()
+            instrumentor._instrument()
+
+        finally:
+            sys.modules.clear()
+            sys.modules.update(original_modules)
+
+    @patch("amazon.opentelemetry.distro.patches._fastapi_patches.get_code_correlation_enabled_status")
+    def test_fastapi_patches_double_decoration_prevention(self, mock_get_status):
+        """Test prevention of double decoration."""
+        mock_get_status.return_value = True
+
+        _apply_fastapi_instrumentation_patches()
+        instrumentor = FastAPIInstrumentor()
+        instrumentor._instrument()
+
+        # Create pre-decorated endpoint
+        async def test_endpoint():
+            return {"message": "test"}
+
+        test_endpoint._current_span_code_attributes_decorated = True
+
+        router = APIRouter()
+        router.add_api_route("/test_double", test_endpoint, methods=["GET"])
+        self.app.include_router(router)
+
+        self.assertTrue(len(self.app.routes) > 0)
+
+    @patch("amazon.opentelemetry.distro.patches._fastapi_patches.get_code_correlation_enabled_status")
+    def test_fastapi_patches_none_endpoint_handling(self, mock_get_status):
+        """Test handling of None endpoints."""
+        mock_get_status.return_value = True
+
+        _apply_fastapi_instrumentation_patches()
+        instrumentor = FastAPIInstrumentor()
+        instrumentor._instrument()
+
+        router = APIRouter()
+
+        # Test None endpoint handling
+        try:
+            router.add_api_route("/test_none", None, methods=["GET"])
+        except Exception:
+            pass  # Expected to handle gracefully
+
+        try:
+            router.add_api_route("/test_string", "not_callable", methods=["GET"])
+        except Exception:
+            pass  # Expected to handle gracefully

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/patches/test_flask_patches.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/patches/test_flask_patches.py
@@ -1,0 +1,307 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+from unittest.mock import patch
+
+import flask
+from werkzeug.test import Client
+from werkzeug.wrappers import Response
+
+from amazon.opentelemetry.distro.patches._flask_patches import _apply_flask_instrumentation_patches
+from opentelemetry import trace
+from opentelemetry.instrumentation.flask import FlaskInstrumentor
+from opentelemetry.test.test_base import TestBase
+
+# Store truly original Flask methods at module level before any patches
+_ORIGINAL_FLASK_ADD_URL_RULE = flask.Flask.add_url_rule
+_ORIGINAL_FLASK_DISPATCH_REQUEST = flask.Flask.dispatch_request
+
+# Store original FlaskInstrumentor methods before any patches
+_ORIGINAL_FLASK_INSTRUMENTOR_INSTRUMENT = FlaskInstrumentor._instrument
+_ORIGINAL_FLASK_INSTRUMENTOR_UNINSTRUMENT = FlaskInstrumentor._uninstrument
+
+
+class TestFlaskPatchesRealApp(TestBase):
+    """Test Flask patches using a real Flask application."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        super().setUp()
+
+        # Always start with clean Flask methods
+        flask.Flask.add_url_rule = _ORIGINAL_FLASK_ADD_URL_RULE
+        flask.Flask.dispatch_request = _ORIGINAL_FLASK_DISPATCH_REQUEST
+
+        # Always start with clean FlaskInstrumentor methods
+        FlaskInstrumentor._instrument = _ORIGINAL_FLASK_INSTRUMENTOR_INSTRUMENT
+        FlaskInstrumentor._uninstrument = _ORIGINAL_FLASK_INSTRUMENTOR_UNINSTRUMENT
+
+        # Create real Flask app
+        self.app = flask.Flask(__name__)
+
+        # Add test routes
+        @self.app.route("/hello/<name>")
+        def hello(name):
+            return f"Hello {name}!"
+
+        @self.app.route("/error")
+        def error_endpoint():
+            raise ValueError("Test error")
+
+        @self.app.route("/simple")
+        def simple():
+            return "OK"
+
+        # Create test client
+        self.client = Client(self.app, Response)
+
+    def tearDown(self):
+        """Clean up after tests."""
+        super().tearDown()
+
+        # Always restore original Flask methods to avoid contamination between tests
+        flask.Flask.add_url_rule = _ORIGINAL_FLASK_ADD_URL_RULE
+        flask.Flask.dispatch_request = _ORIGINAL_FLASK_DISPATCH_REQUEST
+
+        # Always restore original FlaskInstrumentor methods to avoid contamination between tests
+        FlaskInstrumentor._instrument = _ORIGINAL_FLASK_INSTRUMENTOR_INSTRUMENT
+        FlaskInstrumentor._uninstrument = _ORIGINAL_FLASK_INSTRUMENTOR_UNINSTRUMENT
+
+        # Clear any stored class attributes from patches
+        for attr_name in list(vars(FlaskInstrumentor).keys()):
+            if attr_name.startswith("_original_flask_"):
+                delattr(FlaskInstrumentor, attr_name)
+
+        # CRITICAL: Clear instance attributes from the singleton FlaskInstrumentor instance
+        # FlaskInstrumentor is a singleton, so we need to clean up the instance attributes
+        instrumentor_instance = FlaskInstrumentor()
+        instance_attrs_to_remove = []
+        for attr_name in dir(instrumentor_instance):
+            if attr_name.startswith("_original_flask_"):
+                instance_attrs_to_remove.append(attr_name)
+
+        for attr_name in instance_attrs_to_remove:
+            if hasattr(instrumentor_instance, attr_name):
+                delattr(instrumentor_instance, attr_name)
+
+        # Clean up instrumentor - use global uninstrument
+        try:
+            FlaskInstrumentor().uninstrument()
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
+
+    @patch("amazon.opentelemetry.distro.patches._flask_patches.get_code_correlation_enabled_status")
+    def test_flask_patches_with_real_app(self, mock_get_status):
+        """Test Flask patches with real Flask app covering various scenarios."""
+        mock_get_status.return_value = True
+
+        # Store original Flask methods - use the module level constants
+        original_add_url_rule = _ORIGINAL_FLASK_ADD_URL_RULE
+        original_dispatch_request = _ORIGINAL_FLASK_DISPATCH_REQUEST
+
+        # Apply patches FIRST
+        _apply_flask_instrumentation_patches()
+
+        # Verify that get_status was called
+        mock_get_status.assert_called_once()
+
+        # Create instrumentor and manually call _instrument to trigger Flask method wrapping
+        instrumentor = FlaskInstrumentor()
+        instrumentor._instrument()
+
+        # Check if Flask methods were wrapped by patches
+        current_add_url_rule = flask.Flask.add_url_rule
+        current_dispatch_request = flask.Flask.dispatch_request
+
+        # Test that Flask methods are actually wrapped - this is the core functionality
+        self.assertNotEqual(current_add_url_rule, original_add_url_rule, "Flask.add_url_rule should be wrapped")
+        self.assertNotEqual(
+            current_dispatch_request, original_dispatch_request, "Flask.dispatch_request should be wrapped"
+        )
+
+        # Test a request to trigger the patches
+        instrumentor.instrument_app(self.app)
+        resp = self.client.get("/hello/world")
+        self.assertEqual(200, resp.status_code)
+
+        # Test uninstrumentation - this should restore original Flask methods
+        instrumentor._uninstrument()
+
+        # Check if Flask methods were restored
+        restored_add_url_rule = flask.Flask.add_url_rule
+        restored_dispatch_request = flask.Flask.dispatch_request
+
+        # Methods should be restored to original after uninstrument
+        self.assertEqual(restored_add_url_rule, original_add_url_rule, "Flask.add_url_rule should be restored")
+        self.assertEqual(
+            restored_dispatch_request, original_dispatch_request, "Flask.dispatch_request should be restored"
+        )
+
+    @patch("amazon.opentelemetry.distro.patches._flask_patches.get_code_correlation_enabled_status")
+    def test_flask_patches_disabled(self, mock_get_status):
+        """Test Flask patches when code correlation is disabled."""
+        mock_get_status.return_value = False
+
+        # Apply patches (should not modify anything)
+        _apply_flask_instrumentation_patches()
+
+        # Instrument the app normally
+        instrumentor = FlaskInstrumentor()
+        instrumentor.instrument_app(self.app)
+
+        # Verify that get_status was called
+        mock_get_status.assert_called_once()
+
+        # Make a request
+        resp = self.client.get("/hello/world")
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual([b"Hello world!"], list(resp.response))
+
+        # Check spans were still generated (normal instrumentation)
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+
+        span = spans[0]
+        self.assertEqual(span.name, "GET /hello/<name>")
+        self.assertEqual(span.kind, trace.SpanKind.SERVER)
+
+        # Clean up - avoid Flask instrumentation issues
+        try:
+            instrumentor.uninstrument_app(self.app)
+        except Exception:
+            pass  # Flask instrumentation cleanup may fail, that's ok
+
+    @patch("amazon.opentelemetry.distro.patches._flask_patches.get_code_correlation_enabled_status")
+    def test_flask_patches_import_error_handling(self, mock_get_status):
+        """Test Flask patches with import errors."""
+        mock_get_status.return_value = True
+
+        # Test that patches handle import errors gracefully by mocking sys.modules
+        import sys
+
+        original_modules = sys.modules.copy()
+
+        try:
+            # Remove flask from sys.modules to simulate import error
+            if "flask" in sys.modules:
+                del sys.modules["flask"]
+
+            # Should not raise exception even with missing flask
+            _apply_flask_instrumentation_patches()
+
+            # Verify status was checked
+            mock_get_status.assert_called_once()
+
+        finally:
+            # Restore original modules
+            sys.modules.clear()
+            sys.modules.update(original_modules)
+
+    @patch("amazon.opentelemetry.distro.patches._flask_patches.get_code_correlation_enabled_status")
+    def test_flask_patches_view_function_decoration(self, mock_get_status):
+        """Test Flask patches view function decoration edge cases."""
+        mock_get_status.return_value = True
+
+        # Create instrumentor and apply patches
+        instrumentor = FlaskInstrumentor()
+        instrumentor.instrument_app(self.app)
+        _apply_flask_instrumentation_patches()
+        instrumentor._instrument()
+
+        # Test adding routes with None view_func (edge case)
+        try:
+            self.app.add_url_rule("/test_none", "test_none", None)
+        except Exception:
+            pass  # Expected to handle gracefully
+
+        # Test adding routes with non-callable view_func
+        try:
+            self.app.add_url_rule("/test_string", "test_string", "not_callable")
+        except Exception:
+            pass  # Expected to handle gracefully
+
+        # Test route with lambda (should be decorated)
+        def lambda_func():
+            return "lambda response"
+
+        self.app.add_url_rule("/test_lambda", "test_lambda", lambda_func)
+
+        # Clean up - don't call uninstrument_app to avoid Flask instrumentation issues
+        pass
+
+    @patch("amazon.opentelemetry.distro.patches._flask_patches.get_code_correlation_enabled_status")
+    def test_flask_patches_dispatch_request_coverage(self, mock_get_status):
+        """Test Flask patches dispatch_request method coverage."""
+        mock_get_status.return_value = True
+
+        # Create a special app with deferred view function binding
+        test_app = flask.Flask(__name__)
+
+        # Add route after creating app but before applying patches
+        @test_app.route("/deferred")
+        def deferred_view():
+            return "deferred"
+
+        # Create instrumentor and apply patches
+        instrumentor = FlaskInstrumentor()
+        _apply_flask_instrumentation_patches()
+        instrumentor._instrument()
+        instrumentor.instrument_app(test_app)
+
+        # Create test client and make request to trigger dispatch_request
+        client = Client(test_app, Response)
+        resp = client.get("/deferred")
+        self.assertEqual(200, resp.status_code)
+
+    @patch("amazon.opentelemetry.distro.patches._flask_patches.get_code_correlation_enabled_status")
+    def test_flask_patches_uninstrument_error_handling(self, mock_get_status):
+        """Test Flask patches uninstrument error handling."""
+        mock_get_status.return_value = True
+
+        # Create instrumentor and apply patches
+        instrumentor = FlaskInstrumentor()
+        _apply_flask_instrumentation_patches()
+        instrumentor._instrument()
+
+        # Manually break the stored references to trigger error handling
+        if hasattr(instrumentor, "_original_flask_add_url_rule"):
+            # Set invalid values to trigger exceptions during restoration
+            instrumentor._original_flask_add_url_rule = None
+            instrumentor._original_flask_dispatch_request = None
+
+        # This should trigger error handling in patched_uninstrument
+        try:
+            instrumentor._uninstrument()
+        except Exception:
+            pass  # Expected to handle gracefully
+
+    @patch("amazon.opentelemetry.distro.patches._flask_patches.get_code_correlation_enabled_status")
+    def test_flask_patches_code_correlation_import_error(self, mock_get_status):
+        """Test Flask patches when code_correlation import fails."""
+        mock_get_status.return_value = True
+
+        # Mock import error for code_correlation module
+        import sys
+
+        original_modules = sys.modules.copy()
+
+        try:
+            # Remove code_correlation module to simulate import error
+            modules_to_remove = [
+                "amazon.opentelemetry.distro.code_correlation",
+                "amazon.opentelemetry.distro.code_correlation.record_code_attributes",
+            ]
+            for module in modules_to_remove:
+                if module in sys.modules:
+                    del sys.modules[module]
+
+            # Create instrumentor and apply patches - should handle import error gracefully
+            instrumentor = FlaskInstrumentor()
+            _apply_flask_instrumentation_patches()
+
+            # Try to trigger the patched methods
+            instrumentor._instrument()
+
+        finally:
+            # Restore original modules
+            sys.modules.clear()
+            sys.modules.update(original_modules)

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/patches/test_starlette_patches.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/patches/test_starlette_patches.py
@@ -3,7 +3,10 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
-from amazon.opentelemetry.distro.patches._starlette_patches import _apply_starlette_instrumentation_patches
+from amazon.opentelemetry.distro.patches._starlette_patches import (
+    _apply_starlette_code_attributes_patch,
+    _apply_starlette_instrumentation_patches,
+)
 
 
 class TestStarlettePatch(TestCase):
@@ -83,58 +86,558 @@ class TestStarlettePatch(TestCase):
             args = mock_logger.warning.call_args[0]
             self.assertIn("Failed to apply Starlette instrumentation patches", args[0])
 
+
+class TestStarletteCodeAttributesPatch(TestCase):
+    """Test the Starlette code attributes instrumentation patches using real Route class."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+
+        # Sample endpoint functions for testing
+        def sample_endpoint():
+            return {"message": "Hello World"}
+
+        def another_endpoint():
+            return {"message": "Another endpoint"}
+
+        self.sample_endpoint = sample_endpoint
+        self.another_endpoint = another_endpoint
+
     @patch("amazon.opentelemetry.distro.patches._starlette_patches._logger")
-    def test_starlette_patch_handles_attribute_error(self, mock_logger):
-        """Test that the patch handles attribute errors gracefully."""
+    def test_code_attributes_patch_applied_successfully(self, mock_logger):
+        """Test that the code attributes patch is applied successfully using real Route class."""
+        try:
+            from starlette.routing import Route
+        except ImportError:
+            self.skipTest("Starlette not available")
 
-        # Create a metaclass that raises AttributeError when setting class attributes
-        class ErrorMeta(type):
-            def __setattr__(cls, name, value):
-                if name == "instrumentation_dependencies":
-                    raise AttributeError("Cannot set attribute")
-                super().__setattr__(name, value)
+        # Create a mock StarletteInstrumentor class with proper methods
+        class MockStarletteInstrumentor:
+            def __init__(self):
+                pass
 
-        # Create a class with the error-raising metaclass
-        class MockStarletteInstrumentor(metaclass=ErrorMeta):
-            pass
+            def _instrument(self, **kwargs):
+                pass
 
-        # Create a mock module
-        mock_starlette_module = MagicMock()
-        mock_starlette_module.StarletteInstrumentor = MockStarletteInstrumentor
+            def _uninstrument(self, **kwargs):
+                pass
 
-        with patch.dict("sys.modules", {"opentelemetry.instrumentation.starlette": mock_starlette_module}):
+        mock_instrumentor_class = MockStarletteInstrumentor
+        mock_instrumentor = MockStarletteInstrumentor()
+
+        # Mock the code correlation decorator
+        mock_record_code_attributes = MagicMock()
+
+        def mock_decorator(func):
+            """Mock decorator that marks function as decorated."""
+
+            # Create a wrapper that preserves the original function
+            def wrapper(*args, **kwargs):
+                return func(*args, **kwargs)
+
+            # Mark as decorated
+            wrapper._current_span_code_attributes_decorated = True
+            wrapper._original_endpoint = func
+            wrapper.__name__ = getattr(func, "__name__", "decorated_endpoint")
+            return wrapper
+
+        mock_record_code_attributes.side_effect = mock_decorator
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "opentelemetry.instrumentation.starlette": MagicMock(StarletteInstrumentor=mock_instrumentor_class),
+                "amazon.opentelemetry.distro.code_correlation": MagicMock(
+                    record_code_attributes=mock_record_code_attributes
+                ),
+            },
+        ):
+            # Store original Route.__init__
+            original_route_init = Route.__init__
+
+            try:
+                # Apply the patch
+                _apply_starlette_code_attributes_patch()
+
+                # Verify the instrumentor methods were patched
+                self.assertTrue(hasattr(mock_instrumentor_class, "_instrument"))
+                self.assertTrue(hasattr(mock_instrumentor_class, "_uninstrument"))
+
+                # Call the patched _instrument method to set up instrumentation
+                mock_instrumentor._instrument()
+
+                # Verify Route.__init__ was modified
+                self.assertNotEqual(Route.__init__, original_route_init)
+
+                # Create a route with the patched Route class
+                route = Route("/test", endpoint=self.sample_endpoint)
+
+                # Verify the endpoint was decorated
+                mock_record_code_attributes.assert_called_once_with(self.sample_endpoint)
+
+                # Test that the route was created successfully
+                self.assertEqual(route.path, "/test")
+                self.assertIsNotNone(route.endpoint)
+
+                # Verify the endpoint is decorated
+                self.assertTrue(hasattr(route.endpoint, "_current_span_code_attributes_decorated"))
+                self.assertEqual(route.endpoint._original_endpoint, self.sample_endpoint)
+
+                # Test uninstrumentation
+                mock_instrumentor._uninstrument()
+
+                # Verify Route.__init__ was restored
+                self.assertEqual(Route.__init__, original_route_init)
+
+                # Verify logging
+                mock_logger.debug.assert_called_with(
+                    "Starlette instrumentation code attributes patch applied successfully"
+                )
+
+            finally:
+                # Restore original Route.__init__
+                Route.__init__ = original_route_init
+
+    @patch("amazon.opentelemetry.distro.patches._starlette_patches._logger")
+    def test_code_attributes_patch_with_none_endpoint(self, mock_logger):
+        """Test that the patch handles None endpoint gracefully."""
+        try:
+            from starlette.routing import Route
+        except ImportError:
+            self.skipTest("Starlette not available")
+
+        mock_instrumentor_class = MagicMock()
+        mock_instrumentor = MagicMock()
+        mock_instrumentor_class.return_value = mock_instrumentor
+
+        mock_record_code_attributes = MagicMock()
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "opentelemetry.instrumentation.starlette": MagicMock(StarletteInstrumentor=mock_instrumentor_class),
+                "amazon.opentelemetry.distro.code_correlation": MagicMock(
+                    record_code_attributes=mock_record_code_attributes
+                ),
+            },
+        ):
+            original_route_init = Route.__init__
+
+            try:
+                _apply_starlette_code_attributes_patch()
+                mock_instrumentor_class._instrument(mock_instrumentor)
+
+                # Create route with None endpoint
+                route = Route("/test", endpoint=None)
+
+                # Verify no decoration was attempted
+                mock_record_code_attributes.assert_not_called()
+
+                # Verify route was created successfully
+                self.assertEqual(route.path, "/test")
+                self.assertIsNone(route.endpoint)
+
+            finally:
+                Route.__init__ = original_route_init
+
+    @patch("amazon.opentelemetry.distro.patches._starlette_patches._logger")
+    def test_code_attributes_patch_avoids_double_decoration(self, mock_logger):
+        """Test that the patch avoids double decoration of endpoints."""
+        try:
+            from starlette.routing import Route
+        except ImportError:
+            self.skipTest("Starlette not available")
+
+        mock_instrumentor_class = MagicMock()
+        mock_instrumentor = MagicMock()
+        mock_instrumentor_class.return_value = mock_instrumentor
+
+        mock_record_code_attributes = MagicMock()
+
+        # Create an already decorated endpoint
+        def already_decorated_endpoint():
+            return {"message": "Already decorated"}
+
+        already_decorated_endpoint._current_span_code_attributes_decorated = True
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "opentelemetry.instrumentation.starlette": MagicMock(StarletteInstrumentor=mock_instrumentor_class),
+                "amazon.opentelemetry.distro.code_correlation": MagicMock(
+                    record_code_attributes=mock_record_code_attributes
+                ),
+            },
+        ):
+            original_route_init = Route.__init__
+
+            try:
+                _apply_starlette_code_attributes_patch()
+                mock_instrumentor_class._instrument(mock_instrumentor)
+
+                # Create route with already decorated endpoint
+                route = Route("/test", endpoint=already_decorated_endpoint)
+
+                # Verify no additional decoration was attempted
+                mock_record_code_attributes.assert_not_called()
+
+                # Verify route was created successfully
+                self.assertEqual(route.path, "/test")
+                self.assertEqual(route.endpoint, already_decorated_endpoint)
+
+            finally:
+                Route.__init__ = original_route_init
+
+    @patch("amazon.opentelemetry.distro.patches._starlette_patches._logger")
+    def test_code_attributes_patch_handles_non_callable_endpoint(self, mock_logger):
+        """Test that the patch handles non-callable endpoints gracefully."""
+        try:
+            from starlette.routing import Route
+        except ImportError:
+            self.skipTest("Starlette not available")
+
+        mock_instrumentor_class = MagicMock()
+        mock_instrumentor = MagicMock()
+        mock_instrumentor_class.return_value = mock_instrumentor
+
+        mock_record_code_attributes = MagicMock()
+
+        # Non-callable endpoint
+        non_callable_endpoint = "not_a_function"
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "opentelemetry.instrumentation.starlette": MagicMock(StarletteInstrumentor=mock_instrumentor_class),
+                "amazon.opentelemetry.distro.code_correlation": MagicMock(
+                    record_code_attributes=mock_record_code_attributes
+                ),
+            },
+        ):
+            original_route_init = Route.__init__
+
+            try:
+                _apply_starlette_code_attributes_patch()
+                mock_instrumentor_class._instrument(mock_instrumentor)
+
+                # Create route with non-callable endpoint
+                route = Route("/test", endpoint=non_callable_endpoint)
+
+                # Verify no decoration was attempted
+                mock_record_code_attributes.assert_not_called()
+
+                # Verify route was created successfully
+                self.assertEqual(route.path, "/test")
+                self.assertEqual(route.endpoint, non_callable_endpoint)
+
+            finally:
+                Route.__init__ = original_route_init
+
+    @patch("amazon.opentelemetry.distro.patches._starlette_patches._logger")
+    def test_code_attributes_patch_handles_decorator_error(self, mock_logger):
+        """Test that the patch handles decorator errors gracefully."""
+        try:
+            from starlette.routing import Route
+        except ImportError:
+            self.skipTest("Starlette not available")
+
+        # Create a mock StarletteInstrumentor class with proper methods
+        class MockStarletteInstrumentor:
+            def __init__(self):
+                pass
+
+            def _instrument(self, **kwargs):
+                pass
+
+            def _uninstrument(self, **kwargs):
+                pass
+
+        mock_instrumentor_class = MockStarletteInstrumentor
+        mock_instrumentor = MockStarletteInstrumentor()
+
+        # Mock decorator that raises exception
+        mock_record_code_attributes = MagicMock()
+        mock_record_code_attributes.side_effect = RuntimeError("Decorator failed")
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "opentelemetry.instrumentation.starlette": MagicMock(StarletteInstrumentor=mock_instrumentor_class),
+                "amazon.opentelemetry.distro.code_correlation": MagicMock(
+                    record_code_attributes=mock_record_code_attributes
+                ),
+            },
+        ):
+            original_route_init = Route.__init__
+
+            try:
+                _apply_starlette_code_attributes_patch()
+                mock_instrumentor._instrument()
+
+                # Create route - should not raise exception despite decorator error
+                route = Route("/test", endpoint=self.sample_endpoint)
+
+                # Verify route was created successfully with original endpoint
+                self.assertEqual(route.path, "/test")
+                self.assertEqual(route.endpoint, self.sample_endpoint)
+
+                # Verify warning was logged
+                mock_logger.warning.assert_called()
+                args = mock_logger.warning.call_args[0]
+                self.assertIn("Failed to apply code attributes decorator to endpoint", args[0])
+
+            finally:
+                Route.__init__ = original_route_init
+
+    @patch("amazon.opentelemetry.distro.patches._starlette_patches._logger")
+    def test_code_attributes_patch_uninstrument_restores_original(self, mock_logger):
+        """Test that uninstrumentation properly restores the original Route.__init__."""
+        try:
+            from starlette.routing import Route
+        except ImportError:
+            self.skipTest("Starlette not available")
+
+        # Create a mock StarletteInstrumentor class with proper methods
+        class MockStarletteInstrumentor:
+            def __init__(self):
+                pass
+
+            def _instrument(self, **kwargs):
+                pass
+
+            def _uninstrument(self, **kwargs):
+                pass
+
+        mock_instrumentor_class = MockStarletteInstrumentor
+        mock_instrumentor = MockStarletteInstrumentor()
+
+        mock_record_code_attributes = MagicMock()
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "opentelemetry.instrumentation.starlette": MagicMock(StarletteInstrumentor=mock_instrumentor_class),
+                "amazon.opentelemetry.distro.code_correlation": MagicMock(
+                    record_code_attributes=mock_record_code_attributes
+                ),
+            },
+        ):
+            original_route_init = Route.__init__
+
+            try:
+                _apply_starlette_code_attributes_patch()
+
+                # Apply instrumentation - this is when Route.__init__ gets wrapped
+                mock_instrumentor._instrument()
+                patched_init = Route.__init__
+
+                # Verify Route.__init__ was patched
+                self.assertNotEqual(patched_init, original_route_init)
+
+                # Apply uninstrumentation
+                mock_instrumentor._uninstrument()
+
+                # Verify Route.__init__ was restored
+                self.assertEqual(Route.__init__, original_route_init)
+
+            finally:
+                Route.__init__ = original_route_init
+
+    @patch("amazon.opentelemetry.distro.patches._starlette_patches._logger")
+    def test_code_attributes_patch_route_with_kwargs(self, mock_logger):
+        """Test that the patch works with routes that have additional kwargs."""
+        try:
+            from starlette.routing import Route
+        except ImportError:
+            self.skipTest("Starlette not available")
+
+        # Create a mock StarletteInstrumentor class with proper methods
+        class MockStarletteInstrumentor:
+            def __init__(self):
+                pass
+
+            def _instrument(self, **kwargs):
+                pass
+
+            def _uninstrument(self, **kwargs):
+                pass
+
+        mock_instrumentor_class = MockStarletteInstrumentor
+        mock_instrumentor = MockStarletteInstrumentor()
+
+        mock_record_code_attributes = MagicMock()
+        mock_record_code_attributes.side_effect = lambda func: func
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "opentelemetry.instrumentation.starlette": MagicMock(StarletteInstrumentor=mock_instrumentor_class),
+                "amazon.opentelemetry.distro.code_correlation": MagicMock(
+                    record_code_attributes=mock_record_code_attributes
+                ),
+            },
+        ):
+            original_route_init = Route.__init__
+
+            try:
+                _apply_starlette_code_attributes_patch()
+                mock_instrumentor._instrument()
+
+                # Create route with additional kwargs
+                route = Route("/test", endpoint=self.sample_endpoint, methods=["GET", "POST"], name="test_route")
+
+                # Verify decorator was called
+                mock_record_code_attributes.assert_called_once_with(self.sample_endpoint)
+
+                # Verify route was created successfully with all attributes
+                self.assertEqual(route.path, "/test")
+                # Starlette automatically adds HEAD when GET is specified
+                self.assertIn("GET", route.methods)
+                self.assertIn("POST", route.methods)
+                self.assertEqual(route.name, "test_route")
+                self.assertIsNotNone(route.endpoint)
+
+            finally:
+                Route.__init__ = original_route_init
+
+    @patch("amazon.opentelemetry.distro.patches._starlette_patches._logger")
+    def test_code_attributes_patch_handles_import_error(self, mock_logger):
+        """Test that the patch handles import errors gracefully."""
+        # Mock import failure
+        with patch.dict("sys.modules", {"starlette.routing": None}):
             # This should not raise an exception
-            _apply_starlette_instrumentation_patches()
+            _apply_starlette_code_attributes_patch()
 
             # Verify warning was logged
             mock_logger.warning.assert_called_once()
             args = mock_logger.warning.call_args[0]
-            self.assertIn("Failed to apply Starlette instrumentation patches", args[0])
-
-    def test_starlette_patch_logs_failure_with_no_logger_patch(self):  # pylint: disable=no-self-use
-        """Test that the patch handles exceptions gracefully without logger mock."""
-        # Mock the import to fail
-        with patch.dict("sys.modules", {"opentelemetry.instrumentation.starlette": None}):
-            # This should not raise an exception even without logger mock
-            _apply_starlette_instrumentation_patches()
+            self.assertIn("Failed to apply Starlette code attributes patch", args[0])
 
     @patch("amazon.opentelemetry.distro.patches._starlette_patches._logger")
-    def test_starlette_patch_with_exception_during_import(self, mock_logger):
-        """Test that the patch handles exceptions during import."""
+    def test_code_attributes_patch_handles_general_exception(self, mock_logger):
+        """Test that the patch handles general exceptions gracefully."""
 
-        # Create a module that raises exception when accessing StarletteInstrumentor
-        class FailingModule:
-            @property
-            def StarletteInstrumentor(self):  # pylint: disable=invalid-name
-                raise RuntimeError("Import failed")
+        # Mock import to cause exception - simulate an issue in module loading
+        def failing_import(*args, **kwargs):
+            raise RuntimeError("General failure")
 
-        failing_module = FailingModule()
-
-        with patch.dict("sys.modules", {"opentelemetry.instrumentation.starlette": failing_module}):
+        with patch("builtins.__import__", side_effect=failing_import):
             # This should not raise an exception
-            _apply_starlette_instrumentation_patches()
+            _apply_starlette_code_attributes_patch()
 
             # Verify warning was logged
             mock_logger.warning.assert_called_once()
             args = mock_logger.warning.call_args[0]
-            self.assertIn("Failed to apply Starlette instrumentation patches", args[0])
+            self.assertIn("Failed to apply Starlette code attributes patch", args[0])
+
+    def test_code_attributes_patch_multiple_routes(self):
+        """Test that the patch works correctly with multiple routes."""
+        try:
+            from starlette.routing import Route
+        except ImportError:
+            self.skipTest("Starlette not available")
+
+        # Create a mock StarletteInstrumentor class with proper methods
+        class MockStarletteInstrumentor:
+            def __init__(self):
+                pass
+
+            def _instrument(self, **kwargs):
+                pass
+
+            def _uninstrument(self, **kwargs):
+                pass
+
+        mock_instrumentor_class = MockStarletteInstrumentor
+        mock_instrumentor = MockStarletteInstrumentor()
+
+        mock_record_code_attributes = MagicMock()
+        mock_record_code_attributes.side_effect = lambda func: func
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "opentelemetry.instrumentation.starlette": MagicMock(StarletteInstrumentor=mock_instrumentor_class),
+                "amazon.opentelemetry.distro.code_correlation": MagicMock(
+                    record_code_attributes=mock_record_code_attributes
+                ),
+            },
+        ):
+            original_route_init = Route.__init__
+
+            try:
+                _apply_starlette_code_attributes_patch()
+                mock_instrumentor._instrument()
+
+                # Create multiple routes
+                route1 = Route("/test1", endpoint=self.sample_endpoint)
+                route2 = Route("/test2", endpoint=self.another_endpoint)
+
+                # Verify both endpoints were decorated
+                self.assertEqual(mock_record_code_attributes.call_count, 2)
+                mock_record_code_attributes.assert_any_call(self.sample_endpoint)
+                mock_record_code_attributes.assert_any_call(self.another_endpoint)
+
+                # Verify routes were created successfully
+                self.assertEqual(route1.path, "/test1")
+                self.assertEqual(route2.path, "/test2")
+                self.assertIsNotNone(route1.endpoint)
+                self.assertIsNotNone(route2.endpoint)
+
+            finally:
+                Route.__init__ = original_route_init
+
+    def test_code_attributes_patch_route_class_methods(self):
+        """Test that the patch preserves Route class methods and attributes."""
+        try:
+            from starlette.routing import Route
+        except ImportError:
+            self.skipTest("Starlette not available")
+
+        # Create a mock StarletteInstrumentor class with proper methods
+        class MockStarletteInstrumentor:
+            def __init__(self):
+                pass
+
+            def _instrument(self, **kwargs):
+                pass
+
+            def _uninstrument(self, **kwargs):
+                pass
+
+        mock_instrumentor_class = MockStarletteInstrumentor
+        mock_instrumentor = MockStarletteInstrumentor()
+
+        mock_record_code_attributes = MagicMock()
+        mock_record_code_attributes.side_effect = lambda func: func
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "opentelemetry.instrumentation.starlette": MagicMock(StarletteInstrumentor=mock_instrumentor_class),
+                "amazon.opentelemetry.distro.code_correlation": MagicMock(
+                    record_code_attributes=mock_record_code_attributes
+                ),
+            },
+        ):
+            original_route_init = Route.__init__
+
+            try:
+                _apply_starlette_code_attributes_patch()
+                mock_instrumentor._instrument()
+
+                # Create a route
+                route = Route("/test", endpoint=self.sample_endpoint, methods=["GET"])
+
+                # Verify Route methods still work
+                self.assertTrue(hasattr(route, "matches"))
+                self.assertTrue(hasattr(route, "url_path_for"))
+
+                # Test that the route still functions as expected
+                self.assertEqual(route.path, "/test")
+                # Starlette automatically adds HEAD when GET is specified
+                self.assertIn("GET", route.methods)
+                self.assertIn("HEAD", route.methods)
+
+            finally:
+                Route.__init__ = original_route_init

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/sampler/test_aws_xray_remote_sampler.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/sampler/test_aws_xray_remote_sampler.py
@@ -344,10 +344,14 @@ class TestAwsXRayRemoteSampler(TestCase):
         self.rs = AwsXRayRemoteSampler(resource=Resource.get_empty())
 
         # Mock rule cache to be expired
-        with patch.object(self.rs._root._root._AwsXRayRemoteSampler__rule_cache, "expired", return_value=True):
-            with patch("amazon.opentelemetry.distro.sampler.aws_xray_remote_sampler._logger") as mock_logger:
+        with patch.object(
+            self.rs._root._root._AwsXRayRemoteSampler__rule_cache, "expired", return_value=True
+        ):  # pylint: disable=not-context-manager
+            with patch(
+                "amazon.opentelemetry.distro.sampler.aws_xray_remote_sampler._logger"
+            ) as mock_logger:  # pylint: disable=not-context-manager
                 # Call should_sample when cache is expired
-                result = self.rs._root._root.should_sample(None, 0, "test_span")
+                result = self.rs._root._root.should_sample(None, 0, "test_span")  # pylint: disable=not-context-manager
 
                 # Verify debug log was called
                 mock_logger.debug.assert_called_once_with("Rule cache is expired so using fallback sampling strategy")

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py
@@ -94,6 +94,13 @@ class TestAwsOpenTelemetryConfigurator(TestCase):
 
     @classmethod
     def setUpClass(cls):
+        # Store original environment variables to restore later
+        cls._original_env = {}
+        for key in list(os.environ.keys()):
+            if key.startswith("OTEL_"):
+                cls._original_env[key] = os.environ[key]
+                del os.environ[key]
+
         # Run AwsOpenTelemetryDistro to set up environment, then validate expected env values.
         aws_open_telemetry_distro: AwsOpenTelemetryDistro = AwsOpenTelemetryDistro()
         aws_open_telemetry_distro.configure(apply_patches=False)

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py
@@ -40,12 +40,12 @@ from amazon.opentelemetry.distro.aws_opentelemetry_configurator import (
     _export_unsampled_span_for_agent_observability,
     _export_unsampled_span_for_lambda,
     _fetch_logs_header,
-    _get_code_correlation_enabled_status,
     _init_logging,
     _is_application_signals_enabled,
     _is_application_signals_runtime_enabled,
     _is_defer_to_workers_enabled,
     _is_wsgi_master_process,
+    get_code_correlation_enabled_status,
 )
 from amazon.opentelemetry.distro.aws_opentelemetry_distro import AwsOpenTelemetryDistro
 from amazon.opentelemetry.distro.aws_span_metrics_processor import AwsSpanMetricsProcessor
@@ -1428,60 +1428,60 @@ class TestAwsOpenTelemetryConfigurator(TestCase):
                 mock_logger.error.assert_called_once()
 
     def test_get_code_correlation_enabled_status(self):
-        """Test _get_code_correlation_enabled_status function with various environment variable values"""
+        """Test get_code_correlation_enabled_status function with various environment variable values"""
         # Test when environment variable is not set (default state)
         os.environ.pop(CODE_CORRELATION_ENABLED_CONFIG, None)
-        result = _get_code_correlation_enabled_status()
+        result = get_code_correlation_enabled_status()
         self.assertIsNone(result)
 
         # Test when environment variable is set to 'true' (case insensitive)
         os.environ[CODE_CORRELATION_ENABLED_CONFIG] = "true"
-        result = _get_code_correlation_enabled_status()
+        result = get_code_correlation_enabled_status()
         self.assertTrue(result)
 
         os.environ[CODE_CORRELATION_ENABLED_CONFIG] = "TRUE"
-        result = _get_code_correlation_enabled_status()
+        result = get_code_correlation_enabled_status()
         self.assertTrue(result)
 
         os.environ[CODE_CORRELATION_ENABLED_CONFIG] = "True"
-        result = _get_code_correlation_enabled_status()
+        result = get_code_correlation_enabled_status()
         self.assertTrue(result)
 
         # Test when environment variable is set to 'false' (case insensitive)
         os.environ[CODE_CORRELATION_ENABLED_CONFIG] = "false"
-        result = _get_code_correlation_enabled_status()
+        result = get_code_correlation_enabled_status()
         self.assertFalse(result)
 
         os.environ[CODE_CORRELATION_ENABLED_CONFIG] = "FALSE"
-        result = _get_code_correlation_enabled_status()
+        result = get_code_correlation_enabled_status()
         self.assertFalse(result)
 
         os.environ[CODE_CORRELATION_ENABLED_CONFIG] = "False"
-        result = _get_code_correlation_enabled_status()
+        result = get_code_correlation_enabled_status()
         self.assertFalse(result)
 
         # Test with leading/trailing whitespace
         os.environ[CODE_CORRELATION_ENABLED_CONFIG] = "  true  "
-        result = _get_code_correlation_enabled_status()
+        result = get_code_correlation_enabled_status()
         self.assertTrue(result)
 
         os.environ[CODE_CORRELATION_ENABLED_CONFIG] = "  false  "
-        result = _get_code_correlation_enabled_status()
+        result = get_code_correlation_enabled_status()
         self.assertFalse(result)
 
         # Test invalid values (should return None and log warning)
         os.environ[CODE_CORRELATION_ENABLED_CONFIG] = "invalid"
-        result = _get_code_correlation_enabled_status()
+        result = get_code_correlation_enabled_status()
         self.assertIsNone(result)
 
         # Test another invalid value
         os.environ[CODE_CORRELATION_ENABLED_CONFIG] = "yes"
-        result = _get_code_correlation_enabled_status()
+        result = get_code_correlation_enabled_status()
         self.assertIsNone(result)
 
         # Test empty string (invalid)
         os.environ[CODE_CORRELATION_ENABLED_CONFIG] = ""
-        result = _get_code_correlation_enabled_status()
+        result = get_code_correlation_enabled_status()
         self.assertIsNone(result)
 
         # Clean up

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -15,3 +15,6 @@ requests==2.32.4
 ruamel.yaml==0.17.21
 flaky==3.7.0
 botocore==1.34.67
+flask>=2.0.0
+fastapi>=0.68.0
+starlette>=0.14.2

--- a/eachdist.ini
+++ b/eachdist.ini
@@ -4,7 +4,7 @@
 
 [lintroots]
 extraroots=scripts/, sample-applications/, contract-tests/images/
-subglob=*.py,tests/,test/,src/*, simple-client-server, applications/django/**
+subglob=*.py,src/*, simple-client-server, applications/django/**
 
 [testroots]
 extraroots=tests/

--- a/lambda-layer/src/opentelemetry/instrumentation/aws_lambda/__init__.py
+++ b/lambda-layer/src/opentelemetry/instrumentation/aws_lambda/__init__.py
@@ -91,6 +91,18 @@ from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.trace import Span, SpanKind, TracerProvider, get_tracer, get_tracer_provider
 from opentelemetry.trace.status import Status, StatusCode
 
+# Import code correlation functionality
+try:
+    from amazon.opentelemetry.distro.aws_opentelemetry_configurator import get_code_correlation_enabled_status
+    from amazon.opentelemetry.distro.code_correlation import add_code_attributes_to_span
+except ImportError:
+    # If code correlation module is not available, define no-op functions
+    def add_code_attributes_to_span(span, func):
+        pass
+    
+    def get_code_correlation_enabled_status():
+        return None
+
 logger = logging.getLogger(__name__)
 
 _HANDLER = "_HANDLER"
@@ -302,6 +314,17 @@ def _instrument(
                         ResourceAttributes.CLOUD_ACCOUNT_ID,
                         account_id,
                     )
+
+                    # Add code-level information attributes to the span if enabled
+                    if get_code_correlation_enabled_status() is True:
+                        try:
+                            add_code_attributes_to_span(span, call_wrapped)
+                        except Exception as exc:
+                            # Log but don't fail the instrumentation
+                            logger.debug(
+                                "Failed to add code attributes to lambda span: %s", 
+                                str(exc)
+                            )
 
                 exception = None
                 result = None

--- a/lambda-layer/src/opentelemetry/instrumentation/aws_lambda/__init__.py
+++ b/lambda-layer/src/opentelemetry/instrumentation/aws_lambda/__init__.py
@@ -99,7 +99,7 @@ except ImportError:
     # If code correlation module is not available, define no-op functions
     def add_code_attributes_to_span(span, func):
         pass
-    
+
     def get_code_correlation_enabled_status():
         return None
 
@@ -322,7 +322,7 @@ def _instrument(
                         except Exception as exc:
                             # Log but don't fail the instrumentation
                             logger.debug(
-                                "Failed to add code attributes to lambda span: %s", 
+                                "Failed to add code attributes to lambda span: %s",
                                 str(exc)
                             )
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,9 @@ deps =
   -c dev-requirements.txt
   test: pytest
   test: pytest-cov
+  test: fastapi
+  test: starlette
+  test: flask
 
 setenv =
   ; TODO: The two repos branches need manual updated over time, need to figure out a more sustainable solution.

--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,7 @@ commands_pre =
   test: pip install "opentelemetry-sdk[test] @ {env:CORE_REPO}#egg=opentelemetry-sdk&subdirectory=opentelemetry-sdk"
   test: pip install "opentelemetry-instrumentation[test] @ {env:CONTRIB_REPO}#egg=opentelemetry-instrumentation&subdirectory=opentelemetry-instrumentation"
   test: pip install "opentelemetry-exporter-otlp[test] @ {env:CORE_REPO}#egg=opentelemetry-exporter-otlp&subdirectory=exporter/opentelemetry-exporter-otlp"
+  test: pip install "opentelemetry-test-utils @ {env:CORE_REPO}#egg=opentelemetry-test-utils&subdirectory=tests/opentelemetry-test-utils"
   aws-opentelemetry-distro: pip install {toxinidir}/aws-opentelemetry-distro
 
 commands =


### PR DESCRIPTION
*Description of changes:*
If set environment variable `OTEL_AWS_CODE_CORRELATION_ENABLED=true`, server spans of starlette, fastapi, flask and aws lambda have code-level information. 
```
    "attributes": {
        "code.function.name": "home",
        "code.file.path": "/Volumes/workplace/extension/aws-otel-python-instrumentation/samples/fastapi/app.py",
        "code.line.number": 87,
    },
``` 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

