### PR TITLE
fix: pin urllib3 to 2.7.0

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -94,93 +94,93 @@ jobs:
           echo ${MATRIX}
           echo "aws_regions_json=${MATRIX}" >> $GITHUB_OUTPUT
 
-  #   publish-sdk:
-  #     needs: download-artifacts
-  #     runs-on: ubuntu-latest
-  #     steps:
-  #       - name: Checkout Repo @ SHA - ${{ github.sha }}
-  #         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
-  # 
-  #       - name: Set up Docker Buildx
-  #         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 #3.11.1
-  # 
-  #       - name: Configure AWS credentials for private ECR
-  #         uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
-  #         with:
-  #           role-to-assume: ${{ secrets.AWS_ROLE_ARN_ECR_RELEASE }}
-  #           aws-region: ${{ env.AWS_PRIVATE_ECR_REGION }}
-  # 
-  #       - name: Log in to AWS private ECR
-  #         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 #v3.5.0
-  #         with:
-  #           registry: ${{ env.RELEASE_PRIVATE_REGISTRY }}
-  # 
-  #       - name: Configure AWS credentials for public ECR
-  #         uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
-  #         with:
-  #           role-to-assume: ${{ secrets.AWS_ROLE_ARN_ECR_RELEASE }}
-  #           aws-region: ${{ env.AWS_PUBLIC_ECR_REGION }}
-  # 
-  #       - name: Log in to AWS public ECR
-  #         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 #v3.5.0
-  #         with:
-  #           registry: public.ecr.aws
-  #      
-  #       - name: Download SDK wheel artifact
-  #         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
-  #         with:
-  #           name: ${{ env.WHEEL_ARTIFACT_NAME }}
-  #           path: dist-pypi
-  # 
-  #       - name: Download SDK source artifact
-  #         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
-  #         with:
-  #           name: ${{ env.SOURCE_ARTIFACT_NAME }}
-  #           path: dist-pypi
-  #       
-  #       # The step below publishes to testpypi in order to catch any issues 
-  #       - name: Publish to TestPyPI
-  #         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
-  #         with:
-  #           repository-url: https://test.pypi.org/legacy/
-  #           attestations: false
-  #           skip-existing: true
-  #           verbose: true
-  #           packages-dir: dist-pypi
-  # 
-  #       # Publish to prod PyPI
-  #       - name: Publish to PyPI
-  #         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
-  #         with:
-  #           skip-existing: true
-  #           verbose: true
-  #           packages-dir: dist-pypi
-  # 
-  #       # Publish to public ECR
-  #       - name: Build and push public ECR image
-  #         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
-  #         with:
-  #           push: true
-  #           context: .
-  #           file: ./Dockerfile
-  #           platforms: linux/amd64,linux/arm64
-  #           tags: |
-  #             ${{ env.RELEASE_PUBLIC_REPOSITORY }}:v${{ env.VERSION }}
-  # 
-  #       # Publish to private ECR
-  #       - name: Build and push private ECR image
-  #         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
-  #         with:
-  #           push: true
-  #           context: .
-  #           file: ./Dockerfile
-  #           platforms: linux/amd64,linux/arm64
-  #           tags: |
-  #             ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ env.VERSION }}
+  publish-sdk:
+    needs: download-artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo @ SHA - ${{ github.sha }}
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 #3.11.1
+
+      - name: Configure AWS credentials for private ECR
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_ECR_RELEASE }}
+          aws-region: ${{ env.AWS_PRIVATE_ECR_REGION }}
+
+      - name: Log in to AWS private ECR
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 #v3.5.0
+        with:
+          registry: ${{ env.RELEASE_PRIVATE_REGISTRY }}
+
+      - name: Configure AWS credentials for public ECR
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_ECR_RELEASE }}
+          aws-region: ${{ env.AWS_PUBLIC_ECR_REGION }}
+
+      - name: Log in to AWS public ECR
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 #v3.5.0
+        with:
+          registry: public.ecr.aws
+     
+      - name: Download SDK wheel artifact
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
+        with:
+          name: ${{ env.WHEEL_ARTIFACT_NAME }}
+          path: dist-pypi
+
+      - name: Download SDK source artifact
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
+        with:
+          name: ${{ env.SOURCE_ARTIFACT_NAME }}
+          path: dist-pypi
+      
+      # The step below publishes to testpypi in order to catch any issues 
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          attestations: false
+          skip-existing: true
+          verbose: true
+          packages-dir: dist-pypi
+
+      # Publish to prod PyPI
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
+        with:
+          skip-existing: true
+          verbose: true
+          packages-dir: dist-pypi
+
+      # Publish to public ECR
+      - name: Build and push public ECR image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
+        with:
+          push: true
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ${{ env.RELEASE_PUBLIC_REPOSITORY }}:v${{ env.VERSION }}
+
+      # Publish to private ECR
+      - name: Build and push private ECR image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
+        with:
+          push: true
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ env.VERSION }}
   
   publish-layer-prod:
     runs-on: ubuntu-latest
