### PR TITLE
chore: remove Python 3.9 EKS E2E test

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -125,17 +125,6 @@ jobs:
   # DEFAULT SETTING: {Python Version}, EKS, AMD64, AL2
   #
 
-  eks-py39-amd64:
-    if: ${{ always() }}
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@main
-    secrets: inherit
-    with:
-      aws-region: us-east-1
-      test-cluster-name: 'e2e-python-adot-test'
-      adot-image-name: ${{ inputs.adot-image-name }}
-      caller-workflow-name: 'main-build'
-      python-version: '3.9'
-
   eks-py310-amd64:
     if: ${{ always() }}
     needs: eks-py39-amd64

--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -127,7 +127,6 @@ jobs:
 
   eks-py310-amd64:
     if: ${{ always() }}
-    needs: eks-py39-amd64
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@main
     secrets: inherit
     with:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The urllib3 dependency release 2.7.0 requires Python 3.10+. Our python EKS test builds the image from Python 3.11 and then fails when injected into a Python 3.9 container with the following type error:

```
File "/otel-auto-instrumentation-python/urllib3/_base_connection.py", line 10, in <module>
    bytes, typing.IO[typing.Any], typing.Iterable[bytes | str], str
TypeError: unsupported operand type(s) for |: 'type' and 'type'
```

We will drop this test as Python 3.9 is EOL and upstream has already dropped 3.8 support. We will officially drop Python 3.9 support ahead of the next major/minor release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

