### PR TITLE
simplify lambda layer signing step in release workflow

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -233,60 +233,22 @@ jobs:
         run: |
           aws s3 mb s3://${{ env.BUCKET_NAME }}
           aws s3 cp ${{ env.LAYER_ARTIFACT_NAME }} s3://${{ env.BUCKET_NAME }}
-          
+
           # Sign the layer
-          echo "Checking for signing profile..."
           PROFILE=$(aws signer list-signing-profiles --query "profiles[?profileName=='ADOTLambdaLayerSigningProfile'].arn" --output text 2>/dev/null)
           [ -z "$PROFILE" ] && echo "No signing profile found, skipping" && exit 0
 
-          echo "PROFILE is: $PROFILE"
-
-          echo "Starting signing job..."
-          # Capture both stdout and stderr to properly handle errors
-          SIGNING_OUTPUT=$(aws signer start-signing-job \
+          JOB_ID=$(aws signer start-signing-job \
             --source "s3={bucketName=${{ env.BUCKET_NAME }},key=${{ env.LAYER_ARTIFACT_NAME }},version=null}" \
             --destination "s3={bucketName=${{ env.BUCKET_NAME }},prefix=signed-}" \
             --profile-name ADOTLambdaLayerSigningProfile \
-            --query 'jobId' --output text 2>&1)
-          SIGNING_EXIT_CODE=$?
-          
-          if [ $SIGNING_EXIT_CODE -ne 0 ]; then
-            echo "Signing job failed with exit code $SIGNING_EXIT_CODE"
-            echo "Error output: $SIGNING_OUTPUT"
-            exit 0  # Continue workflow but log the failure
-          fi
-          
-          JOB_ID="$SIGNING_OUTPUT"
-          [ -z "$JOB_ID" ] && echo "No job ID returned" && exit 0
-          echo "Job ID: $JOB_ID"
+            --query 'jobId' --output text)
 
-          echo "Waiting for signing job to complete..."
-          if ! aws signer wait successful-signing-job --job-id "$JOB_ID" 2>&1; then
-            echo "Warning: Signing job wait failed or timed out"
-            exit 0
-          fi
-          echo "Signing completed"
-          
-          echo "Moving signed layer..."
-          SIGNED=$(aws signer describe-signing-job --job-id "$JOB_ID" --query 'signedObject.s3.key' --output text 2>&1)
-          DESCRIBE_EXIT_CODE=$?
-          
-          if [ $DESCRIBE_EXIT_CODE -ne 0 ]; then
-            echo "Warning: Failed to describe signing job"
-            echo "Error: $SIGNED"
-            exit 0
-          fi
-          
-          echo "SIGNED value: '$SIGNED'"
-          if [ -n "$SIGNED" ]; then
-            # Delete the original unsigned file first
-            aws s3 rm "s3://${{ env.BUCKET_NAME }}/${{ env.LAYER_ARTIFACT_NAME }}"
-            # Move the signed file to replace it
-            aws s3 mv "s3://${{ env.BUCKET_NAME }}/$SIGNED" "s3://${{ env.BUCKET_NAME }}/${{ env.LAYER_ARTIFACT_NAME }}"
-            echo "Signed layer moved successfully"
-          else
-            echo "No SIGNED value returned, skipping move"
-          fi
+          aws signer wait successful-signing-job --job-id "$JOB_ID"
+
+          SIGNED=$(aws signer describe-signing-job --job-id "$JOB_ID" --query 'signedObject.s3.key' --output text)
+          aws s3 rm "s3://${{ env.BUCKET_NAME }}/${{ env.LAYER_ARTIFACT_NAME }}"
+          aws s3 mv "s3://${{ env.BUCKET_NAME }}/$SIGNED" "s3://${{ env.BUCKET_NAME }}/${{ env.LAYER_ARTIFACT_NAME }}"
       
       - name: Publish Layer Version
         run: |


### PR DESCRIPTION
Remove defensive exit-code checks and debug output that were masking the real signing failure. The root cause (missing s3:GetObjectVersion permission) is being fixed in the IAM policy.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