-    needs: [download-artifacts]
+    needs: [download-artifacts, publish-sdk]
     strategy:
       matrix:
         aws_region: ${{ fromJson(needs.download-artifacts.outputs.aws_regions_json) }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
   ([#741](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/741))
 - fix(mcp-instrumentation): suppress MCP `/ping` spans when agent observability is enabled
   ([#748](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/748))
+- fix: pin urllib3 to 2.7.0 to fix CVE-2026-44431 and CVE-2026-44432
+  ([#752](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/752))
 
 ## v0.17.0 - 2026-04-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- feat(agent-observability): add `AWS_GENAI_CONTENT_EXTRACTION_OPT_OUT` env var to allow disabling LLO content extraction from spans
+  ([#741](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/741))
+- fix(mcp-instrumentation): suppress MCP `/ping` spans when agent observability is enabled
+  ([#748](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/748))
+
 ## v0.17.0 - 2026-04-08
 
 - fix(lambda-layer): Disable all agentic instrumentation in Lambda by default

--- a/aws-opentelemetry-distro/pyproject.toml
+++ b/aws-opentelemetry-distro/pyproject.toml
@@ -86,6 +86,7 @@ dependencies = [
   "opentelemetry-instrumentation-cassandra == 0.61b0",
   "opentelemetry-instrumentation-openai-agents-v2 == 0.1.0",
   "cachetools == 6.2.4",
+  "urllib3 >= 2.7.0; python_version >= '3.10'",
   "protobuf == 6.33.5",
   "pyyaml == 6.0.3",
 ]

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_utils.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_utils.py
@@ -14,6 +14,7 @@ _logger: Logger = getLogger(__name__)
 AGENT_OBSERVABILITY_ENABLED = "AGENT_OBSERVABILITY_ENABLED"
 AWS_AGENTIC_OBSERVABILITY_OPT_IN = "AWS_AGENTIC_OBSERVABILITY_OPT_IN"
 OTEL_METRICS_ADD_APPLICATION_SIGNALS_DIMENSIONS = "OTEL_METRICS_ADD_APPLICATION_SIGNALS_DIMENSIONS"
+AWS_GENAI_CONTENT_EXTRACTION_OPT_OUT = "AWS_GENAI_CONTENT_EXTRACTION_OPT_OUT"
 
 
 def is_installed(req: str) -> bool:
@@ -39,6 +40,11 @@ def is_installed(req: str) -> bool:
 def is_agent_observability_enabled() -> bool:
     # Maintained for backwards compatibility. New users should use AWS_AGENTIC_OBSERVABILITY_OPT_IN instead.
     return os.environ.get(AGENT_OBSERVABILITY_ENABLED, "false").lower() == "true"
+
+
+def is_genai_content_extraction_opted_out() -> bool:
+    """Has the user opted out of GenAI content extraction from spans?"""
+    return os.environ.get(AWS_GENAI_CONTENT_EXTRACTION_OPT_OUT, "false").lower() == "true"
 
 
 def is_aws_agentic_observability_opt_in() -> bool:

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/exporter/otlp/aws/traces/otlp_aws_span_exporter.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/exporter/otlp/aws/traces/otlp_aws_span_exporter.py
@@ -6,7 +6,7 @@ from typing import Dict, Optional, Sequence
 
 from botocore.session import Session
 
-from amazon.opentelemetry.distro._utils import is_agentic_observability_enabled
+from amazon.opentelemetry.distro._utils import is_agentic_observability_enabled, is_genai_content_extraction_opted_out
 from amazon.opentelemetry.distro.exporter.otlp.aws.common._aws_http_headers import _OTLP_AWS_HTTP_HEADERS
 from amazon.opentelemetry.distro.exporter.otlp.aws.common.aws_auth_session import AwsAuthSession
 from amazon.opentelemetry.distro.llo_handler import LLOHandler
@@ -77,7 +77,11 @@ class OTLPAwsSpanExporter(OTLPSpanExporter):
 
     def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
         try:
-            if is_agentic_observability_enabled() and self._ensure_llo_handler():
+            if (
+                is_agentic_observability_enabled()
+                and not is_genai_content_extraction_opted_out()
+                and self._ensure_llo_handler()
+            ):
                 llo_processed_spans = self._llo_handler.process_spans(spans)
                 return super().export(llo_processed_spans)
         except Exception:  # pylint: disable=broad-exception-caught

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/mcp/_wrappers.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/mcp/_wrappers.py
@@ -8,6 +8,7 @@ from contextvars import Token
 from typing import Any, Callable, Coroutine, Dict, Optional, Tuple
 from urllib.parse import urlparse
 
+from amazon.opentelemetry.distro._utils import is_agent_observability_enabled
 from amazon.opentelemetry.distro.instrumentation.common.instrumentation_utils import serialize_to_json_string
 from opentelemetry import context, trace
 from opentelemetry.instrumentation.utils import suppress_http_instrumentation
@@ -60,9 +61,9 @@ class McpWrapper:
         self._should_suppress_http_spans = (
             os.environ.get(OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION, "true").lower() == "true"
         )
+        self._agent_observability_enabled = is_agent_observability_enabled()
 
-    @staticmethod
-    def _should_suppress_mcp_span(message: Any) -> bool:
+    def _should_suppress_mcp_span(self, message: Any) -> bool:
         from mcp import types  # pylint: disable=import-outside-toplevel
 
         if isinstance(
@@ -70,7 +71,12 @@ class McpWrapper:
         ):
             message = message.root
         # noisy spans most of the time
-        return isinstance(message, (types.InitializeRequest, types.InitializedNotification))
+        if isinstance(message, (types.InitializeRequest, types.InitializedNotification)):
+            return True
+        # MCP servers hosted on AgentCore get frequent /ping health checks
+        if self._agent_observability_enabled and isinstance(message, types.PingRequest):
+            return True
+        return False
 
     @staticmethod
     def _set_mcp_attributes(span: trace.Span, message: Any, request_id: Optional[int]) -> None:

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/exporter/otlp/aws/traces/test_otlp_aws_span_exporter.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/exporter/otlp/aws/traces/test_otlp_aws_span_exporter.py
@@ -223,3 +223,70 @@ class TestOTLPAwsSpanExporter(TestCase):
         result = exporter.export(spans)
 
         self.assertEqual(result, SpanExportResult.FAILURE)
+
+    @patch(
+        "amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter."
+        "is_genai_content_extraction_opted_out"
+    )
+    @patch(
+        "amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.is_agentic_observability_enabled"
+    )
+    @patch("amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.get_logger_provider")
+    @patch("amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.LLOHandler")
+    def test_export_skips_llo_when_content_extraction_opted_out(
+        self, mock_llo_handler_class, mock_get_logger_provider, mock_is_enabled, mock_opted_out
+    ):
+        mock_is_enabled.return_value = True
+        mock_opted_out.return_value = True
+        mock_logger_provider = MagicMock(spec=LoggerProvider)
+        mock_get_logger_provider.return_value = mock_logger_provider
+
+        endpoint = "https://xray.us-east-1.amazonaws.com/v1/traces"
+        exporter = OTLPAwsSpanExporter(session=get_aws_session(), aws_region="us-east-1", endpoint=endpoint)
+
+        original_spans = [MagicMock(spec=ReadableSpan)]
+
+        with patch.object(OTLPSpanExporter, "export") as mock_parent_export:
+            mock_parent_export.return_value = SpanExportResult.SUCCESS
+
+            result = exporter.export(original_spans)
+
+            self.assertEqual(result, SpanExportResult.SUCCESS)
+            mock_parent_export.assert_called_once_with(original_spans)
+            mock_llo_handler_class.assert_not_called()
+
+    @patch(
+        "amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter."
+        "is_genai_content_extraction_opted_out"
+    )
+    @patch(
+        "amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.is_agentic_observability_enabled"
+    )
+    @patch("amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.get_logger_provider")
+    @patch("amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.LLOHandler")
+    def test_export_processes_llo_when_content_extraction_not_opted_out(
+        self, mock_llo_handler_class, mock_get_logger_provider, mock_is_enabled, mock_opted_out
+    ):
+        mock_is_enabled.return_value = True
+        mock_opted_out.return_value = False
+        mock_logger_provider = MagicMock(spec=LoggerProvider)
+        mock_get_logger_provider.return_value = mock_logger_provider
+
+        mock_llo_handler = MagicMock()
+        mock_llo_handler_class.return_value = mock_llo_handler
+
+        endpoint = "https://xray.us-east-1.amazonaws.com/v1/traces"
+        exporter = OTLPAwsSpanExporter(session=get_aws_session(), aws_region="us-east-1", endpoint=endpoint)
+
+        original_spans = [MagicMock(spec=ReadableSpan)]
+        processed_spans = [MagicMock(spec=ReadableSpan)]
+        mock_llo_handler.process_spans.return_value = processed_spans
+
+        with patch.object(OTLPSpanExporter, "export") as mock_parent_export:
+            mock_parent_export.return_value = SpanExportResult.SUCCESS
+
+            result = exporter.export(original_spans)
+
+            self.assertEqual(result, SpanExportResult.SUCCESS)
+            mock_llo_handler.process_spans.assert_called_once_with(original_spans)
+            mock_parent_export.assert_called_once_with(processed_spans)

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/mcp/test_mcp_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/mcp/test_mcp_instrumentor.py
@@ -473,6 +473,27 @@ class TestMcpInstrumentorInProcess(McpInstrumentorTestBase):
                     finally:
                         HTTPXClientInstrumentor().uninstrument()
 
+    def test_ping_span_suppression(self):
+        for agent_obs_enabled, expect_suppressed in [("true", True), ("false", False)]:
+            with self.subTest(agent_observability=agent_obs_enabled):
+                self.instrumentor.uninstrument()
+                self.span_exporter.clear()
+                with unittest.mock.patch.dict(os.environ, {"AGENT_OBSERVABILITY_ENABLED": agent_obs_enabled}):
+                    self.instrumentor.instrument(tracer_provider=self.tracer_provider, propagators=self.propagator)
+                    self.server = self._create_server()
+
+                    async def run(session):
+                        await session.send_ping()
+
+                    asyncio.run(self._run_inprocess(run))
+                    spans = self.span_exporter.get_finished_spans()
+
+                    ping_spans = [s for s in spans if "ping" in s.name.lower()]
+                    if expect_suppressed:
+                        self.assertEqual(len(ping_spans), 0, "Ping spans should be suppressed")
+                    else:
+                        self.assertGreater(len(ping_spans), 0, "Ping spans should not be suppressed")
+
     def test_mcp_respects_active_parent_span(self):
         tracer = get_tracer("test", tracer_provider=self.tracer_provider)
 

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_utils.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_utils.py
@@ -9,30 +9,35 @@ from unittest.mock import MagicMock, patch
 from amazon.opentelemetry.distro._utils import (
     AGENT_OBSERVABILITY_ENABLED,
     AWS_AGENTIC_OBSERVABILITY_OPT_IN,
+    AWS_GENAI_CONTENT_EXTRACTION_OPT_OUT,
     get_aws_region,
     get_aws_session,
     is_agent_observability_enabled,
     is_agentic_observability_enabled,
     is_aws_agentic_observability_opt_in,
+    is_genai_content_extraction_opted_out,
     is_installed,
 )
 
 
 class TestUtils(TestCase):
     def setUp(self):
-        # Store original env var if it exists
         self.original_env = os.environ.get(AGENT_OBSERVABILITY_ENABLED)
-        # Clear it to ensure clean state
+        self.original_opt_out_env = os.environ.get(AWS_GENAI_CONTENT_EXTRACTION_OPT_OUT)
         if AGENT_OBSERVABILITY_ENABLED in os.environ:
             del os.environ[AGENT_OBSERVABILITY_ENABLED]
+        if AWS_GENAI_CONTENT_EXTRACTION_OPT_OUT in os.environ:
+            del os.environ[AWS_GENAI_CONTENT_EXTRACTION_OPT_OUT]
 
     def tearDown(self):
-        # First clear the env var
         if AGENT_OBSERVABILITY_ENABLED in os.environ:
             del os.environ[AGENT_OBSERVABILITY_ENABLED]
-        # Then restore original if it existed
+        if AWS_GENAI_CONTENT_EXTRACTION_OPT_OUT in os.environ:
+            del os.environ[AWS_GENAI_CONTENT_EXTRACTION_OPT_OUT]
         if self.original_env is not None:
             os.environ[AGENT_OBSERVABILITY_ENABLED] = self.original_env
+        if self.original_opt_out_env is not None:
+            os.environ[AWS_GENAI_CONTENT_EXTRACTION_OPT_OUT] = self.original_opt_out_env
 
     def test_is_installed_package_not_found(self):
         """Test is_installed returns False when package is not found"""
@@ -211,3 +216,26 @@ class TestUtils(TestCase):
         self.assertEqual(region, "eu-west-1")
 
         os.environ.pop("AWS_DEFAULT_REGION", None)
+
+    def test_is_genai_content_extraction_opted_out_various_values(self):
+        os.environ[AWS_GENAI_CONTENT_EXTRACTION_OPT_OUT] = "true"
+        self.assertTrue(is_genai_content_extraction_opted_out())
+
+        os.environ[AWS_GENAI_CONTENT_EXTRACTION_OPT_OUT] = "True"
+        self.assertTrue(is_genai_content_extraction_opted_out())
+
+        os.environ[AWS_GENAI_CONTENT_EXTRACTION_OPT_OUT] = "TRUE"
+        self.assertTrue(is_genai_content_extraction_opted_out())
+
+        os.environ[AWS_GENAI_CONTENT_EXTRACTION_OPT_OUT] = "false"
+        self.assertFalse(is_genai_content_extraction_opted_out())
+
+        os.environ[AWS_GENAI_CONTENT_EXTRACTION_OPT_OUT] = "False"
+        self.assertFalse(is_genai_content_extraction_opted_out())
+
+        os.environ[AWS_GENAI_CONTENT_EXTRACTION_OPT_OUT] = ""
+        self.assertFalse(is_genai_content_extraction_opted_out())
+
+        if AWS_GENAI_CONTENT_EXTRACTION_OPT_OUT in os.environ:
+            del os.environ[AWS_GENAI_CONTENT_EXTRACTION_OPT_OUT]
+        self.assertFalse(is_genai_content_extraction_opted_out())


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Pins urllib3 to 2.7.0 for Python 3.10 or higher, to resolve CVE-2026-44431 and CVE-2026-44432.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

