### PR TITLE
Cherry-pick #712 #713: Fix agentcore collector S3 upload

### DIFF
--- a/.github/workflows/build-agentcore-collector.yml
+++ b/.github/workflows/build-agentcore-collector.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 # v5.0.0
         with:
-          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          role-to-assume: arn:aws:iam::${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}:role/${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
           aws-region: us-east-1
 
       - name: Package and upload collector to S3

--- a/.github/workflows/build-agentcore-collector.yml
+++ b/.github/workflows/build-agentcore-collector.yml
@@ -87,7 +87,7 @@ jobs:
           cp bin/otelcol-agentcore_linux_arm64 collector-package/otelcol-agentcore
           cp cmd/otelcol-agentcore/config.yaml collector-package/config.yaml
           cd collector-package && zip -r ../otelcol-agentcore.zip . && cd ..
-          aws s3 cp otelcol-agentcore.zip s3://${{ secrets.STAGING_BUCKET_NAME }}/otelcol-agentcore.zip
+          aws s3 cp otelcol-agentcore.zip s3://adot-main-build-staging-jar/otelcol-agentcore.zip
 
       - name: Checkout current repo for cache context
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
## Summary
Cherry-pick two fixes from main to release/v0.17.x:
- #712 — Update S3 bucket path to hardcoded `adot-main-build-staging-jar`
- #713 — Use correct IAM role (`APPLICATION_SIGNALS_E2E_TEST` role) for S3 upload, fixing AccessDenied errors

