### PR TITLE
fix: respect OTEL_EXPORTER_OTLP_ENDPOINT when setting trace/log/metrics endpoints

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
@@ -94,6 +94,7 @@ from opentelemetry.sdk.environment_variables import (
     _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED as OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED,
 )
 from opentelemetry.sdk.environment_variables import (
+    OTEL_EXPORTER_OTLP_ENDPOINT,
     OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
     OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION,
     OTEL_EXPORTER_OTLP_PROTOCOL,
@@ -206,16 +207,19 @@ class AwsOpenTelemetryDistro(OpenTelemetryDistro):
             os.environ.setdefault("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "true")
 
             region = get_aws_region()
-            if region:
-                os.environ.setdefault(
-                    OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, f"https://xray.{region}.amazonaws.com/v1/traces"
-                )
-                os.environ.setdefault(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT, f"https://logs.{region}.amazonaws.com/v1/logs")
-            else:
-                _logger.warning(
-                    "AWS region could not be determined. OTLP endpoints will not be automatically configured. "
-                    "Please set AWS_REGION environment variable or configure OTLP endpoints manually."
-                )
+            if not os.environ.get(OTEL_EXPORTER_OTLP_ENDPOINT):
+                if region:
+                    os.environ.setdefault(
+                        OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, f"https://xray.{region}.amazonaws.com/v1/traces"
+                    )
+                    os.environ.setdefault(
+                        OTEL_EXPORTER_OTLP_LOGS_ENDPOINT, f"https://logs.{region}.amazonaws.com/v1/logs"
+                    )
+                else:
+                    _logger.warning(
+                        "AWS region could not be determined. OTLP endpoints will not be automatically configured. "
+                        "Please set AWS_REGION environment variable or configure OTLP endpoints manually."
+                    )
 
             os.environ.setdefault(
                 OTEL_PYTHON_DISABLED_INSTRUMENTATIONS,

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelemetry_distro.py
@@ -492,11 +492,11 @@ class TestAwsOpenTelemetryDistro(TestCase):
         disabled = os.environ.get(OTEL_PYTHON_DISABLED_INSTRUMENTATIONS, "")
         self.assertTrue(disabled.startswith("custom_lib"))
 
-    def test_base_otlp_endpoint_does_not_prevent_specific_endpoints(self):
+    def test_base_otlp_endpoint_prevents_specific_endpoints(self):
         os.environ[OTEL_EXPORTER_OTLP_ENDPOINT] = "http://my-collector:4318"
         self._configure_with_agent_observability()
-        self.assertIn(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, os.environ)
-        self.assertIn(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT, os.environ)
+        self.assertNotIn(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, os.environ)
+        self.assertNotIn(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT, os.environ)
 
     @staticmethod
     def _make_ep(name, dist_name=None):


### PR DESCRIPTION
*Description of changes:*
- Restore the `OTEL_EXPORTER_OTLP_ENDPOINT` guard that was dropped in #729
- When the base `OTEL_EXPORTER_OTLP_ENDPOINT` is set (e.g. to a local collector), skip defaulting `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` and `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` to the direct-to-AWS URLs so the OTel SDK honors the base URL