### PR TITLE
chore: switch Claude review to Opus 4.6, increase timeout to 30m

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   claude-review:
     if: ${{ !github.event.pull_request.draft }}
-    timeout-minutes: 15
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -45,6 +45,6 @@ jobs:
           direct_api: "true"
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
-            --model us.anthropic.claude-opus-4-7 --allowedTools "Bash(gh pr diff ${{ github.event.pull_request.number }}),Bash(gh pr diff ${{ github.event.pull_request.number }} *),Bash(gh pr view ${{ github.event.pull_request.number }}),Bash(gh pr view ${{ github.event.pull_request.number }} *),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews*)"
+            --model us.anthropic.claude-opus-4-6-v1 --allowedTools "Bash(gh pr diff ${{ github.event.pull_request.number }}),Bash(gh pr diff ${{ github.event.pull_request.number }} *),Bash(gh pr view ${{ github.event.pull_request.number }}),Bash(gh pr view ${{ github.event.pull_request.number }} *),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews*)"
           prompt: |
             Review PR #${{ github.event.pull_request.number }} in this repository for bugs, security issues, and code quality. Post your findings as inline review comments on the relevant lines of this PR only. Do not modify, comment on, or interact with any other PR.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -42,7 +42,6 @@ jobs:
         uses: anthropics/claude-code-action@0766301cba8671db92e3025984e2fd038ad48ff7 #v1.0.104
         with:
           use_bedrock: "true"
-          direct_api: "true"
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
             --model us.anthropic.claude-opus-4-6-v1 --allowedTools "Bash(gh pr diff ${{ github.event.pull_request.number }}),Bash(gh pr diff ${{ github.event.pull_request.number }} *),Bash(gh pr view ${{ github.event.pull_request.number }}),Bash(gh pr view ${{ github.event.pull_request.number }} *),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews*)"


### PR DESCRIPTION
## Summary
- Switch model from `us.anthropic.claude-opus-4-7` to `us.anthropic.claude-opus-4-6-v1` to avoid throttling issues
- Increase `timeout-minutes` from 15 to 30 to handle larger PRs

## Motivation
Opus 4.7 is getting throttled on Bedrock, causing reviews to timeout at 15 minutes on larger PRs (e.g. dependency update PRs with ~3000 lines changed).