### PR TITLE
fix: grant write permissions to main build call inside nightly build

### DIFF
--- a/.github/workflows/build-agentcore-collector.yml
+++ b/.github/workflows/build-agentcore-collector.yml
@@ -53,6 +53,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      actions: write
     steps:
       - name: Checkout code repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -100,6 +100,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      actions: write
     with:
       ref: nightly-dependency-updates
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
[Nightly build runs](https://github.com/aws-observability/aws-otel-python-instrumentation/actions/runs/24436157839) have been failing with the following error:
>The workflow is not valid. .github/workflows/nightly-build.yml (Line: 95, Col: 3): Error calling workflow 'aws-observability/aws-otel-python-instrumentation/.github/workflows/main-build.yml@6779621bb1b5d9f01762645b67949c5787ba4b75'. The nested job 'build-agentcore-collector' is requesting 'actions: write', but is only allowed 'actions: none'.

This PR adds the write permission needed by build-agentcore-collector in the build-collector step (where it saves to cache), and grants the permission accordingly in nightly-build.yml.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

