### PR TITLE
feat: introduce AWS_AGENTIC_OBSERVABILITY_OPT_IN and refactor agent observability config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
-- feat: introduce AWS_AGENTIC_OBSERVABILITY_OPT_IN and refactor agent observability config
+- feat: [BREAKING CHANGE] introduce AWS_AGENTIC_OBSERVABILITY_OPT_IN and refactor agent observability config
   ([#691](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/691))
 - feat: propagate HTTP context for MCP requests and prefix all span names with mcp
   ([#683](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/683))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- feat: introduce AWS_AGENTIC_OBSERVABILITY_OPT_IN and refactor agent observability config
+  ([#691](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/691))
 - feat: propagate HTTP context for MCP requests and prefix all span names with mcp
   ([#683](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/683))
 - feat: add threading instrumentation dependency

--- a/aws-opentelemetry-distro/pyproject.toml
+++ b/aws-opentelemetry-distro/pyproject.toml
@@ -108,6 +108,9 @@ aws_distro = "amazon.opentelemetry.distro.aws_opentelemetry_distro:AwsOpenTeleme
 aws_crewai = "amazon.opentelemetry.distro.instrumentation.crewai:CrewAIInstrumentor"
 aws_langchain = "amazon.opentelemetry.distro.instrumentation.langchain:LangChainInstrumentor"
 aws_mcp = "amazon.opentelemetry.distro.instrumentation.mcp:McpInstrumentor"
+# Wraps the upstream OTel OpenAI Agents instrumentor under a unique entry point name.
+# This allows us to disable 3rd party "openai_agents" entry points in the opt-in path
+# while keeping OpenAI Agents instrumentation active via this alias.
 aws_openai_agents = "opentelemetry.instrumentation.openai_agents:OpenAIAgentsInstrumentor"
 
 [project.urls]

--- a/aws-opentelemetry-distro/pyproject.toml
+++ b/aws-opentelemetry-distro/pyproject.toml
@@ -108,6 +108,7 @@ aws_distro = "amazon.opentelemetry.distro.aws_opentelemetry_distro:AwsOpenTeleme
 aws_crewai = "amazon.opentelemetry.distro.instrumentation.crewai:CrewAIInstrumentor"
 aws_langchain = "amazon.opentelemetry.distro.instrumentation.langchain:LangChainInstrumentor"
 aws_mcp = "amazon.opentelemetry.distro.instrumentation.mcp:McpInstrumentor"
+aws_openai_agents = "opentelemetry.instrumentation.openai_agents:OpenAIAgentsInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/aws-observability/aws-otel-python-instrumentation/tree/main/aws-opentelemetry-distro"

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_utils.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_utils.py
@@ -10,7 +10,9 @@ from packaging.requirements import Requirement
 
 _logger: Logger = getLogger(__name__)
 
+# Maintained for backwards compatibility. New users should use AWS_AGENTIC_OBSERVABILITY_OPT_IN instead.
 AGENT_OBSERVABILITY_ENABLED = "AGENT_OBSERVABILITY_ENABLED"
+AWS_AGENTIC_OBSERVABILITY_OPT_IN = "AWS_AGENTIC_OBSERVABILITY_OPT_IN"
 OTEL_METRICS_ADD_APPLICATION_SIGNALS_DIMENSIONS = "OTEL_METRICS_ADD_APPLICATION_SIGNALS_DIMENSIONS"
 
 
@@ -35,8 +37,18 @@ def is_installed(req: str) -> bool:
 
 
 def is_agent_observability_enabled() -> bool:
-    """Is the Agentic AI monitoring flag set to true?"""
+    # Maintained for backwards compatibility. New users should use AWS_AGENTIC_OBSERVABILITY_OPT_IN instead.
     return os.environ.get(AGENT_OBSERVABILITY_ENABLED, "false").lower() == "true"
+
+
+def is_aws_agentic_observability_opt_in() -> bool:
+    """Is the AI observability opt-in flag set to true?"""
+    return os.environ.get(AWS_AGENTIC_OBSERVABILITY_OPT_IN, "false").lower() == "true"
+
+
+def is_agentic_observability_enabled() -> bool:
+    """Returns True if either AGENT_OBSERVABILITY_ENABLED or AWS_AGENTIC_OBSERVABILITY_OPT_IN is set to true."""
+    return is_agent_observability_enabled() or is_aws_agentic_observability_opt_in()
 
 
 def should_add_application_signals_dimensions() -> bool:

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
@@ -526,7 +526,7 @@ def _customize_span_processors(provider: TracerProvider, resource: Resource, sam
     # AI applications typically have low throughput traffic patterns and require
     # comprehensive monitoring to catch subtle failure modes like hallucinations
     # and quality degradation that sampling could miss.
-    if is_agent_observability_enabled():
+    if is_agentic_observability_enabled():
         _export_unsampled_span_for_agent_observability(provider, resource)
         baggage_keys.add("session.id")
 

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
@@ -17,7 +17,7 @@ from typing_extensions import override
 
 from amazon.opentelemetry.distro._aws_attribute_keys import AWS_LOCAL_SERVICE, AWS_SERVICE_TYPE
 from amazon.opentelemetry.distro._aws_resource_attribute_configurator import get_service_attribute
-from amazon.opentelemetry.distro._utils import get_aws_session, is_agent_observability_enabled
+from amazon.opentelemetry.distro._utils import get_aws_session, is_agentic_observability_enabled
 from amazon.opentelemetry.distro.always_record_sampler import AlwaysRecordSampler
 from amazon.opentelemetry.distro.attribute_propagating_span_processor_builder import (
     AttributePropagatingSpanProcessorBuilder,
@@ -204,7 +204,7 @@ def _initialize_components():
             AwsEksResourceDetector(),
             AwsEcsResourceDetector(),
         ]
-        if not (_is_lambda_environment() or is_agent_observability_enabled())
+        if not (_is_lambda_environment() or is_agentic_observability_enabled())
         else []
     )
 
@@ -326,7 +326,7 @@ def _export_unsampled_span_for_lambda(trace_provider: TracerProvider, resource: 
 
 
 def _export_unsampled_span_for_agent_observability(trace_provider: TracerProvider, resource: Resource = None):
-    if not is_agent_observability_enabled():
+    if not is_agentic_observability_enabled():
         return
 
     traces_endpoint = os.environ.get(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT)
@@ -467,7 +467,7 @@ def _customize_log_record_processor(logger_provider: LoggerProvider, log_exporte
     if not log_exporter:
         return
 
-    if is_agent_observability_enabled():
+    if is_agentic_observability_enabled():
         # pylint: disable=import-outside-toplevel
         from amazon.opentelemetry.distro.exporter.otlp.aws.logs._aws_cw_otlp_batch_log_record_processor import (
             AwsCloudWatchOtlpBatchLogRecordProcessor,
@@ -525,7 +525,7 @@ def _customize_span_processors(provider: TracerProvider, resource: Resource, sam
     # and quality degradation that sampling could miss.
     # Add session.id baggage attribute to span attributes to support AI Agent use cases
     # enabling session ID tracking in spans.
-    if is_agent_observability_enabled():
+    if is_agentic_observability_enabled():
         _export_unsampled_span_for_agent_observability(provider, resource)
         # propagates baggage entries matching OTEL_BAGGAGE_SPAN_ATTRIBUTE_KEYS into span attributes
         raw: str = os.environ.get(OTEL_BAGGAGE_SPAN_ATTRIBUTE_KEYS, "").strip()
@@ -635,7 +635,7 @@ def _customize_resource(resource: Resource) -> Resource:
 
     custom_attributes = {AWS_LOCAL_SERVICE: service_name}
 
-    if is_agent_observability_enabled():
+    if is_agentic_observability_enabled():
         # Add aws.service.type if it doesn't exist in the resource
         if resource and resource.attributes.get(AWS_SERVICE_TYPE) is None:
             # Set a default agent type for AI agent observability
@@ -916,7 +916,7 @@ def _create_aws_otlp_exporter(endpoint: str, service: str, region: str):
         from amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter import OTLPAwsSpanExporter
 
         if service == XRAY_SERVICE:
-            if is_agent_observability_enabled():
+            if is_agentic_observability_enabled():
                 # Span exporter needs an instance of logger provider in ai agent
                 # observability case because we need to split input/output prompts
                 # from span attributes and send them to the logs pipeline per

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
@@ -16,10 +16,12 @@ import os
 import sys
 from logging import ERROR, Logger, getLogger
 
+
 from amazon.opentelemetry.distro._utils import (
     OTEL_METRICS_ADD_APPLICATION_SIGNALS_DIMENSIONS,
     get_aws_region,
     is_agent_observability_enabled,
+    is_aws_agentic_observability_opt_in,
     is_installed,
 )
 from amazon.opentelemetry.distro.aws_opentelemetry_configurator import APPLICATION_SIGNALS_ENABLED_CONFIG
@@ -36,7 +38,7 @@ from opentelemetry.environment_variables import (
 from opentelemetry.instrumentation.auto_instrumentation import _load
 from opentelemetry.instrumentation.environment_variables import OTEL_PYTHON_DISABLED_INSTRUMENTATIONS
 from opentelemetry.instrumentation.logging import LEVELS
-from opentelemetry.instrumentation.logging.environment_variables import OTEL_PYTHON_LOG_LEVEL
+from opentelemetry.instrumentation.logging.environment_variables import OTEL_PYTHON_LOG_CORRELATION, OTEL_PYTHON_LOG_LEVEL
 from opentelemetry.sdk.environment_variables import (
     _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED as OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED,
 )
@@ -44,10 +46,8 @@ from opentelemetry.sdk.environment_variables import (
     OTEL_EXPORTER_OTLP_ENDPOINT,
     OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
     OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION,
-    OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,
     OTEL_EXPORTER_OTLP_PROTOCOL,
     OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
-    OTEL_TRACES_SAMPLER,
 )
 
 _logger: Logger = getLogger(__name__)
@@ -57,7 +57,12 @@ _load._logger.setLevel(LEVELS.get(os.environ.get(OTEL_PYTHON_LOG_LEVEL, "error")
 
 AGENT_OBSERVABILITY_DISABLED_INSTRUMENTATIONS = (
     "http,sqlalchemy,psycopg2,pymysql,sqlite3,aiopg,asyncpg,mysql_connector,"
-    "urllib3,requests,system_metrics,google-genai,crewai,langchain,mcp"
+    "urllib3,requests,system_metrics,google-genai,aws_crewai,aws_langchain,aws_mcp"
+)
+
+AWS_AGENTIC_OBSERVABILITY_DISABLED_INSTRUMENTATIONS = (
+    "sqlalchemy,psycopg2,pymysql,sqlite3,aiopg,asyncpg,mysql_connector,"
+    "system_metrics,google-genai,crewai,langchain,mcp"
 )
 
 
@@ -134,51 +139,41 @@ class AwsOpenTelemetryDistro(OpenTelemetryDistro):
             OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION, "base2_exponential_bucket_histogram"
         )
 
-        if is_agent_observability_enabled():
-            os.environ.setdefault("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "true")
-            os.environ.setdefault(OTEL_TRACES_SAMPLER, "parentbased_always_on")
-            os.environ.setdefault(
-                OTEL_PYTHON_DISABLED_INSTRUMENTATIONS,
-                AGENT_OBSERVABILITY_DISABLED_INSTRUMENTATIONS,
+        if is_aws_agentic_observability_opt_in():
+            _logger.info("AWS Agentic Observability enabled.")
+            self._configure_common_agent_observability(AWS_AGENTIC_OBSERVABILITY_DISABLED_INSTRUMENTATIONS)
+            os.environ.setdefault(OTEL_METRICS_EXPORTER, "otlp")
+            os.environ.setdefault("CREWAI_DISABLE_TELEMETRY", "true")
+        elif is_agent_observability_enabled():
+             # Maintained for backwards compatibility. New users should use AWS_AGENTIC_OBSERVABILITY_OPT_IN instead.
+            _logger.info(
+                "AGENT_OBSERVABILITY_ENABLED is set. Consider using AWS_AGENTIC_OBSERVABILITY_OPT_IN for ADOT Agentic Observability."
             )
-            os.environ.setdefault(OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED, "true")
-            os.environ.setdefault(APPLICATION_SIGNALS_ENABLED_CONFIG, "false")
-            os.environ.setdefault(OTEL_METRICS_ADD_APPLICATION_SIGNALS_DIMENSIONS, "false")
-
-            version = os.environ.get("AGENT_OBSERVABILITY_VERSION", "1")
-            if version == "1":
-                _configure_agent_observability_v1(get_aws_region())
-            else:
-                _configure_agent_observability_v2()
+            self._configure_common_agent_observability(AGENT_OBSERVABILITY_DISABLED_INSTRUMENTATIONS)
+            os.environ.setdefault(OTEL_METRICS_EXPORTER, "awsemf")
+            region = get_aws_region()
+            if not os.environ.get(OTEL_EXPORTER_OTLP_ENDPOINT):
+                if region:
+                    os.environ.setdefault(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, f"https://xray.{region}.amazonaws.com/v1/traces")
+                    os.environ.setdefault(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT, f"https://logs.{region}.amazonaws.com/v1/logs")
+                else:
+                    _logger.warning(
+                        "AWS region could not be determined. OTLP endpoints will not be automatically configured. "
+                        "Please set AWS_REGION environment variable or configure OTLP endpoints manually."
+                    )
 
         super(AwsOpenTelemetryDistro, self)._configure()
 
         if kwargs.get("apply_patches", True):
             apply_instrumentation_patches()
 
-
-def _configure_agent_observability_v1(region: str) -> None:
-    # "otlp" is already native OTel default, but we set them here to be explicit
-    # about intended configuration for agent observability
-    os.environ.setdefault(OTEL_TRACES_EXPORTER, "otlp")
-    os.environ.setdefault(OTEL_LOGS_EXPORTER, "otlp")
-    os.environ.setdefault(OTEL_METRICS_EXPORTER, "awsemf")
-    if not os.environ.get(OTEL_EXPORTER_OTLP_ENDPOINT):
-        if region:
-            os.environ.setdefault(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, f"https://xray.{region}.amazonaws.com/v1/traces")
-            os.environ.setdefault(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT, f"https://logs.{region}.amazonaws.com/v1/logs")
-        else:
-            _logger.warning(
-                "AWS region could not be determined. OTLP endpoints will not be automatically configured. "
-                "Please set AWS_REGION environment variable or configure OTLP endpoints manually."
-            )
-
-
-def _configure_agent_observability_v2() -> None:
-    os.environ.setdefault(OTEL_TRACES_EXPORTER, "otlp")
-    os.environ.setdefault(OTEL_LOGS_EXPORTER, "otlp")
-    os.environ.setdefault(OTEL_METRICS_EXPORTER, "otlp")
-    if not os.environ.get(OTEL_EXPORTER_OTLP_ENDPOINT):
-        os.environ.setdefault(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, "http://localhost:4318/v1/traces")
-        os.environ.setdefault(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT, "http://localhost:4318/v1/logs")
-        os.environ.setdefault(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT, "http://localhost:4318/v1/metrics")
+    @staticmethod
+    def _configure_common_agent_observability(disabled_instrumentations: str) -> None:
+        os.environ.setdefault("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "true")
+        os.environ.setdefault(OTEL_PYTHON_DISABLED_INSTRUMENTATIONS, disabled_instrumentations)
+        os.environ.setdefault(OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED, "true")
+        os.environ.setdefault(OTEL_PYTHON_LOG_CORRELATION, "true")
+        os.environ.setdefault(APPLICATION_SIGNALS_ENABLED_CONFIG, "false")
+        os.environ.setdefault(OTEL_METRICS_ADD_APPLICATION_SIGNALS_DIMENSIONS, "false")
+        os.environ.setdefault(OTEL_TRACES_EXPORTER, "otlp")
+        os.environ.setdefault(OTEL_LOGS_EXPORTER, "otlp")

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
@@ -57,12 +57,12 @@ _load._logger.setLevel(LEVELS.get(os.environ.get(OTEL_PYTHON_LOG_LEVEL, "error")
 
 AGENT_OBSERVABILITY_DISABLED_INSTRUMENTATIONS = (
     "http,sqlalchemy,psycopg2,pymysql,sqlite3,aiopg,asyncpg,mysql_connector,"
-    "urllib3,requests,system_metrics,google-genai,aws_crewai,aws_langchain,aws_mcp"
+    "urllib3,requests,system_metrics,google-genai,aws_crewai,aws_langchain,aws_mcp,aws_openai_agents"
 )
 
 AWS_AGENTIC_OBSERVABILITY_DISABLED_INSTRUMENTATIONS = (
     "sqlalchemy,psycopg2,pymysql,sqlite3,aiopg,asyncpg,mysql_connector,"
-    "system_metrics,google-genai,crewai,langchain,mcp"
+    "system_metrics,google-genai,crewai,langchain,mcp,openai_agents"
 )
 
 

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
@@ -15,8 +15,6 @@ import importlib
 import os
 import sys
 from logging import ERROR, Logger, getLogger
-from opentelemetry.util._importlib_metadata import EntryPoint
-
 
 from amazon.opentelemetry.distro._utils import (
     OTEL_METRICS_ADD_APPLICATION_SIGNALS_DIMENSIONS,
@@ -53,6 +51,7 @@ from opentelemetry.sdk.environment_variables import (
     OTEL_EXPORTER_OTLP_PROTOCOL,
     OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
 )
+from opentelemetry.util._importlib_metadata import EntryPoint
 
 _logger: Logger = getLogger(__name__)
 # Suppress configurator warnings from auto-instrumentation

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
@@ -15,6 +15,7 @@ import importlib
 import os
 import sys
 from logging import ERROR, Logger, getLogger
+from opentelemetry.util._importlib_metadata import EntryPoint
 
 
 from amazon.opentelemetry.distro._utils import (
@@ -166,6 +167,27 @@ class AwsOpenTelemetryDistro(OpenTelemetryDistro):
 
         if kwargs.get("apply_patches", True):
             apply_instrumentation_patches()
+
+    def load_instrumentor(self, entry_point: EntryPoint, **kwargs):
+        if self._should_skip_instrumentor(entry_point):
+            return
+        super().load_instrumentor(entry_point, **kwargs)
+
+    @staticmethod
+    def _should_skip_instrumentor(entry_point: EntryPoint) -> bool:
+        # Some third-party SDKs register the same entry point name as the upstream
+        # OTel packages that we depend on. For Agentic Observability legacy mode, skip our bundled
+        # OTel instrumentation so that existing third-party setups are not brokens.
+        if (
+            is_agent_observability_enabled()
+            and not is_aws_agentic_observability_opt_in()
+            and entry_point.dist
+            and entry_point.name == "openai_agents"
+            and entry_point.dist.name == "opentelemetry-instrumentation-openai-agents-v2"
+        ):
+            return True
+        # TODO: add additional skip conditions here as needed
+        return False
 
     @staticmethod
     def _configure_common_agent_observability(disabled_instrumentations: str) -> None:

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
@@ -39,7 +39,10 @@ from opentelemetry.environment_variables import (
 from opentelemetry.instrumentation.auto_instrumentation import _load
 from opentelemetry.instrumentation.environment_variables import OTEL_PYTHON_DISABLED_INSTRUMENTATIONS
 from opentelemetry.instrumentation.logging import LEVELS
-from opentelemetry.instrumentation.logging.environment_variables import OTEL_PYTHON_LOG_CORRELATION, OTEL_PYTHON_LOG_LEVEL
+from opentelemetry.instrumentation.logging.environment_variables import (
+    OTEL_PYTHON_LOG_CORRELATION,
+    OTEL_PYTHON_LOG_LEVEL,
+)
 from opentelemetry.sdk.environment_variables import (
     _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED as OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED,
 )
@@ -146,7 +149,7 @@ class AwsOpenTelemetryDistro(OpenTelemetryDistro):
             os.environ.setdefault(OTEL_METRICS_EXPORTER, "otlp")
             os.environ.setdefault("CREWAI_DISABLE_TELEMETRY", "true")
         elif is_agent_observability_enabled():
-             # Maintained for backwards compatibility. New users should use AWS_AGENTIC_OBSERVABILITY_OPT_IN instead.
+            # Maintained for backwards compatibility. New users should use AWS_AGENTIC_OBSERVABILITY_OPT_IN instead.
             _logger.info(
                 "AGENT_OBSERVABILITY_ENABLED is set. Consider using AWS_AGENTIC_OBSERVABILITY_OPT_IN for ADOT Agentic Observability."
             )
@@ -155,8 +158,12 @@ class AwsOpenTelemetryDistro(OpenTelemetryDistro):
             region = get_aws_region()
             if not os.environ.get(OTEL_EXPORTER_OTLP_ENDPOINT):
                 if region:
-                    os.environ.setdefault(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, f"https://xray.{region}.amazonaws.com/v1/traces")
-                    os.environ.setdefault(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT, f"https://logs.{region}.amazonaws.com/v1/logs")
+                    os.environ.setdefault(
+                        OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, f"https://xray.{region}.amazonaws.com/v1/traces"
+                    )
+                    os.environ.setdefault(
+                        OTEL_EXPORTER_OTLP_LOGS_ENDPOINT, f"https://logs.{region}.amazonaws.com/v1/logs"
+                    )
                 else:
                     _logger.warning(
                         "AWS region could not be determined. OTLP endpoints will not be automatically configured. "

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
@@ -59,8 +59,8 @@ _load._logger.setLevel(LEVELS.get(os.environ.get(OTEL_PYTHON_LOG_LEVEL, "error")
 
 
 AGENT_OBSERVABILITY_DISABLED_INSTRUMENTATIONS = (
-    "http,sqlalchemy,psycopg2,pymysql,sqlite3,aiopg,asyncpg,mysql_connector,"
-    "urllib3,requests,system_metrics,google-genai,aws_crewai,aws_langchain,aws_mcp,aws_openai_agents"
+    "sqlalchemy,psycopg2,pymysql,sqlite3,aiopg,asyncpg,mysql_connector,"
+    "system_metrics,google-genai,aws_crewai,aws_langchain,aws_mcp,aws_openai_agents"
 )
 
 AWS_AGENTIC_OBSERVABILITY_DISABLED_INSTRUMENTATIONS = (

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/code_correlation/internal/3rd.txt
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/code_correlation/internal/3rd.txt
@@ -135,7 +135,6 @@ coverage
 azure-core
 gitpython
 opentelemetry-util-http
-opentelemetry-util-genai
 msal
 asn1crypto
 wcwidth
@@ -4671,7 +4670,6 @@ curatorbin
 ocspbuilder
 apache-airflow-providers-apache-livy
 opentelemetry-instrumentation-openai-agents
-opentelemetry-instrumentation-openai-agents-v2
 pyserde
 mypy-boto3-ssm-guiconnect
 evergreen-lint

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/code_correlation/internal/3rd.txt
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/code_correlation/internal/3rd.txt
@@ -135,6 +135,7 @@ coverage
 azure-core
 gitpython
 opentelemetry-util-http
+opentelemetry-util-genai
 msal
 asn1crypto
 wcwidth
@@ -4670,6 +4671,7 @@ curatorbin
 ocspbuilder
 apache-airflow-providers-apache-livy
 opentelemetry-instrumentation-openai-agents
+opentelemetry-instrumentation-openai-agents-v2
 pyserde
 mypy-boto3-ssm-guiconnect
 evergreen-lint

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/exporter/otlp/aws/common/_aws_http_headers.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/exporter/otlp/aws/common/_aws_http_headers.py
@@ -1,14 +1,14 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from amazon.opentelemetry.distro._utils import is_agent_observability_enabled
+from amazon.opentelemetry.distro._utils import is_agentic_observability_enabled
 from amazon.opentelemetry.distro.version import __version__
 
 
 def build_user_agent() -> str:
     user_agent = f"ADOT-OTLP-Exporter-Python/{__version__}"
 
-    if is_agent_observability_enabled():
+    if is_agentic_observability_enabled():
         user_agent = f"ADOT-GenAI-OTLP-Exporter-Python/{__version__}"
     return user_agent
 

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/exporter/otlp/aws/traces/otlp_aws_span_exporter.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/exporter/otlp/aws/traces/otlp_aws_span_exporter.py
@@ -6,7 +6,7 @@ from typing import Dict, Optional, Sequence
 
 from botocore.session import Session
 
-from amazon.opentelemetry.distro._utils import is_agent_observability_enabled
+from amazon.opentelemetry.distro._utils import is_agentic_observability_enabled
 from amazon.opentelemetry.distro.exporter.otlp.aws.common._aws_http_headers import _OTLP_AWS_HTTP_HEADERS
 from amazon.opentelemetry.distro.exporter.otlp.aws.common.aws_auth_session import AwsAuthSession
 from amazon.opentelemetry.distro.llo_handler import LLOHandler
@@ -61,7 +61,7 @@ class OTLPAwsSpanExporter(OTLPSpanExporter):
 
     def _ensure_llo_handler(self):
         """Lazily initialize LLO handler when needed to avoid initialization order issues"""
-        if self._llo_handler is None and is_agent_observability_enabled():
+        if self._llo_handler is None and is_agentic_observability_enabled():
             if self._logger_provider is None:
                 try:
                     self._logger_provider = get_logger_provider()
@@ -77,7 +77,7 @@ class OTLPAwsSpanExporter(OTLPSpanExporter):
 
     def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
         try:
-            if is_agent_observability_enabled() and self._ensure_llo_handler():
+            if is_agentic_observability_enabled() and self._ensure_llo_handler():
                 llo_processed_spans = self._llo_handler.process_spans(spans)
                 return super().export(llo_processed_spans)
         except Exception:  # pylint: disable=broad-exception-caught

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_starlette_patches.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_starlette_patches.py
@@ -3,7 +3,7 @@
 # Modifications Copyright The OpenTelemetry Authors. Licensed under the Apache License 2.0 License.
 from logging import Logger, getLogger
 
-from amazon.opentelemetry.distro._utils import is_agent_observability_enabled
+from amazon.opentelemetry.distro._utils import is_agentic_observability_enabled
 
 _logger: Logger = getLogger(__name__)
 
@@ -24,7 +24,7 @@ def _apply_starlette_instrumentation_patches() -> None:
         #
         # Issue for tracking a feature to customize this setting within Starlette:
         # https://github.com/open-telemetry/opentelemetry-python-contrib/issues/3725
-        if is_agent_observability_enabled():
+        if is_agentic_observability_enabled():
             original_init = OpenTelemetryMiddleware.__init__
 
             def patched_init(self, app, **kwargs):

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/exporter/otlp/aws/traces/test_otlp_aws_span_exporter.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/exporter/otlp/aws/traces/test_otlp_aws_span_exporter.py
@@ -50,7 +50,9 @@ class TestOTLPAwsSpanExporter(TestCase):
         self.assertEqual(exporter._session.headers["X-Custom-Header"], "custom-value")
         self.assertIn("User-Agent", exporter._session.headers)
 
-    @patch("amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.is_agent_observability_enabled")
+    @patch(
+        "amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.is_agentic_observability_enabled"
+    )
     def test_ensure_llo_handler_when_disabled(self, mock_is_enabled):
         # Test _ensure_llo_handler when agent observability is disabled
         mock_is_enabled.return_value = False
@@ -64,7 +66,9 @@ class TestOTLPAwsSpanExporter(TestCase):
         mock_is_enabled.assert_called_once()
 
     @patch("amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.get_logger_provider")
-    @patch("amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.is_agent_observability_enabled")
+    @patch(
+        "amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.is_agentic_observability_enabled"
+    )
     @patch("amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.LLOHandler")
     def test_ensure_llo_handler_lazy_initialization(
         self, mock_llo_handler_class, mock_is_enabled, mock_get_logger_provider
@@ -98,7 +102,9 @@ class TestOTLPAwsSpanExporter(TestCase):
         mock_get_logger_provider.assert_not_called()
 
     @patch("amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.get_logger_provider")
-    @patch("amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.is_agent_observability_enabled")
+    @patch(
+        "amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.is_agentic_observability_enabled"
+    )
     def test_ensure_llo_handler_with_existing_logger_provider(self, mock_is_enabled, mock_get_logger_provider):
         # Test when logger_provider is already provided
         mock_is_enabled.return_value = True
@@ -123,7 +129,9 @@ class TestOTLPAwsSpanExporter(TestCase):
             mock_get_logger_provider.assert_not_called()
 
     @patch("amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.get_logger_provider")
-    @patch("amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.is_agent_observability_enabled")
+    @patch(
+        "amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.is_agentic_observability_enabled"
+    )
     def test_ensure_llo_handler_get_logger_provider_fails(self, mock_is_enabled, mock_get_logger_provider):
         # Test when get_logger_provider raises exception
         mock_is_enabled.return_value = True
@@ -137,7 +145,9 @@ class TestOTLPAwsSpanExporter(TestCase):
         self.assertFalse(result)
         self.assertIsNone(exporter._llo_handler)
 
-    @patch("amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.is_agent_observability_enabled")
+    @patch(
+        "amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.is_agentic_observability_enabled"
+    )
     def test_export_with_llo_disabled(self, mock_is_enabled):
         # Test export when LLO is disabled
         mock_is_enabled.return_value = False
@@ -156,7 +166,9 @@ class TestOTLPAwsSpanExporter(TestCase):
             mock_parent_export.assert_called_once_with(spans)
             self.assertIsNone(exporter._llo_handler)
 
-    @patch("amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.is_agent_observability_enabled")
+    @patch(
+        "amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.is_agentic_observability_enabled"
+    )
     @patch("amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.get_logger_provider")
     @patch("amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.LLOHandler")
     def test_export_with_llo_enabled(self, mock_llo_handler_class, mock_get_logger_provider, mock_is_enabled):
@@ -186,7 +198,9 @@ class TestOTLPAwsSpanExporter(TestCase):
             mock_llo_handler.process_spans.assert_called_once_with(original_spans)
             mock_parent_export.assert_called_once_with(processed_spans)
 
-    @patch("amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.is_agent_observability_enabled")
+    @patch(
+        "amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.is_agentic_observability_enabled"
+    )
     @patch("amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.get_logger_provider")
     @patch("amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.LLOHandler")
     def test_export_with_llo_processing_failure(

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/openai_agents/test_openai_agents_entry_point.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/openai_agents/test_openai_agents_entry_point.py
@@ -1,0 +1,38 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest import TestCase
+
+from opentelemetry.instrumentation.openai_agents import OpenAIAgentsInstrumentor
+
+
+class TestOpenAIAgentsInstrumentation(TestCase):
+
+    def test_aws_openai_agents_entry_point_resolves(self):
+        from importlib.metadata import entry_points
+
+        eps = entry_points(group="opentelemetry_instrumentor", name="aws_openai_agents")
+        self.assertEqual(len(list(eps)), 1)
+
+        ep = list(eps)[0]
+        instrumentor_class = ep.load()
+        self.assertIs(instrumentor_class, OpenAIAgentsInstrumentor)
+
+    def test_instrumentor_can_be_instantiated(self):
+        instrumentor = OpenAIAgentsInstrumentor()
+        self.assertIsNotNone(instrumentor)
+
+    def test_instrument_called_twice_only_sets_processor_once(self):
+        instrumentor = OpenAIAgentsInstrumentor()
+        if instrumentor.is_instrumented_by_opentelemetry:
+            instrumentor.uninstrument()
+
+        instrumentor.instrument()
+        first_processor = instrumentor._processor
+        self.assertIsNotNone(first_processor)
+
+        instrumentor.instrument()
+        self.assertIs(instrumentor._processor, first_processor)
+
+        instrumentor.uninstrument()
+        self.assertIsNone(instrumentor._processor)

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/openai_agents/test_openai_agents_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/openai_agents/test_openai_agents_instrumentor.py
@@ -1,13 +1,19 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import unittest
 from importlib.metadata import entry_points
-from unittest import TestCase
 
-from opentelemetry.instrumentation.openai_agents import OpenAIAgentsInstrumentor
+try:
+    from opentelemetry.instrumentation.openai_agents import OpenAIAgentsInstrumentor
+
+    _AGENTS_AVAILABLE = True
+except ImportError:
+    _AGENTS_AVAILABLE = False
 
 
-class TestOpenAIAgentsInstrumentation(TestCase):
+@unittest.skipUnless(_AGENTS_AVAILABLE, "openai-agents SDK not installed")
+class TestOpenAIAgentsInstrumentation(unittest.TestCase):
 
     def test_aws_openai_agents_entry_point_resolves(self):
         eps = entry_points(group="opentelemetry_instrumentor", name="aws_openai_agents")

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/openai_agents/test_openai_agents_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/openai_agents/test_openai_agents_instrumentor.py
@@ -5,19 +5,17 @@ import unittest
 from importlib.metadata import entry_points
 
 try:
-    import agents  # noqa: F401
+    from opentelemetry.instrumentation.openai_agents import OpenAIAgentsInstrumentor
 
-    _AGENTS_AVAILABLE = True
+    _AVAILABLE = True
 except ImportError:
-    _AGENTS_AVAILABLE = False
+    _AVAILABLE = False
 
 
-@unittest.skipUnless(_AGENTS_AVAILABLE, "openai-agents SDK not installed")
+@unittest.skipUnless(_AVAILABLE, "opentelemetry-instrumentation-openai-agents-v2 not available")
 class TestOpenAIAgentsInstrumentation(unittest.TestCase):
 
     def test_aws_openai_agents_entry_point_resolves(self):
-        from opentelemetry.instrumentation.openai_agents import OpenAIAgentsInstrumentor
-
         eps = entry_points(group="opentelemetry_instrumentor", name="aws_openai_agents")
         self.assertEqual(len(list(eps)), 1)
 
@@ -26,8 +24,6 @@ class TestOpenAIAgentsInstrumentation(unittest.TestCase):
         self.assertIs(instrumentor_class, OpenAIAgentsInstrumentor)
 
     def test_aws_entry_point_survives_when_openai_agents_disabled(self):
-        from opentelemetry.instrumentation.openai_agents import OpenAIAgentsInstrumentor
-
         disabled = {"openai_agents"}
 
         aws_eps = entry_points(group="opentelemetry_instrumentor", name="aws_openai_agents")
@@ -41,8 +37,6 @@ class TestOpenAIAgentsInstrumentation(unittest.TestCase):
         self.assertIs(instrumentor_class, OpenAIAgentsInstrumentor)
 
     def test_instrument_called_twice_only_sets_processor_once(self):
-        from opentelemetry.instrumentation.openai_agents import OpenAIAgentsInstrumentor
-
         instrumentor = OpenAIAgentsInstrumentor()
         if instrumentor.is_instrumented_by_opentelemetry:
             instrumentor.uninstrument()

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/openai_agents/test_openai_agents_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/openai_agents/test_openai_agents_instrumentor.py
@@ -1,16 +1,15 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from importlib.metadata import entry_points
 from unittest import TestCase
 
 from opentelemetry.instrumentation.openai_agents import OpenAIAgentsInstrumentor
 
 
-class TestOpenAIAgentsInstrumentor(TestCase):
+class TestOpenAIAgentsInstrumentation(TestCase):
 
     def test_aws_openai_agents_entry_point_resolves(self):
-        from importlib.metadata import entry_points
-
         eps = entry_points(group="opentelemetry_instrumentor", name="aws_openai_agents")
         self.assertEqual(len(list(eps)), 1)
 
@@ -18,9 +17,18 @@ class TestOpenAIAgentsInstrumentor(TestCase):
         instrumentor_class = ep.load()
         self.assertIs(instrumentor_class, OpenAIAgentsInstrumentor)
 
-    def test_instrumentor_can_be_instantiated(self):
-        instrumentor = OpenAIAgentsInstrumentor()
-        self.assertIsNotNone(instrumentor)
+    def test_aws_entry_point_survives_when_openai_agents_disabled(self):
+        disabled = {"openai_agents"}
+
+        aws_eps = entry_points(group="opentelemetry_instrumentor", name="aws_openai_agents")
+        otel_eps = entry_points(group="opentelemetry_instrumentor", name="openai_agents")
+
+        self.assertTrue(any(ep.name in disabled for ep in otel_eps))
+        self.assertFalse(any(ep.name in disabled for ep in aws_eps))
+
+        ep = list(aws_eps)[0]
+        instrumentor_class = ep.load()
+        self.assertIs(instrumentor_class, OpenAIAgentsInstrumentor)
 
     def test_instrument_called_twice_only_sets_processor_once(self):
         instrumentor = OpenAIAgentsInstrumentor()

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/openai_agents/test_openai_agents_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/openai_agents/test_openai_agents_instrumentor.py
@@ -6,7 +6,7 @@ from unittest import TestCase
 from opentelemetry.instrumentation.openai_agents import OpenAIAgentsInstrumentor
 
 
-class TestOpenAIAgentsInstrumentation(TestCase):
+class TestOpenAIAgentsInstrumentor(TestCase):
 
     def test_aws_openai_agents_entry_point_resolves(self):
         from importlib.metadata import entry_points

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/openai_agents/test_openai_agents_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/openai_agents/test_openai_agents_instrumentor.py
@@ -5,7 +5,7 @@ import unittest
 from importlib.metadata import entry_points
 
 try:
-    from opentelemetry.instrumentation.openai_agents import OpenAIAgentsInstrumentor
+    import agents  # noqa: F401
 
     _AGENTS_AVAILABLE = True
 except ImportError:
@@ -16,6 +16,8 @@ except ImportError:
 class TestOpenAIAgentsInstrumentation(unittest.TestCase):
 
     def test_aws_openai_agents_entry_point_resolves(self):
+        from opentelemetry.instrumentation.openai_agents import OpenAIAgentsInstrumentor
+
         eps = entry_points(group="opentelemetry_instrumentor", name="aws_openai_agents")
         self.assertEqual(len(list(eps)), 1)
 
@@ -24,6 +26,8 @@ class TestOpenAIAgentsInstrumentation(unittest.TestCase):
         self.assertIs(instrumentor_class, OpenAIAgentsInstrumentor)
 
     def test_aws_entry_point_survives_when_openai_agents_disabled(self):
+        from opentelemetry.instrumentation.openai_agents import OpenAIAgentsInstrumentor
+
         disabled = {"openai_agents"}
 
         aws_eps = entry_points(group="opentelemetry_instrumentor", name="aws_openai_agents")
@@ -37,6 +41,8 @@ class TestOpenAIAgentsInstrumentation(unittest.TestCase):
         self.assertIs(instrumentor_class, OpenAIAgentsInstrumentor)
 
     def test_instrument_called_twice_only_sets_processor_once(self):
+        from opentelemetry.instrumentation.openai_agents import OpenAIAgentsInstrumentor
+
         instrumentor = OpenAIAgentsInstrumentor()
         if instrumentor.is_instrumented_by_opentelemetry:
             instrumentor.uninstrument()

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/patches/test_starlette_patches.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/patches/test_starlette_patches.py
@@ -15,12 +15,18 @@ class TestStarlettePatch(TestCase):
     @patch("amazon.opentelemetry.distro.patches._starlette_patches._logger")
     def test_starlette_patch_applied_successfully(self, mock_logger):
         """Test that the Starlette ASGI middleware patch is applied successfully."""
-        for agent_enabled in [True, False]:
-            with self.subTest(agent_enabled=agent_enabled):
-                # Reset mock for each sub-test
+        env_configs = [
+            {"AGENT_OBSERVABILITY_ENABLED": "true"},
+            {"AWS_AGENTIC_OBSERVABILITY_OPT_IN": "true"},
+            {"AGENT_OBSERVABILITY_ENABLED": "false"},
+            {"AWS_AGENTIC_OBSERVABILITY_OPT_IN": "false"},
+        ]
+        for env_vars in env_configs:
+            agent_enabled = any(v == "true" for v in env_vars.values())
+            with self.subTest(env_vars=env_vars):
                 mock_logger.reset_mock()
 
-                with patch.dict("os.environ", {"AGENT_OBSERVABILITY_ENABLED": "true" if agent_enabled else "false"}):
+                with patch.dict("os.environ", env_vars, clear=False):
 
                     def create_middleware_class():
                         class MockMiddleware:

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py
@@ -1298,7 +1298,8 @@ class TestAwsOpenTelemetryConfigurator(TestCase):
         _clear_logs_header_cache()
 
     @patch(
-        "amazon.opentelemetry.distro.aws_opentelemetry_configurator.is_agent_observability_enabled", return_value=False
+        "amazon.opentelemetry.distro.aws_opentelemetry_configurator.is_agentic_observability_enabled",
+        return_value=False,
     )
     def test_customize_log_record_processor_without_agent_observability(self, _):
         """Test that BatchLogRecordProcessor is used when agent observability is not enabled"""
@@ -1312,7 +1313,7 @@ class TestAwsOpenTelemetryConfigurator(TestCase):
         self.assertIsInstance(added_processor, BatchLogRecordProcessor)
 
     @patch(
-        "amazon.opentelemetry.distro.aws_opentelemetry_configurator.is_agent_observability_enabled", return_value=True
+        "amazon.opentelemetry.distro.aws_opentelemetry_configurator.is_agentic_observability_enabled", return_value=True
     )
     def test_customize_log_record_processor_with_agent_observability(self, _):
         """Test that AwsCloudWatchOtlpBatchLogRecordProcessor is used when agent observability is enabled"""
@@ -1326,7 +1327,7 @@ class TestAwsOpenTelemetryConfigurator(TestCase):
         self.assertIsInstance(added_processor, AwsCloudWatchOtlpBatchLogRecordProcessor)
 
     @patch("amazon.opentelemetry.distro.aws_opentelemetry_configurator.get_logger_provider")
-    @patch("amazon.opentelemetry.distro.aws_opentelemetry_configurator.is_agent_observability_enabled")
+    @patch("amazon.opentelemetry.distro.aws_opentelemetry_configurator.is_agentic_observability_enabled")
     @patch("amazon.opentelemetry.distro.aws_opentelemetry_configurator.get_aws_session")
     def test_create_aws_otlp_exporter(self, mock_get_session, mock_is_agent_enabled, mock_get_logger_provider):
         # Test when botocore is not installed
@@ -1391,7 +1392,7 @@ class TestAwsOpenTelemetryConfigurator(TestCase):
         result = _create_aws_otlp_exporter("https://xray.us-east-1.amazonaws.com/v1/traces", "xray", "us-east-1")
         self.assertIsNone(result)
 
-    @patch("amazon.opentelemetry.distro.aws_opentelemetry_configurator.is_agent_observability_enabled")
+    @patch("amazon.opentelemetry.distro.aws_opentelemetry_configurator.is_agentic_observability_enabled")
     @patch("amazon.opentelemetry.distro.aws_opentelemetry_configurator.get_service_attribute")
     def test_customize_resource_without_agent_observability(self, mock_get_service_attribute, mock_is_agent_enabled):
         """Test _customize_resource when agent observability is disabled"""
@@ -1405,7 +1406,7 @@ class TestAwsOpenTelemetryConfigurator(TestCase):
         self.assertEqual(result.attributes[AWS_LOCAL_SERVICE], "test-service")
         self.assertNotIn(AWS_SERVICE_TYPE, result.attributes)
 
-    @patch("amazon.opentelemetry.distro.aws_opentelemetry_configurator.is_agent_observability_enabled")
+    @patch("amazon.opentelemetry.distro.aws_opentelemetry_configurator.is_agentic_observability_enabled")
     @patch("amazon.opentelemetry.distro.aws_opentelemetry_configurator.get_service_attribute")
     def test_customize_resource_with_agent_observability_default(
         self, mock_get_service_attribute, mock_is_agent_enabled
@@ -1421,7 +1422,7 @@ class TestAwsOpenTelemetryConfigurator(TestCase):
         self.assertEqual(result.attributes[AWS_LOCAL_SERVICE], "test-service")
         self.assertEqual(result.attributes[AWS_SERVICE_TYPE], "gen_ai_agent")
 
-    @patch("amazon.opentelemetry.distro.aws_opentelemetry_configurator.is_agent_observability_enabled")
+    @patch("amazon.opentelemetry.distro.aws_opentelemetry_configurator.is_agentic_observability_enabled")
     @patch("amazon.opentelemetry.distro.aws_opentelemetry_configurator.get_service_attribute")
     def test_customize_resource_with_existing_agent_type(self, mock_get_service_attribute, mock_is_agent_enabled):
         """Test _customize_resource when agent type already exists in resource"""

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelemetry_distro.py
@@ -575,14 +575,10 @@ class TestAwsOpenTelemetryDistro(TestCase):
 
                 distro = AwsOpenTelemetryDistro()
                 with patch.dict(os.environ, case["env"], clear=False):
-                    with patch.object(
-                        OpenTelemetryDistro, "load_instrumentor"
-                    ) as mock_super:
+                    with patch.object(OpenTelemetryDistro, "load_instrumentor") as mock_super:
                         distro.load_instrumentor(mock_entry_point)
                         if case["should_load"]:
-                            mock_super.assert_called_once_with(
-                                mock_entry_point
-                            )
+                            mock_super.assert_called_once_with(mock_entry_point)
                         else:
                             mock_super.assert_not_called()
 

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelemetry_distro.py
@@ -32,7 +32,6 @@ from opentelemetry.sdk.environment_variables import (
     OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,
     OTEL_EXPORTER_OTLP_PROTOCOL,
     OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
-    OTEL_TRACES_SAMPLER,
 )
 
 
@@ -52,7 +51,6 @@ class TestAwsOpenTelemetryDistro(TestCase):
             "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT",
             OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
             OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
-            OTEL_TRACES_SAMPLER,
             OTEL_PYTHON_DISABLED_INSTRUMENTATIONS,
             OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED,
             APPLICATION_SIGNALS_ENABLED_CONFIG,
@@ -60,7 +58,7 @@ class TestAwsOpenTelemetryDistro(TestCase):
             "DJANGO_SETTINGS_MODULE",
             OTEL_EXPORTER_OTLP_ENDPOINT,
             OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,
-            "AGENT_OBSERVABILITY_VERSION",
+            "AWS_AGENTIC_OBSERVABILITY_OPT_IN",
         ]
 
         # First, save all current values
@@ -159,7 +157,7 @@ class TestAwsOpenTelemetryDistro(TestCase):
         self.assertEqual(
             os.environ.get(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT), "https://logs.us-west-2.amazonaws.com/v1/logs"
         )
-        self.assertEqual(os.environ.get(OTEL_TRACES_SAMPLER), "parentbased_always_on")
+
         self.assertEqual(
             os.environ.get(OTEL_PYTHON_DISABLED_INSTRUMENTATIONS),
             AGENT_OBSERVABILITY_DISABLED_INSTRUMENTATIONS,
@@ -272,22 +270,24 @@ class TestAwsOpenTelemetryDistro(TestCase):
 
     @patch("amazon.opentelemetry.distro.aws_opentelemetry_distro.get_aws_region")
     @patch("amazon.opentelemetry.distro.aws_opentelemetry_distro.is_agent_observability_enabled")
+    @patch("amazon.opentelemetry.distro.aws_opentelemetry_distro.is_aws_agentic_observability_opt_in")
     @patch("amazon.opentelemetry.distro.aws_opentelemetry_distro.is_installed")
     @patch("amazon.opentelemetry.distro.aws_opentelemetry_distro.apply_instrumentation_patches")
     @patch("amazon.opentelemetry.distro.aws_opentelemetry_distro.OpenTelemetryDistro._configure")
-    def test_configure_agent_observability_defaults_to_v1_when_version_not_set(
+    def test_configure_agent_observability_v1(
         self,
         mock_super_configure,
         mock_apply_patches,
         mock_is_installed,
+        mock_is_aws_agentic_observability_opt_in,
         mock_is_agent_observability,
         mock_get_aws_region,
     ):
-        """Test that when AGENT_OBSERVABILITY_VERSION is not set, it defaults to v1 configuration"""
+        """Test that AGENT_OBSERVABILITY_ENABLED uses v1 configuration"""
         mock_is_agent_observability.return_value = True
+        mock_is_aws_agentic_observability_opt_in.return_value = False
         mock_get_aws_region.return_value = "us-east-1"
         mock_is_installed.return_value = False
-        os.environ.pop("AGENT_OBSERVABILITY_VERSION", None)
 
         AwsOpenTelemetryDistro()._configure()
 
@@ -299,43 +299,54 @@ class TestAwsOpenTelemetryDistro(TestCase):
             os.environ.get(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT), "https://logs.us-east-1.amazonaws.com/v1/logs"
         )
         self.assertEqual(os.environ.get("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"), "true")
-        self.assertEqual(os.environ.get(OTEL_TRACES_SAMPLER), "parentbased_always_on")
+
         self.assertEqual(os.environ.get(OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED), "true")
         self.assertEqual(os.environ.get(APPLICATION_SIGNALS_ENABLED_CONFIG), "false")
         self.assertEqual(os.environ.get("OTEL_METRICS_ADD_APPLICATION_SIGNALS_DIMENSIONS"), "false")
+        disabled = os.environ.get(OTEL_PYTHON_DISABLED_INSTRUMENTATIONS, "").split(",")
+        self.assertNotIn("crewai", disabled)
+        self.assertNotIn("langchain", disabled)
+        self.assertNotIn("mcp", disabled)
+        self.assertIn("aws_crewai", disabled)
+        self.assertIn("aws_langchain", disabled)
+        self.assertIn("aws_mcp", disabled)
 
     @patch("amazon.opentelemetry.distro.aws_opentelemetry_distro.get_aws_region")
     @patch("amazon.opentelemetry.distro.aws_opentelemetry_distro.is_agent_observability_enabled")
+    @patch("amazon.opentelemetry.distro.aws_opentelemetry_distro.is_aws_agentic_observability_opt_in")
     @patch("amazon.opentelemetry.distro.aws_opentelemetry_distro.is_installed")
     @patch("amazon.opentelemetry.distro.aws_opentelemetry_distro.apply_instrumentation_patches")
     @patch("amazon.opentelemetry.distro.aws_opentelemetry_distro.OpenTelemetryDistro._configure")
-    def test_configure_agent_observability_v2(
+    def test_configure_ai_observability_opt_in(
         self,
         mock_super_configure,
         mock_apply_patches,
         mock_is_installed,
+        mock_is_aws_agentic_observability_opt_in,
         mock_is_agent_observability,
         mock_get_aws_region,
     ):
-        """Test that version 2 uses localhost collector endpoint and otlp metrics"""
-        mock_is_agent_observability.return_value = True
+        """Test that AI_OBSERVABILITY_OPT_IN uses v2 collector config and disables 3rd party instrumentations"""
+        mock_is_agent_observability.return_value = False
+        mock_is_aws_agentic_observability_opt_in.return_value = True
         mock_get_aws_region.return_value = "us-east-1"
         mock_is_installed.return_value = False
-        os.environ["AGENT_OBSERVABILITY_VERSION"] = "2"
 
         AwsOpenTelemetryDistro()._configure()
 
         self.assertEqual(os.environ.get(OTEL_METRICS_EXPORTER), "otlp")
-        self.assertEqual(os.environ.get(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT), "http://localhost:4318/v1/traces")
-        self.assertEqual(os.environ.get(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT), "http://localhost:4318/v1/logs")
-        self.assertEqual(os.environ.get(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT), "http://localhost:4318/v1/metrics")
         self.assertEqual(os.environ.get("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"), "true")
-        self.assertEqual(os.environ.get(OTEL_TRACES_SAMPLER), "parentbased_always_on")
+
         self.assertEqual(os.environ.get(OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED), "true")
         self.assertEqual(os.environ.get(APPLICATION_SIGNALS_ENABLED_CONFIG), "false")
         self.assertEqual(os.environ.get("OTEL_METRICS_ADD_APPLICATION_SIGNALS_DIMENSIONS"), "false")
-
-        os.environ.pop("AGENT_OBSERVABILITY_VERSION", None)
+        disabled = os.environ.get(OTEL_PYTHON_DISABLED_INSTRUMENTATIONS, "").split(",")
+        self.assertIn("crewai", disabled)
+        self.assertIn("langchain", disabled)
+        self.assertIn("mcp", disabled)
+        self.assertNotIn("aws_crewai", disabled)
+        self.assertNotIn("aws_langchain", disabled)
+        self.assertNotIn("aws_mcp", disabled)
 
     @patch("amazon.opentelemetry.distro.aws_opentelemetry_distro.apply_instrumentation_patches")
     @patch("amazon.opentelemetry.distro.aws_opentelemetry_distro.OpenTelemetryDistro._configure")
@@ -528,18 +539,13 @@ class TestAwsOpenTelemetryDistro(TestCase):
         self.assertNotIn(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, os.environ)
         self.assertNotIn(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT, os.environ)
 
-    def test_base_otlp_endpoint_prevents_specific_endpoints_v2(self):
-        os.environ[OTEL_EXPORTER_OTLP_ENDPOINT] = "http://my-collector:4318"
-        os.environ["AGENT_OBSERVABILITY_VERSION"] = "2"
-        self._configure_with_agent_observability()
-        self.assertNotIn(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, os.environ)
-        self.assertNotIn(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT, os.environ)
-        self.assertNotIn(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT, os.environ)
-
     def _configure_with_agent_observability(self, region="us-west-2"):
         with patch("amazon.opentelemetry.distro.aws_opentelemetry_distro.OpenTelemetryDistro._configure"), patch(
             "amazon.opentelemetry.distro.aws_opentelemetry_distro.apply_instrumentation_patches"
         ), patch("amazon.opentelemetry.distro.aws_opentelemetry_distro.is_installed", return_value=False), patch(
+            "amazon.opentelemetry.distro.aws_opentelemetry_distro.is_aws_agentic_observability_opt_in",
+            return_value=False,
+        ), patch(
             "amazon.opentelemetry.distro.aws_opentelemetry_distro.is_agent_observability_enabled", return_value=True
         ), patch(
             "amazon.opentelemetry.distro.aws_opentelemetry_distro.get_aws_region", return_value=region

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelemetry_distro.py
@@ -5,9 +5,10 @@ import os
 import sys
 from importlib.metadata import PackageNotFoundError, version
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from amazon.opentelemetry.distro.aws_opentelemetry_configurator import APPLICATION_SIGNALS_ENABLED_CONFIG
+from opentelemetry.distro import OpenTelemetryDistro
 from amazon.opentelemetry.distro.aws_opentelemetry_distro import (
     AGENT_OBSERVABILITY_DISABLED_INSTRUMENTATIONS,
     AwsOpenTelemetryDistro,
@@ -538,6 +539,39 @@ class TestAwsOpenTelemetryDistro(TestCase):
         self._configure_with_agent_observability()
         self.assertNotIn(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, os.environ)
         self.assertNotIn(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT, os.environ)
+
+    def test_load_instrumentor_skips_otel_openai_agents_in_legacy(self):
+        mock_entry_point = MagicMock()
+        mock_entry_point.name = "openai_agents"
+        mock_entry_point.dist.name = "opentelemetry-instrumentation-openai-agents-v2"
+
+        distro = AwsOpenTelemetryDistro()
+        with patch.dict(os.environ, {"AGENT_OBSERVABILITY_ENABLED": "true"}):
+            with patch.object(OpenTelemetryDistro, "load_instrumentor") as mock_super:
+                distro.load_instrumentor(mock_entry_point)
+                mock_super.assert_not_called()
+
+    def test_load_instrumentor_allows_third_party_openai_agents_in_legacy(self):
+        mock_entry_point = MagicMock()
+        mock_entry_point.name = "openai_agents"
+        mock_entry_point.dist.name = "openinference-instrumentation-openai-agents"
+
+        distro = AwsOpenTelemetryDistro()
+        with patch.dict(os.environ, {"AGENT_OBSERVABILITY_ENABLED": "true"}):
+            with patch.object(OpenTelemetryDistro, "load_instrumentor") as mock_super:
+                distro.load_instrumentor(mock_entry_point)
+                mock_super.assert_called_once_with(mock_entry_point)
+
+    def test_load_instrumentor_allows_otel_openai_agents_in_opt_in(self):
+        mock_entry_point = MagicMock()
+        mock_entry_point.name = "openai_agents"
+        mock_entry_point.dist.name = "opentelemetry-instrumentation-openai-agents-v2"
+
+        distro = AwsOpenTelemetryDistro()
+        with patch.dict(os.environ, {"AWS_AGENTIC_OBSERVABILITY_OPT_IN": "true"}):
+            with patch.object(OpenTelemetryDistro, "load_instrumentor") as mock_super:
+                distro.load_instrumentor(mock_entry_point)
+                mock_super.assert_called_once_with(mock_entry_point)
 
     def _configure_with_agent_observability(self, region="us-west-2"):
         with patch("amazon.opentelemetry.distro.aws_opentelemetry_distro.OpenTelemetryDistro._configure"), patch(

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelemetry_distro.py
@@ -540,38 +540,51 @@ class TestAwsOpenTelemetryDistro(TestCase):
         self.assertNotIn(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, os.environ)
         self.assertNotIn(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT, os.environ)
 
-    def test_load_instrumentor_skips_otel_openai_agents_in_legacy(self):
-        mock_entry_point = MagicMock()
-        mock_entry_point.name = "openai_agents"
-        mock_entry_point.dist.name = "opentelemetry-instrumentation-openai-agents-v2"
+    def test_load_instrumentor_skip_behavior(self):
+        cases = [
+            {
+                "env": {"AGENT_OBSERVABILITY_ENABLED": "true"},
+                "entry_name": "openai_agents",
+                "dist_name": "opentelemetry-instrumentation-openai-agents-v2",
+                "should_load": False,
+            },
+            {
+                "env": {"AGENT_OBSERVABILITY_ENABLED": "true"},
+                "entry_name": "openai_agents",
+                "dist_name": "openinference-instrumentation-openai-agents",
+                "should_load": True,
+            },
+            {
+                "env": {"AWS_AGENTIC_OBSERVABILITY_OPT_IN": "true"},
+                "entry_name": "openai_agents",
+                "dist_name": "opentelemetry-instrumentation-openai-agents-v2",
+                "should_load": True,
+            },
+            {
+                "env": {},
+                "entry_name": "openai_agents",
+                "dist_name": "opentelemetry-instrumentation-openai-agents-v2",
+                "should_load": True,
+            },
+        ]
+        for case in cases:
+            with self.subTest(case=case):
+                mock_entry_point = MagicMock()
+                mock_entry_point.name = case["entry_name"]
+                mock_entry_point.dist.name = case["dist_name"]
 
-        distro = AwsOpenTelemetryDistro()
-        with patch.dict(os.environ, {"AGENT_OBSERVABILITY_ENABLED": "true"}):
-            with patch.object(OpenTelemetryDistro, "load_instrumentor") as mock_super:
-                distro.load_instrumentor(mock_entry_point)
-                mock_super.assert_not_called()
-
-    def test_load_instrumentor_allows_third_party_openai_agents_in_legacy(self):
-        mock_entry_point = MagicMock()
-        mock_entry_point.name = "openai_agents"
-        mock_entry_point.dist.name = "openinference-instrumentation-openai-agents"
-
-        distro = AwsOpenTelemetryDistro()
-        with patch.dict(os.environ, {"AGENT_OBSERVABILITY_ENABLED": "true"}):
-            with patch.object(OpenTelemetryDistro, "load_instrumentor") as mock_super:
-                distro.load_instrumentor(mock_entry_point)
-                mock_super.assert_called_once_with(mock_entry_point)
-
-    def test_load_instrumentor_allows_otel_openai_agents_in_opt_in(self):
-        mock_entry_point = MagicMock()
-        mock_entry_point.name = "openai_agents"
-        mock_entry_point.dist.name = "opentelemetry-instrumentation-openai-agents-v2"
-
-        distro = AwsOpenTelemetryDistro()
-        with patch.dict(os.environ, {"AWS_AGENTIC_OBSERVABILITY_OPT_IN": "true"}):
-            with patch.object(OpenTelemetryDistro, "load_instrumentor") as mock_super:
-                distro.load_instrumentor(mock_entry_point)
-                mock_super.assert_called_once_with(mock_entry_point)
+                distro = AwsOpenTelemetryDistro()
+                with patch.dict(os.environ, case["env"], clear=False):
+                    with patch.object(
+                        OpenTelemetryDistro, "load_instrumentor"
+                    ) as mock_super:
+                        distro.load_instrumentor(mock_entry_point)
+                        if case["should_load"]:
+                            mock_super.assert_called_once_with(
+                                mock_entry_point
+                            )
+                        else:
+                            mock_super.assert_not_called()
 
     def _configure_with_agent_observability(self, region="us-west-2"):
         with patch("amazon.opentelemetry.distro.aws_opentelemetry_distro.OpenTelemetryDistro._configure"), patch(

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelemetry_distro.py
@@ -8,12 +8,12 @@ from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 from amazon.opentelemetry.distro.aws_opentelemetry_configurator import APPLICATION_SIGNALS_ENABLED_CONFIG
-from opentelemetry.distro import OpenTelemetryDistro
 from amazon.opentelemetry.distro.aws_opentelemetry_distro import (
     AGENT_OBSERVABILITY_DISABLED_INSTRUMENTATIONS,
     AwsOpenTelemetryDistro,
 )
 from opentelemetry import propagate
+from opentelemetry.distro import OpenTelemetryDistro
 from opentelemetry.environment_variables import (
     OTEL_LOGS_EXPORTER,
     OTEL_METRICS_EXPORTER,

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_utils.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_utils.py
@@ -8,9 +8,12 @@ from unittest.mock import MagicMock, patch
 
 from amazon.opentelemetry.distro._utils import (
     AGENT_OBSERVABILITY_ENABLED,
+    AWS_AGENTIC_OBSERVABILITY_OPT_IN,
     get_aws_region,
     get_aws_session,
     is_agent_observability_enabled,
+    is_agentic_observability_enabled,
+    is_aws_agentic_observability_opt_in,
     is_installed,
 )
 
@@ -104,6 +107,41 @@ class TestUtils(TestCase):
         if AGENT_OBSERVABILITY_ENABLED in os.environ:
             del os.environ[AGENT_OBSERVABILITY_ENABLED]
         self.assertFalse(is_agent_observability_enabled())
+
+    def test_is_aws_agentic_observability_opt_in_various_values(self):
+        """Test is_aws_agentic_observability_opt_in with various environment variable values"""
+        os.environ[AWS_AGENTIC_OBSERVABILITY_OPT_IN] = "true"
+        self.assertTrue(is_aws_agentic_observability_opt_in())
+
+        os.environ[AWS_AGENTIC_OBSERVABILITY_OPT_IN] = "True"
+        self.assertTrue(is_aws_agentic_observability_opt_in())
+
+        os.environ[AWS_AGENTIC_OBSERVABILITY_OPT_IN] = "false"
+        self.assertFalse(is_aws_agentic_observability_opt_in())
+
+        if AWS_AGENTIC_OBSERVABILITY_OPT_IN in os.environ:
+            del os.environ[AWS_AGENTIC_OBSERVABILITY_OPT_IN]
+        self.assertFalse(is_aws_agentic_observability_opt_in())
+
+    def test_is_agentic_observability_enabled_combined(self):
+        """Test is_agentic_observability_enabled returns True if either env var is set"""
+        os.environ.pop(AGENT_OBSERVABILITY_ENABLED, None)
+        os.environ.pop(AWS_AGENTIC_OBSERVABILITY_OPT_IN, None)
+        self.assertFalse(is_agentic_observability_enabled())
+
+        os.environ[AGENT_OBSERVABILITY_ENABLED] = "true"
+        self.assertTrue(is_agentic_observability_enabled())
+        os.environ.pop(AGENT_OBSERVABILITY_ENABLED, None)
+
+        os.environ[AWS_AGENTIC_OBSERVABILITY_OPT_IN] = "true"
+        self.assertTrue(is_agentic_observability_enabled())
+        os.environ.pop(AWS_AGENTIC_OBSERVABILITY_OPT_IN, None)
+
+        os.environ[AGENT_OBSERVABILITY_ENABLED] = "true"
+        os.environ[AWS_AGENTIC_OBSERVABILITY_OPT_IN] = "true"
+        self.assertTrue(is_agentic_observability_enabled())
+        os.environ.pop(AGENT_OBSERVABILITY_ENABLED, None)
+        os.environ.pop(AWS_AGENTIC_OBSERVABILITY_OPT_IN, None)
 
     def test_get_aws_session_with_botocore(self):
         """Test get_aws_session when botocore is installed"""

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ deps =
   3.{10,11,12,13}-test-aws-opentelemetry-distro: langchain >= 0.3.21, < 2
   3.{10,11,12,13}-test-aws-opentelemetry-distro: langchain-classic
   3.{10,11,12,13}-test-aws-opentelemetry-distro: mcp >= 1.8.1, < 2
+  3.{10,11,12,13}-test-aws-opentelemetry-distro: openai-agents >= 0.3.3
   3.{10,11,12,13}-test-aws-opentelemetry-distro: uvicorn
 
 setenv =


### PR DESCRIPTION
*Description of changes:*

- add note for `AGENT_OBSERVABILITY_VERSION` with a new env var `AWS_AGENTIC_OBSERVABILITY_OPT_IN` that controls ADOT-native agentic instrumentation. When enabled, ADOT disables third-party agentic instrumentations. 

- `AGENT_OBSERVABILITY_ENABLED` is maintained for backwards compatibility, disabling native ADOT instrumentations.

- **BREAKING CHANGE**: enable ALL HTTP library instrumentations for `AGENT_OBSERVABILITY_ENABLED` and `AWS_AGENTIC_OBSERVABILITY_OPT_IN` path

Other changes:
- Add `OTEL_PYTHON_LOG_CORRELATION` to common agent observability config
- Remove redundant `OTEL_TRACES_SAMPLER` env variable
- Remove hardcoded `localhost` OTLP endpoints from opt-in path


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

