### PR TITLE
fix: pin urllib3 to 2.7.0 to fix CVE-2026-44431 and CVE-2026-44432

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
   ([#741](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/741))
 - fix(mcp-instrumentation): suppress MCP `/ping` spans when agent observability is enabled
   ([#748](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/748))
+- fix: pin urllib3 to 2.7.0 to fix CVE-2026-44431 and CVE-2026-44432
+  ([#752](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/752))
 
 ## v0.17.0 - 2026-04-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 - fix(mcp-instrumentation): suppress MCP `/ping` spans when agent observability is enabled
   ([#748](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/748))
 - fix: pin urllib3 to 2.7.0 to fix CVE-2026-44431 and CVE-2026-44432
-  ([#752](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/752))
+  ([#753](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/753))
 
 ## v0.17.0 - 2026-04-08
 

--- a/aws-opentelemetry-distro/pyproject.toml
+++ b/aws-opentelemetry-distro/pyproject.toml
@@ -86,6 +86,7 @@ dependencies = [
   "opentelemetry-instrumentation-cassandra == 0.61b0",
   "opentelemetry-instrumentation-openai-agents-v2 == 0.1.0",
   "cachetools == 6.2.4",
+  "urllib3 >= 2.7.0; python_version >= '3.10'",
   "protobuf == 6.33.5",
   "pyyaml == 6.0.3",
 ]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Pins urllib3 to 2.7.0 for Python 3.10 or higher (not compatible with 3.9), to fix CVE-2026-44431 and CVE-2026-44432

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

