### PR TITLE
Suppress urllib3 HIGH CVEs in daily scan until 2026-06-01

### DIFF
--- a/.github/trivy/daily-scan.trivyignore.yaml
+++ b/.github/trivy/daily-scan.trivyignore.yaml
@@ -10,4 +10,10 @@
 #    statement: "<Why are we excluding?> <link to CVE where we can we status>"
 #    expired_at: <required - YYYY-MM-DD>
 
-vulnerabilities: []
+vulnerabilities:
+  - id: CVE-2026-44431
+    statement: "urllib3 sensitive headers forwarded across origins - pending image rebuild. https://avd.aquasec.com/nvd/cve-2026-44431"
+    expired_at: 2026-06-01
+  - id: CVE-2026-44432
+    statement: "urllib3 decompression-bomb safeguards bypassed - pending image rebuild. https://avd.aquasec.com/nvd/cve-2026-44432"
+    expired_at: 2026-06-01


### PR DESCRIPTION
- Add trivy ignore entries for CVE-2026-44431 and CVE-2026-44432 in the daily scan config
- Suppressions expire on 2026-06-01