### PR TITLE
[Python]feat: Run auto-instrumentation init container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,3 +59,5 @@ ADD THIRD-PARTY-LICENSES ./THIRD-PARTY-LICENSES
 
 COPY --from=builder /usr/src/cp-utility/bin/cp-utility /bin/cp
 COPY --from=build /operator-build/workspace /autoinstrumentation
+
+USER 65534:65534


### PR DESCRIPTION
## Problem
Customers enforcing runAsNonRoot: true via Pod Security Standards cannot use ADOT auto-instrumentation. Kubernetes checks the image metadata for a USER directive, finds none (defaults to UID 0 / root), and rejects the pod with:
Error: container has runAsNonRoot and image will run as root

## Summary
Enables customers using the Kubernetes Restricted Pod Security Standard to use ADOT auto-instrumentation
Without this change, customers enforcing runAsNonRoot: true at the namespace or pod level cannot use ADOT auto-instrumentation because Kubernetes rejects the init container with:
container has runAsNonRoot and image will run as root

Follows the upstream OTel Operator fix (https://github.com/open-telemetry/opentelemetry-operator/issues/2272)

## Changes
Add USER 65534:65534 to the auto-instrumentation Dockerfile so the init container runs as non-root by default

## Testing
Validated on EKS cluster (us-east-1, EKS v1.34.6) with CW Observability add-on v5.3.1

For more in-depth analysis please see [Test Results](https://quip-amazon.com/2WlNA0XUepQA/Test-Results)
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

