### PR TITLE
fix(build): use correct IAM role for agentcore collector S3 upload

### DIFF
--- a/.github/workflows/build-agentcore-collector.yml
+++ b/.github/workflows/build-agentcore-collector.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 # v5.0.0
         with:
-          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          role-to-assume: arn:aws:iam::${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}:role/${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
           aws-region: us-east-1
 
       - name: Package and upload collector to S3


### PR DESCRIPTION
## Summary
- The `build-agentcore-collector` workflow was using `AWS_ASSUME_ROLE_ARN` which does not have write access to the `adot-main-build-staging-jar` S3 bucket, causing `AccessDenied` errors on upload
- Switch to the E2E test role (`APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID` / `APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME`), consistent with `application-signals-e2e-test.yml` which successfully uploads to the same bucket

## Test plan
- [ ] Trigger `build-agentcore-collector` workflow manually and verify S3 upload succeeds
- [ ] Verify `otelcol-agentcore.zip` is updated in the S3 bucket