### PR TITLE
Tag Private ECR images in release workflow

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -156,8 +156,27 @@ jobs:
           verbose: true
           packages-dir: dist-pypi
 
-      # Publish to public ECR
-      - name: Build and push public ECR image
+      - name: Build and push amd64 image to private ECR
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
+        with:
+          push: true
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          tags: |
+            ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ env.VERSION }}-amd64
+
+      - name: Build and push arm64 image to private ECR
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
+        with:
+          push: true
+          context: .
+          file: ./Dockerfile
+          platforms: linux/arm64
+          tags: |
+            ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ env.VERSION }}-arm64
+
+      - name: Build and push multi-arch image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
         with:
           push: true
@@ -166,16 +185,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: |
             ${{ env.RELEASE_PUBLIC_REPOSITORY }}:v${{ env.VERSION }}
-
-      # Publish to private ECR
-      - name: Build and push private ECR image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
-        with:
-          push: true
-          context: .
-          file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
-          tags: |
             ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ env.VERSION }}
   
   publish-layer-prod:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add tagging to the per-arch images in private ECR as needed by ARS.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

