### PR TITLE
feat(serviceevents): add ServiceEvents feature

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,4 @@
 [codespell]
 # skipping auto generated folders
 skip = ./.tox,./.mypy_cache,./target,*/LICENSE,./venv,*/sql_dialect_keywords.json,*/3rd.txt
-ignore-words-list = afterall,assertIn, crate
+ignore-words-list = afterall,assertIn,crate,SEH

--- a/.github/workflows/serviceevents-contract-tests.yml
+++ b/.github/workflows/serviceevents-contract-tests.yml
@@ -1,0 +1,50 @@
+name: ServiceEvents Contract Tests
+
+on:
+  # Run on demand. The serviceevents contract tests are also exercised on every PR
+  # via pr-build.yml (`pytest contract-tests/tests`); this standalone workflow lets
+  # maintainers run just the serviceevents suite (or `all`) against a chosen ref.
+  workflow_dispatch:
+    inputs:
+      test_scope:
+        description: 'Which contract tests to run'
+        required: false
+        type: choice
+        default: serviceevents
+        options:
+          - serviceevents
+          - all
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  contract-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo @ SHA - ${{ github.sha }}
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #5.0.0
+
+      - name: Build Wheel and Image Files
+        uses: ./.github/actions/artifacts_build
+        with:
+          image_uri_with_tag: serviceevents-contract-tests/3.10
+          push_image: false
+          load_image: true
+          # `load` can only materialise a single-platform image into the local Docker
+          # daemon; multi-platform builds produce a manifest list which buildx cannot load.
+          platforms: linux/amd64
+          python_version: "3.10"
+          package_name: aws-opentelemetry-distro
+          os: ubuntu-latest
+
+      - name: Set up and run contract tests with pytest
+        run: |
+          bash scripts/set-up-contract-tests.sh
+          pip install pytest
+          if [ "${{ inputs.test_scope }}" = "all" ]; then
+            pytest contract-tests/tests -v
+          else
+            pytest contract-tests/tests/test/amazon/serviceevents/ -v
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 - feat: add opt-in Dynamic Instrumentation (runtime breakpoints/probes) gated by `OTEL_AWS_DYNAMIC_INSTRUMENTATION_ENABLED` (default off)
   ([#761](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/761))
+- feat(serviceevents): add function metrics, endpoint tracking, error counts, deployment events, and incident snapshots emitted via OTLP
+  ([#763](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/763))
 - feat: support environment-configured endpoint visibility for HTTP operation names
   ([#718](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/718))
 - fix(lambda-layer): Standardize CompactConsoleLogRecordExporter output with CloudWatch OTLP backend schema.

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
@@ -227,6 +227,78 @@ def _initialize_components():
     if logging_enabled.strip().lower() == "true":
         _init_logging(log_exporters, resource)
 
+    # Initialize ServiceEvents instrumentation
+    _init_serviceevents(resource)
+
+
+def _init_serviceevents(resource=None):
+    """Initialize ServiceEvents instrumentation if enabled.
+
+    Args:
+        resource: OTel Resource object from AWS detectors (EC2/ECS/EKS).
+                  Used to extract platform attributes for serviceevents telemetry.
+    """
+    try:
+        if not _is_serviceevents_enabled():
+            return
+
+        # Lazy imports: defer the serviceevents package (and its optional deps) until enabled,
+        # and avoid an import cycle with this configurator module.
+        # pylint: disable=import-outside-toplevel
+        from amazon.opentelemetry.distro.serviceevents import ServiceEventsConfig, get_serviceevents_instrumentation
+        from amazon.opentelemetry.distro.serviceevents.models.resource_attributes import (
+            ResourceAttributes as ServiceEventsResourceAttributes,
+        )
+
+        # Extract resource attributes from OTel Resource
+        resource_attributes = (
+            ServiceEventsResourceAttributes.from_otel_resource(resource)
+            if resource
+            else ServiceEventsResourceAttributes()
+        )
+
+        # Build configuration from environment variables with resource attributes.
+        # `config.enabled` mirrors OTEL_AWS_SERVICE_EVENTS_ENABLED directly; the outer
+        # bundling gate above has already decided ServiceEvents should run, so flip
+        # the inner flag on regardless of whether the env var was set.
+        config = ServiceEventsConfig.from_env(resource_attributes=resource_attributes)
+        config.enabled = True
+
+        # Endpoint policy:
+        # - App Signals enabled: empty/null endpoints default to the 4316 App Signals receiver.
+        # - App Signals disabled + ServiceEvents force-enabled: endpoints are required; refuse to init.
+        as_enabled = _is_application_signals_enabled()
+        if not (config.logs_endpoint or "").strip() or not (config.metrics_endpoint or "").strip():
+            if as_enabled:
+                if not (config.logs_endpoint or "").strip():
+                    config.logs_endpoint = "http://localhost:4316/v1/logs"
+                if not (config.metrics_endpoint or "").strip():
+                    config.metrics_endpoint = "http://localhost:4316/v1/metrics"
+            else:
+                _logger.error(
+                    "ServiceEvents force-enabled (OTEL_AWS_SERVICE_EVENTS_ENABLED=true) without "
+                    "Application Signals, but OTEL_AWS_OTLP_LOGS_ENDPOINT / "
+                    "OTEL_AWS_OTLP_METRICS_ENDPOINT are unset or empty. Both are "
+                    "required in this mode. Skipping ServiceEvents initialization."
+                )
+                return
+
+        # Get or create singleton instrumentation instance
+        # If already initialized (e.g., by manual init), this will return existing instance
+        instrumentation = get_serviceevents_instrumentation(config)
+        if instrumentation is None:
+            _logger.warning("Failed to get ServiceEvents instrumentation instance")
+            return
+
+        # Initialize if not already initialized
+        instrumentation.initialize()
+
+        _logger.info("ServiceEvents instrumentation initialized")
+
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        # Don't fail the whole instrumentation if ServiceEvents fails
+        _logger.error("Failed to initialize ServiceEvents: %s", exc, exc_info=True)
+
 
 def _init_logging(
     exporters: dict[str, Type[LogRecordExporter]],
@@ -645,6 +717,23 @@ def _customize_resource(resource: Resource) -> Resource:
 
     custom_attributes = {AWS_LOCAL_SERVICE: service_name}
 
+    # Add CI/CD and VCS attributes only if they have real values
+    git_repo_url = os.environ.get("OTEL_AWS_SERVICE_EVENTS_GIT_REPO_URL", "")
+    if git_repo_url:
+        custom_attributes["vcs.repository.url.full"] = git_repo_url
+
+    git_commit_sha = os.environ.get("OTEL_AWS_SERVICE_EVENTS_GIT_COMMIT_SHA", "")
+    if git_commit_sha:
+        custom_attributes["vcs.ref.head.revision"] = git_commit_sha
+
+    deployment_url = os.environ.get("OTEL_AWS_SERVICE_EVENTS_DEPLOYMENT_URL", "")
+    if deployment_url:
+        custom_attributes["cicd.pipeline.run.url.full"] = deployment_url
+
+    deployment_timestamp = os.environ.get("OTEL_AWS_SERVICE_EVENTS_DEPLOYMENT_TIMESTAMP", "")
+    if deployment_timestamp:
+        custom_attributes["cicd.pipeline.run.timestamp"] = deployment_timestamp
+
     if is_agent_observability_enabled():
         # Add aws.service.type if it doesn't exist in the resource
         if resource and resource.attributes.get(AWS_SERVICE_TYPE) is None:
@@ -661,6 +750,18 @@ def _is_application_signals_enabled():
         ).lower()
         == "true"
     )
+
+
+def _is_serviceevents_enabled():
+    # ServiceEvents is bundled with Application Signals: on by default when App Signals is on,
+    # off by default when it isn't, and always off on Lambda regardless. An explicit
+    # OTEL_AWS_SERVICE_EVENTS_ENABLED value (true/false) overrides the bundling.
+    if _is_lambda_environment():
+        return False
+    explicit = os.environ.get("OTEL_AWS_SERVICE_EVENTS_ENABLED")
+    if explicit is not None and explicit.strip() != "":
+        return explicit.strip().lower() == "true"
+    return _is_application_signals_enabled()
 
 
 def _is_application_signals_runtime_enabled():

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/__init__.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/__init__.py
@@ -1,0 +1,44 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+ServiceEvents instrumentation for AWS OpenTelemetry Python.
+
+This package provides deep observability capabilities including:
+- Function-level invocation metrics
+- HTTP endpoint performance tracking
+- Automated error investigation on failures
+"""
+
+# Names are resolved by the lazy __getattr__ below; the E0603 here is a false positive.
+# pylint: disable=undefined-all-variable
+__all__ = [
+    "ServiceEventsConfig",
+    "ServiceEventsInstrumentation",
+    "get_serviceevents_instrumentation",
+]
+# pylint: enable=undefined-all-variable
+
+
+def __getattr__(name):
+    """Lazy import to avoid circular dependencies."""
+    # Lazy imports below intentionally live inside __getattr__ to avoid circular dependencies.
+    if name == "ServiceEventsConfig":
+        from amazon.opentelemetry.distro.serviceevents.config import (  # pylint: disable=import-outside-toplevel
+            ServiceEventsConfig,
+        )
+
+        return ServiceEventsConfig
+    if name == "ServiceEventsInstrumentation":
+        # pylint: disable-next=import-outside-toplevel
+        from amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation import ServiceEventsInstrumentation
+
+        return ServiceEventsInstrumentation
+    if name == "get_serviceevents_instrumentation":
+        # pylint: disable-next=import-outside-toplevel
+        from amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation import (
+            get_serviceevents_instrumentation,
+        )
+
+        return get_serviceevents_instrumentation
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/ast_transformation.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/ast_transformation.py
@@ -34,6 +34,22 @@ _registry_lock = threading.Lock()
 FunctionDef = TypeVar("FunctionDef", ast.FunctionDef, ast.AsyncFunctionDef)
 
 
+def _is_docstring_expr(node: ast.stmt) -> bool:
+    """Return True if ``node`` is a string-constant expression statement (a docstring).
+
+    A docstring is only recognised as the FIRST statement of a module/function body. Handles
+    the 3.8 AST change (``ast.Str`` with ``.s`` → ``ast.Constant`` with ``.value``); ``ast.Str``
+    is deprecated and removed in newer CPython, so the version gate keeps this working across
+    interpreters. Shared by the module-docstring check (preamble insertion) and the
+    function-docstring check (body rewrite) so the two cannot drift apart.
+    """
+    if not isinstance(node, ast.Expr):
+        return False
+    if sys.version_info >= (3, 8):
+        return isinstance(node.value, ast.Constant) and isinstance(node.value.value, str)
+    return isinstance(node.value, ast.Str) and isinstance(node.value.s, str)  # type: ignore[attr-defined]
+
+
 def _file_path_to_module_path(file_path: str) -> str:
     """Convert a file path to a module-style path for function naming.
 
@@ -226,21 +242,7 @@ class ServiceEventsASTTransformer(ast.NodeTransformer):
         node: Union[ast.FunctionDef, ast.AsyncFunctionDef],
     ) -> Optional[ast.stmt]:
         """If the first expression in the function is a docstring, remove and return it."""
-        # Mirrors an ast type name (Constant/Str); kept CamelCase to match the ast API.
-        AstStrType = ast.Constant if sys.version_info >= (3, 8) else ast.Str  # pylint: disable=invalid-name
-
-        if not node.body:
-            return None
-
-        if (
-            isinstance(node.body[0], ast.Expr)
-            and isinstance(node.body[0].value, AstStrType)
-            and (
-                isinstance(node.body[0].value.value, str)  # type: ignore[attr-defined]
-                if sys.version_info >= (3, 8)
-                else isinstance(node.body[0].value.s, str)  # type: ignore[attr-defined]
-            )
-        ):
+        if node.body and _is_docstring_expr(node.body[0]):
             return node.body.pop(0)
         return None
 
@@ -407,6 +409,35 @@ class ServiceEventsSourceLoader(SourceFileLoader):
         # Fallback: return the original path unchanged
         return source_path
 
+    @staticmethod
+    def _preamble_insert_index(body: List[ast.stmt]) -> int:
+        """Index at which an injected import may go without displacing required leading statements.
+
+        Returns the position just past the module's mandatory "preamble" so the injected
+        ``PythonServiceEventsMonitor`` import cannot push aside statements Python requires
+        to come first:
+          1. A module docstring — ``__doc__`` is populated only when the FIRST statement is a
+             string-constant ``Expr``; inserting before it silently makes ``__doc__`` None
+             (breaks pydoc/help()/doctest/``__doc__``-based tooling).
+          2. ``from __future__ import ...`` — these MUST be the first statements (after any
+             docstring); inserting before one raises ``SyntaxError`` at compile(), which
+             get_code's broad-except would swallow into a silent fall back to *uninstrumented*
+             loading for the whole module.
+
+        Note on (2): in the current pipeline ServiceEventsASTTransformer.visit_ImportFrom strips
+        every ``__future__`` node into compiler flags BEFORE this runs, so on a transformed tree
+        no ``__future__`` node survives for the loop to skip. The skip is kept deliberately so this
+        helper is correct on ANY body (it is unit-tested directly on un-transformed bodies, and
+        stays safe if that strip step is ever changed) — not because the loop fires today.
+        """
+        if not body:
+            return 0
+        index = 1 if _is_docstring_expr(body[0]) else 0
+        # Skip past any leading ``from __future__`` imports (they may follow the docstring).
+        while index < len(body) and isinstance(body[index], ast.ImportFrom) and body[index].module == "__future__":
+            index += 1
+        return index
+
     def get_code(self, fullname: str) -> Optional[types.CodeType]:
         """Load and transform the module's source code."""
         source_path = self.get_filename(fullname)
@@ -440,22 +471,10 @@ class ServiceEventsSourceLoader(SourceFileLoader):
                 level=0,
             )
             ast.fix_missing_locations(import_node)
-            # Insert the import after a leading module docstring (if any). A module's
-            # __doc__ is populated only when the FIRST statement is a string-constant Expr;
-            # inserting the import at index 0 would displace the docstring and silently make
-            # __doc__ None, breaking pydoc/help()/doctest/__doc__-based tooling. Mirrors the
-            # docstring predicate in get_and_remove_docstring (incl. the 3.8 ast.Str fallback).
-            AstStrType = ast.Constant if sys.version_info >= (3, 8) else ast.Str  # pylint: disable=invalid-name
-            has_leading_docstring = bool(transformed_tree.body) and (
-                isinstance(transformed_tree.body[0], ast.Expr)
-                and isinstance(transformed_tree.body[0].value, AstStrType)
-                and (
-                    isinstance(transformed_tree.body[0].value.value, str)  # type: ignore[attr-defined]
-                    if sys.version_info >= (3, 8)
-                    else isinstance(transformed_tree.body[0].value.s, str)  # type: ignore[attr-defined]
-                )
-            )
-            transformed_tree.body.insert(1 if has_leading_docstring else 0, import_node)
+            # Insert after the module's mandatory preamble (docstring + ``from __future__``)
+            # so the injected import never displaces a statement Python requires to come first.
+            insert_index = self._preamble_insert_index(transformed_tree.body)
+            transformed_tree.body.insert(insert_index, import_node)
 
             # Compile transformed AST to code object
             code = compile(

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/ast_transformation.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/ast_transformation.py
@@ -1,0 +1,630 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+AST transformation for automatic function instrumentation.
+
+This module implements Python's import hook mechanism to automatically wrap
+all functions with ServiceEvents monitoring context managers during module loading.
+"""
+
+import ast
+import fnmatch
+import importlib
+import importlib.abc
+import importlib.util
+import logging
+import os
+import sys
+import threading
+import types
+from importlib.machinery import ModuleSpec, SourceFileLoader
+from typing import Any, Dict, List, Optional, Sequence, Set, TypeVar, Union
+
+logger = logging.getLogger(__name__)
+
+# =============================================================================
+# Function Registry - Thread-safe mapping of function_name -> function metadata
+# =============================================================================
+
+# Global registry storing composite function_name -> {name, file_path, line} mappings
+_function_registry: Dict[str, Dict[str, Any]] = {}
+_registry_lock = threading.Lock()
+
+FunctionDef = TypeVar("FunctionDef", ast.FunctionDef, ast.AsyncFunctionDef)
+
+
+def _file_path_to_module_path(file_path: str) -> str:
+    """Convert a file path to a module-style path for function naming.
+
+    Strips the .py extension and handles __init__.py by using the parent directory.
+
+    Examples:
+        'indico/modules/foo/bar.py' → 'indico/modules/foo/bar'
+        'indico/modules/attachments/__init__.py' → 'indico/modules/attachments'
+        '/absolute/path/to/server.py' → '/absolute/path/to/server'
+    """
+    # Normalize path separators to forward slashes
+    path = file_path.replace(os.sep, "/")
+
+    # Strip .py extension
+    if path.endswith(".py"):
+        path = path[:-3]
+
+    # Handle __init__ files: use parent directory
+    if path.endswith("/__init__"):
+        path = path[:-9]
+
+    return path
+
+
+def build_function_name(function_name: str, file_path: str, lineno: int, is_async: bool = False) -> str:
+    """
+    Build a composite function identifier for ServiceEvents instrumentation.
+
+    Creates a human-readable identifier from the module path and function name.
+    Also registers the function in the global registry for later export.
+
+    Format: "relative/path/to/module.function_name"
+
+    The file_path is typically already a relative path when coming through
+    the ServiceEventsSourceLoader import hooks (via _to_relative_path).
+
+    Args:
+        function_name: Name of the function
+        file_path: Path to source file (relative when coming through import hooks)
+        lineno: Line number where function is defined (stored in registry, not in name)
+        is_async: Whether the function is an async function definition
+
+    Returns:
+        Composite function name (e.g., "myapp/server.my_func")
+
+    Example:
+        >>> build_function_name("my_func", "myapp/server.py", 42)
+        "myapp/server.my_func"
+    """
+    module_path = _file_path_to_module_path(file_path)
+    composite_name = f"{module_path}.{function_name}"
+
+    # Register the function in the global registry (thread-safe)
+    with _registry_lock:
+        _function_registry[composite_name] = {
+            "function_name": composite_name,
+            "name": function_name,
+            "file_path": file_path,
+            "line": lineno,
+            "is_async": is_async,
+        }
+
+    return composite_name
+
+
+def get_function_registry() -> Dict[str, Dict[str, Any]]:
+    """
+    Get a copy of the current function registry.
+
+    Returns:
+        Dictionary mapping composite function_name to function metadata.
+    """
+    with _registry_lock:
+        return dict(_function_registry)
+
+
+def get_function_info(function_name: str) -> Optional[Dict[str, Any]]:
+    """
+    Get metadata for a specific function.
+
+    Args:
+        function_name: The composite function name (e.g., "myapp/server.my_func").
+
+    Returns:
+        Function metadata dict or None if not found.
+    """
+    with _registry_lock:
+        return _function_registry.get(function_name)
+
+
+def get_function_info_unlocked(function_name: str) -> Optional[Dict[str, Any]]:
+    """
+    Get metadata for a specific function WITHOUT acquiring _registry_lock.
+
+    This is a best-effort, lock-free read intended for the hot path where
+    lock contention is unacceptable. It is safe because:
+
+    - CPython protects internal dict structures with per-object locks on both
+      GIL and free-threaded (PEP 703) builds, so dict.get() observes a
+      consistent state even under concurrent writes.
+    - _function_registry entries are immutable once written (during module import).
+    - The worst case is a momentary None for a function whose import hasn't
+      completed yet — callers must tolerate a None return gracefully.
+
+    Use this in performance-critical paths (e.g., __enter__/__exit__ of the
+    monitor context manager). Use get_function_info() when correctness under
+    concurrent writes matters (e.g., during module loading or in tests).
+
+    Args:
+        function_name: The composite function name (e.g., "myapp/server.my_func").
+
+    Returns:
+        Function metadata dict or None if not found (best-effort).
+    """
+    return _function_registry.get(function_name)
+
+
+def get_registry_size() -> int:
+    """Get the number of functions in the registry."""
+    with _registry_lock:
+        return len(_function_registry)
+
+
+def get_deployment_event_telemetry(
+    service_name: str = "unknown-service",
+    environment: Optional[str] = None,
+    sdk_version: str = "0.14.2",
+    pid: Optional[int] = None,
+    resource_attributes=None,
+) -> Dict[str, Any]:
+    """
+    Get a deployment event as a telemetry event dict.
+
+    Returns a dict with telemetry_type="DeploymentEvent" containing
+    deployment metadata (git commit, CI/CD info).
+
+    Args:
+        service_name: Service name for the telemetry metadata.
+        environment: Environment name for the telemetry metadata.
+        sdk_version: SDK version string.
+        pid: Process ID (defaults to current process).
+        resource_attributes: Optional ResourceAttributes from OTel Resource detectors.
+
+    Returns:
+        Dict containing the deployment event telemetry.
+    """
+    # Lazy import to avoid a circular dependency with the models module.
+    # pylint: disable-next=import-outside-toplevel
+    from amazon.opentelemetry.distro.serviceevents.models import DeploymentEventTelemetry
+
+    telemetry = DeploymentEventTelemetry.create(
+        service_name=service_name,
+        environment=environment,
+        sdk_version=sdk_version,
+        pid=pid,
+        include_deployment_context=True,
+        resource_attributes=resource_attributes,
+    )
+
+    return telemetry.to_dict()
+
+
+def clear_function_registry():
+    """Clear the function registry (mainly for testing)."""
+    with _registry_lock:
+        _function_registry.clear()
+
+
+class ServiceEventsASTTransformer(ast.NodeTransformer):
+    """
+    AST transformer that wraps function bodies with PythonServiceEventsMonitor context manager.
+
+    Transforms:
+        def my_function(args):
+            # body
+
+    Into:
+        def my_function(args):
+            with PythonServiceEventsMonitor("module/path.my_function"):
+                # body
+    """
+
+    def __init__(self, file_path: str) -> None:
+        self.file_path = file_path
+        self.compiler_flags = 0
+        self.instrumented_functions = 0
+
+    @staticmethod
+    def get_and_remove_docstring(
+        node: Union[ast.FunctionDef, ast.AsyncFunctionDef],
+    ) -> Optional[ast.stmt]:
+        """If the first expression in the function is a docstring, remove and return it."""
+        # Mirrors an ast type name (Constant/Str); kept CamelCase to match the ast API.
+        AstStrType = ast.Constant if sys.version_info >= (3, 8) else ast.Str  # pylint: disable=invalid-name
+
+        if not node.body:
+            return None
+
+        if (
+            isinstance(node.body[0], ast.Expr)
+            and isinstance(node.body[0].value, AstStrType)
+            and (
+                isinstance(node.body[0].value.value, str)  # type: ignore[attr-defined]
+                if sys.version_info >= (3, 8)
+                else isinstance(node.body[0].value.s, str)  # type: ignore[attr-defined]
+            )
+        ):
+            return node.body.pop(0)
+        return None
+
+    @staticmethod
+    def get_with_location_from_node(node: FunctionDef) -> dict:
+        """Extract location info from AST node for the with statement."""
+        if len(node.body) == 0:
+            return {
+                "lineno": node.lineno,
+                "col_offset": node.col_offset,
+                "end_lineno": getattr(node, "end_lineno", node.lineno),
+                "end_col_offset": getattr(node, "end_col_offset", node.col_offset),
+            }
+
+        return {
+            "lineno": node.body[0].lineno,
+            "col_offset": node.body[0].col_offset,
+            "end_lineno": getattr(node.body[0], "end_lineno", node.body[0].lineno),
+            "end_col_offset": getattr(node.body[0], "end_col_offset", node.body[0].col_offset),
+        }
+
+    def get_with_stmt(self, function_name: str, node: FunctionDef) -> ast.With:
+        """Create the 'with PythonServiceEventsMonitor(function_name):' statement."""
+        locations = self.get_with_location_from_node(node)
+
+        args = [ast.Constant(value=function_name, kind=None, **locations)]  # type: List[ast.expr]
+        return ast.With(
+            items=[
+                ast.withitem(
+                    context_expr=ast.Call(
+                        func=ast.Name(id="PythonServiceEventsMonitor", ctx=ast.Load(), **locations),
+                        args=args,
+                        keywords=[],
+                        **locations,
+                    ),
+                )
+            ],
+            body=[],
+            type_comment=None,
+            **locations,
+        )
+
+    @staticmethod
+    def _is_generator(node: FunctionDef) -> bool:
+        """Return True if this function is a (sync or async) generator.
+
+        A function is a generator when its own body contains a `yield` or `yield from`.
+        We must NOT descend into nested function/lambda bodies: a `yield` inside a nested
+        function makes *that* inner function a generator, not this one. So this walks the
+        function's own scope only, treating nested def/async-def/lambda as opaque.
+        """
+        # Seed the stack with the function's direct children, skipping the node itself
+        # (whose own `yield`, if any, cannot exist at the def level).
+        stack: List[ast.AST] = list(ast.iter_child_nodes(node))
+        while stack:
+            child = stack.pop()
+            if isinstance(child, (ast.Yield, ast.YieldFrom)):
+                return True
+            # A nested function/lambda opens a new scope; any yield inside it belongs to
+            # that inner scope, so do not descend.
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+                continue
+            stack.extend(ast.iter_child_nodes(child))
+        return False
+
+    # Name mirrors the ast.NodeTransformer visitor naming convention (visit_FunctionDef).
+    def _visit_generic_FunctionDef(self, node: FunctionDef) -> FunctionDef:  # pylint: disable=invalid-name
+        """Generic function transformation for both sync and async functions."""
+        # Skip generators / async generators. Wrapping a generator body in a `with` would
+        # bind the monitor's lifetime to the generator object: __enter__ runs on first
+        # advance and __exit__ only at exhaustion or GC, so the recorded "duration" would
+        # span the consumer's iteration (not the function's work) and the call-stack push
+        # would leak across yield boundaries, corrupting caller attribution. Leave them
+        # un-instrumented and recurse so nested non-generator functions still get wrapped.
+        if self._is_generator(node):
+            self.generic_visit(node)
+            return node
+
+        self.instrumented_functions += 1
+
+        # Build composite function name
+        is_async = isinstance(node, ast.AsyncFunctionDef)
+        function_name = build_function_name(
+            function_name=node.name,
+            file_path=self.file_path,
+            lineno=node.lineno,
+            is_async=is_async,
+        )
+
+        # Extract and preserve docstring
+        docstring = self.get_and_remove_docstring(node)
+
+        # Create with statement
+        with_stmt = self.get_with_stmt(function_name, node)
+        with_stmt.body = node.body
+
+        # Handle empty function bodies
+        if not with_stmt.body:
+            with_stmt.body = [ast.Pass(**self.get_with_location_from_node(node))]
+
+        # Reconstruct function body with docstring (if any) and with statement
+        if docstring is not None:
+            node.body = [docstring, with_stmt]
+        else:
+            node.body = [with_stmt]
+
+        # Continue visiting nested nodes
+        self.generic_visit(node)
+        return node
+
+    # Required visitor name from the ast.NodeTransformer visitor API.
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> ast.FunctionDef:  # pylint: disable=invalid-name
+        """Transform synchronous function definitions."""
+        return self._visit_generic_FunctionDef(node)
+
+    # Required visitor name from the ast.NodeTransformer visitor API.
+    # pylint: disable-next=invalid-name
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> ast.AsyncFunctionDef:
+        """Transform asynchronous function definitions."""
+        return self._visit_generic_FunctionDef(node)
+
+    # Required visitor name from the ast.NodeTransformer visitor API.
+    # pylint: disable-next=invalid-name
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> Optional[ast.ImportFrom]:
+        """
+        Handle __future__ imports to set compiler flags.
+        When passing an AST to compile(), __future__ imports need special handling.
+        """
+        if node.module == "__future__":
+            # Lazy import: __future__ is only needed to resolve compiler flags here.
+            import __future__  # pylint: disable=import-outside-toplevel
+
+            for name in node.names:
+                feature = getattr(__future__, name.name)
+                self.compiler_flags |= feature.compiler_flag
+            return None
+
+        self.generic_visit(node)
+        return node
+
+
+class ServiceEventsSourceLoader(SourceFileLoader):
+    """Custom source loader that applies AST transformation before loading modules."""
+
+    @staticmethod
+    def _to_relative_path(fullname: str, source_path: str) -> str:
+        """Derive a relative file path from the module's fully qualified name.
+
+        Uses the module name to strip the installation prefix from the absolute
+        path, producing a path like ``indico/modules/foo/bar.py`` that can be
+        matched against local source trees regardless of where the package is
+        installed.
+        """
+        # module.py pattern (e.g. "indico/modules/foo/bar.py")
+        module_suffix = fullname.replace(".", os.sep) + ".py"
+        if source_path.endswith(os.sep + module_suffix):
+            return module_suffix
+
+        # package/__init__.py pattern
+        package_suffix = fullname.replace(".", os.sep) + os.sep + "__init__.py"
+        if source_path.endswith(os.sep + package_suffix):
+            return package_suffix
+
+        # Fallback: return the original path unchanged
+        return source_path
+
+    def get_code(self, fullname: str) -> Optional[types.CodeType]:
+        """Load and transform the module's source code."""
+        source_path = self.get_filename(fullname)
+
+        try:
+            # Read source file
+            with open(source_path, "rb") as source_file:
+                source_bytes = source_file.read()
+
+            # Parse source to AST
+            try:
+                tree = ast.parse(source_bytes, filename=source_path)
+            except SyntaxError:
+                # If AST parsing fails, fall back to default behavior
+                return super().get_code(fullname)
+
+            # Use relative path for telemetry so paths match local source trees
+            relative_path = self._to_relative_path(fullname, source_path)
+
+            # Transform AST
+            transformer = ServiceEventsASTTransformer(relative_path)
+            transformed_tree = transformer.visit(tree)
+
+            # Fix missing locations in AST nodes
+            ast.fix_missing_locations(transformed_tree)
+
+            # Inject PythonServiceEventsMonitor import at the top of the module
+            import_node = ast.ImportFrom(
+                module="amazon.opentelemetry.distro.serviceevents.python_monitor",
+                names=[ast.alias(name="PythonServiceEventsMonitor", asname=None)],
+                level=0,
+            )
+            ast.fix_missing_locations(import_node)
+            transformed_tree.body.insert(0, import_node)
+
+            # Compile transformed AST to code object
+            code = compile(
+                transformed_tree,
+                source_path,
+                "exec",
+                flags=transformer.compiler_flags,
+                dont_inherit=True,
+            )
+
+            return code
+
+        # Crash-safety: any transformation failure must fall back to normal loading.
+        except Exception:  # pylint: disable=broad-exception-caught
+            # On any error, fall back to default behavior
+            return super().get_code(fullname)
+
+
+# SDK self-exclusion (SDK_SELF_EXCLUDE) — the non-configurable safety boundary.
+# These prefixes cover the entire ADOT distro and OpenTelemetry itself; a customer
+# cannot opt them back in via PACKAGES_INCLUDE. Instrumenting them would cause import
+# cycles (the distro's own modules) or infinite recursion in the tracing pipeline
+# (every signal emit re-enters instrumentation). Matched by module `fullname`
+# (exact-or-dotted-prefix), so it catches OTel/distro modules even when installed in
+# site-packages — making a path-based gate unnecessary.
+#
+#   - "amazon.opentelemetry" — the entire ADOT distro (it installs under the single
+#     `amazon` src root, so every distro submodule is caught by this one prefix).
+#   - "opentelemetry" — OTel API/SDK + contrib, and the lambda-layer's vendored
+#     `opentelemetry/` tree (caught regardless of install path).
+SDK_SELF_EXCLUDE: List[str] = [
+    "amazon.opentelemetry",
+    "opentelemetry",
+]
+
+
+class ServiceEventsMetaPathFinder(importlib.abc.MetaPathFinder):
+    """
+    Meta path finder that intercepts module imports and applies AST transformation.
+
+    This is installed in sys.meta_path to automatically instrument all imported modules.
+    """
+
+    def __init__(self, packages_include: Set[str], packages_exclude: List[str]):
+        self.packages_include = packages_include
+        self.packages_exclude = packages_exclude
+        self._currently_loading: Set[str] = set()
+
+    # pylint: disable-next=too-many-return-statements
+    def should_instrument_module(self, fullname: str, spec: Optional[ModuleSpec]) -> bool:
+        """Determine if a module should be instrumented.
+
+        There is no implicit default scope: PACKAGES_INCLUDE is the only way to opt in
+        and PACKAGES_EXCLUDE is the only way to subtract. The decision (highest priority
+        first):
+
+          0. Matches SDK_SELF_EXCLUDE (non-configurable) → drop
+          1. PACKAGES_INCLUDE is empty → drop (no implicit default scope)
+          2. Matches PACKAGES_EXCLUDE → drop
+          3. Matches PACKAGES_INCLUDE → instrument
+          4. Otherwise → drop
+
+        Plus the structural gates that precede rule 0: no spec / no origin / built-in /
+        frozen → drop (those modules have no source file to transform).
+        """
+        # Structural gates: nothing to transform.
+        if spec is None or spec.origin is None:
+            return False
+        if spec.origin in ("built-in", "frozen"):
+            return False
+
+        # Rule 0: SDK self-exclusion (non-configurable absolute gate, before rule 1).
+        for prefix in SDK_SELF_EXCLUDE:
+            if fullname == prefix or fullname.startswith(f"{prefix}."):
+                return False
+
+        # Rule 1: no implicit default scope — empty include means instrument nothing.
+        if not self.packages_include:
+            return False
+
+        # Rule 2: exclude always wins over include.
+        for pattern in self.packages_exclude:
+            if fnmatch.fnmatch(fullname, pattern):
+                return False
+
+        # Rule 3: include match → instrument.
+        for pattern in self.packages_include:
+            if fnmatch.fnmatch(fullname, pattern) or fullname == pattern or fullname.startswith(f"{pattern}."):
+                return True
+
+        # Rule 4: no include match → drop.
+        return False
+
+    def _name_could_match(self, fullname: str) -> bool:
+        """Cheap name-only pre-filter applied before the expensive spec resolution.
+
+        find_spec sits at the front of sys.meta_path and is consulted for EVERY import in
+        the process — overwhelmingly stdlib/OTel/third-party modules that can never match
+        the allowlist. Those decisions depend only on the module name, so resolve them here
+        (string checks) and skip the costly importlib.util.find_spec call for them. This is
+        a strict subset of should_instrument_module's name-based rules (0, 1, 3); the full
+        check still runs afterward on survivors with the resolved spec for the structural
+        and exclude rules, so the decision is unchanged — only cheaper on the common path.
+        """
+        # Rule 1: empty include → instrument nothing (no need to resolve anything).
+        if not self.packages_include:
+            return False
+        # Rule 0: SDK self-exclusion — never instrument the distro/OTel.
+        for prefix in SDK_SELF_EXCLUDE:
+            if fullname == prefix or fullname.startswith(f"{prefix}."):
+                return False
+        # Rule 3 (name part): must match at least one include pattern to be a candidate.
+        for pattern in self.packages_include:
+            if fnmatch.fnmatch(fullname, pattern) or fullname == pattern or fullname.startswith(f"{pattern}."):
+                return True
+        return False
+
+    # pylint: disable-next=too-many-return-statements
+    def find_spec(
+        self,
+        fullname: str,
+        _path: Optional[Sequence[str]],
+        _target: Optional[types.ModuleType] = None,
+    ) -> Optional[ModuleSpec]:
+        """Find and potentially modify the module spec to use our custom loader."""
+        # Prevent infinite recursion
+        if fullname in self._currently_loading:
+            return None
+
+        # Cheap name-only gate before the expensive spec resolution: the vast majority of
+        # imports can't match the allowlist, and that's decidable from the name alone.
+        if not self._name_could_match(fullname):
+            return None
+
+        self._currently_loading.add(fullname)
+        try:
+            # Get the original spec using the default import machinery
+            spec = importlib.util.find_spec(fullname)
+
+            if spec is None:
+                return None
+
+            # Check if we should instrument this module
+            if not self.should_instrument_module(fullname, spec):
+                return None
+
+            # Only instrument source files (.py)
+            if not (spec.origin and spec.origin.endswith(".py")):
+                return None
+
+            # Replace loader with our custom loader
+            spec.loader = ServiceEventsSourceLoader(fullname, spec.origin)
+
+            return spec
+
+        # Crash-safety: a failure deciding whether/how to instrument a module
+        # must never break the customer's import. Returning None defers to the
+        # default import machinery, leaving the module uninstrumented.
+        except Exception:  # pylint: disable=broad-exception-caught
+            return None
+        finally:
+            self._currently_loading.discard(fullname)
+
+
+def install_ast_hooks(packages_include: Optional[Set[str]] = None, packages_exclude: Optional[List[str]] = None):
+    """
+    Install AST transformation hooks into sys.meta_path.
+
+    Args:
+        packages_include: Set of module patterns to instrument (empty = instrument nothing)
+        packages_exclude: List of fnmatch patterns for modules to exclude (always wins)
+    """
+    if packages_include is None:
+        packages_include = set()
+
+    if packages_exclude is None:
+        packages_exclude = []
+
+    finder = ServiceEventsMetaPathFinder(packages_include, packages_exclude)
+
+    # Insert at the beginning of sys.meta_path to have priority
+    sys.meta_path.insert(0, finder)
+
+
+def uninstall_ast_hooks():
+    """Remove ServiceEvents AST hooks from sys.meta_path."""
+    sys.meta_path = [finder for finder in sys.meta_path if not isinstance(finder, ServiceEventsMetaPathFinder)]

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/ast_transformation.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/ast_transformation.py
@@ -160,7 +160,7 @@ def get_registry_size() -> int:
 def get_deployment_event_telemetry(
     service_name: str = "unknown-service",
     environment: Optional[str] = None,
-    sdk_version: str = "0.14.2",
+    sdk_version: str = "",
     pid: Optional[int] = None,
     resource_attributes=None,
 ) -> Dict[str, Any]:
@@ -440,7 +440,22 @@ class ServiceEventsSourceLoader(SourceFileLoader):
                 level=0,
             )
             ast.fix_missing_locations(import_node)
-            transformed_tree.body.insert(0, import_node)
+            # Insert the import after a leading module docstring (if any). A module's
+            # __doc__ is populated only when the FIRST statement is a string-constant Expr;
+            # inserting the import at index 0 would displace the docstring and silently make
+            # __doc__ None, breaking pydoc/help()/doctest/__doc__-based tooling. Mirrors the
+            # docstring predicate in get_and_remove_docstring (incl. the 3.8 ast.Str fallback).
+            AstStrType = ast.Constant if sys.version_info >= (3, 8) else ast.Str  # pylint: disable=invalid-name
+            has_leading_docstring = bool(transformed_tree.body) and (
+                isinstance(transformed_tree.body[0], ast.Expr)
+                and isinstance(transformed_tree.body[0].value, AstStrType)
+                and (
+                    isinstance(transformed_tree.body[0].value.value, str)  # type: ignore[attr-defined]
+                    if sys.version_info >= (3, 8)
+                    else isinstance(transformed_tree.body[0].value.s, str)  # type: ignore[attr-defined]
+                )
+            )
+            transformed_tree.body.insert(1 if has_leading_docstring else 0, import_node)
 
             # Compile transformed AST to code object
             code = compile(

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/collectors/__init__.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/collectors/__init__.py
@@ -1,0 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+ServiceEvents telemetry collectors for Invocations, EndpointMetrics, and Investigations.
+"""

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/collectors/base_collector.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/collectors/base_collector.py
@@ -1,0 +1,110 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Base collector class for periodic telemetry collection.
+"""
+
+import logging
+import threading
+from abc import ABC, abstractmethod
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class BaseCollector(ABC):
+    """
+    Base class for periodic telemetry collectors.
+
+    Provides common functionality for background collection threads,
+    start/stop lifecycle, and periodic flushing.
+    """
+
+    def __init__(self, flush_interval_ms: int, name: str, otlp_emitter=None):
+        """
+        Initialize the base collector.
+
+        Args:
+            flush_interval_ms: How often to collect data (milliseconds)
+            name: Name of the collector for logging
+            otlp_emitter: Optional ServiceEventsOtlpEmitter for OTLP export
+        """
+        self.flush_interval_ms = flush_interval_ms
+        self.name = name
+        self.otlp_emitter = otlp_emitter
+        self._thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
+        self._running = False
+
+    @property
+    def flush_interval_sec(self):
+        """Derived from flush_interval_ms to ensure consistency."""
+        return self.flush_interval_ms / 1000.0
+
+    def start(self):
+        """Start the collector background thread."""
+        if self._running:
+            logger.warning("%s already running", self.name)
+            return
+
+        logger.info("Starting %s (interval: %sms)", self.name, self.flush_interval_ms)
+        self._stop_event.clear()
+        self._running = True
+        self._thread = threading.Thread(target=self._run_loop, daemon=True, name=self.name)
+        self._thread.start()
+
+    def stop(self):
+        """Stop the collector background thread."""
+        if not self._running:
+            return
+
+        logger.info("Stopping %s", self.name)
+        self._running = False
+        self._stop_event.set()
+
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=5.0)
+            if self._thread.is_alive():
+                logger.warning("%s thread did not stop cleanly", self.name)
+
+    def _reset_for_fork(self):
+        """Reset collector state after fork. The old thread is dead in the child process."""
+        self._stop_event = threading.Event()
+        self._thread = None
+        self._running = False
+
+    def _run_loop(self):
+        """Main collection loop (runs in background thread)."""
+        logger.debug("%s collection loop started", self.name)
+
+        try:
+            while not self._stop_event.is_set():
+                try:
+                    # Collect and export data
+                    self.collect()
+                # telemetry must never crash host app
+                except Exception as exc:  # pylint: disable=broad-exception-caught
+                    logger.error("Error in %s collection: %s", self.name, exc, exc_info=True)
+
+                # Wait for next collection interval (interruptible)
+                self._stop_event.wait(timeout=self.flush_interval_sec)
+
+            # Final collection on shutdown
+            try:
+                logger.debug("%s performing final collection", self.name)
+                self.collect()
+            except Exception as exc:  # pylint: disable=broad-exception-caught  # telemetry must never crash host app
+                logger.error("Error in %s final collection: %s", self.name, exc, exc_info=True)
+
+        finally:
+            logger.debug("%s collection loop stopped", self.name)
+
+    @abstractmethod
+    def collect(self):
+        """
+        Collect and export telemetry data.
+
+        This method is called periodically by the background thread.
+        Subclasses must implement this method to define collection behavior.
+        """

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/collectors/deployment_event_collector.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/collectors/deployment_event_collector.py
@@ -1,0 +1,76 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""DeploymentEventCollector — emits aws.service_events.deployment_event at startup and every flush interval."""
+
+import logging
+from typing import Optional
+
+from amazon.opentelemetry.distro.serviceevents.collectors.base_collector import BaseCollector
+from amazon.opentelemetry.distro.serviceevents.models import DeploymentEventTelemetry, ResourceAttributes
+
+logger = logging.getLogger(__name__)
+
+
+class DeploymentEventCollector(BaseCollector):
+    """Emits DeploymentEvent every flush_interval_ms, independent of AST mode.
+
+    BaseCollector._run_loop calls collect() immediately on start and then once per
+    flush_interval_ms thereafter, so the first emit happens at startup and subsequent
+    emits at +interval, +2*interval, etc.
+
+    Trigger attribute:
+    - First collect() call -> "startup"
+    - Subsequent calls while running -> "periodic"
+    - Final collect() after stop (BaseCollector._running is False) -> "shutdown"
+    """
+
+    def __init__(
+        self,
+        flush_interval_ms: int,
+        environment: Optional[str] = None,
+        service_name: Optional[str] = None,
+        sdk_version: str = "0.14.2",
+        resource_attributes: Optional[ResourceAttributes] = None,
+        otlp_emitter=None,
+    ):
+        super().__init__(flush_interval_ms, "DeploymentEventCollector", otlp_emitter)
+        # Environment from config (None/empty when unset — omitted from emitted signals)
+        self.environment = environment
+        self.service_name = service_name or "UnknownService"
+        self.sdk_version = sdk_version
+        self.resource_attributes = resource_attributes or ResourceAttributes()
+        self._first_collect = True
+
+    def _reset_for_fork(self):
+        """Reset collector state after fork.
+
+        Re-arm the startup emit so each forked worker (e.g. a gunicorn worker) emits its
+        own "startup" DeploymentEvent on its first collect. Without this the child inherits
+        _first_collect=False and its first emit is mislabeled "periodic", losing the
+        per-worker startup signal.
+        """
+        super()._reset_for_fork()
+        self._first_collect = True
+
+    def collect(self):
+        if not self.otlp_emitter:
+            return
+        if self._first_collect:
+            trigger = "startup"
+            self._first_collect = False
+        elif not self._running:
+            trigger = "shutdown"
+        else:
+            trigger = "periodic"
+        try:
+            event = DeploymentEventTelemetry.create(
+                service_name=self.service_name,
+                environment=self.environment,
+                sdk_version=self.sdk_version,
+                resource_attributes=self.resource_attributes,
+            )
+            self.otlp_emitter.emit_deployment_event(event, trigger=trigger)
+            logger.info("Exported DeploymentEvent (trigger=%s)", trigger)
+        except Exception:  # pylint: disable=broad-exception-caught
+            # Telemetry must never crash the customer app; swallow all errors.
+            logger.warning("Failed to emit DeploymentEvent", exc_info=True)

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/collectors/deployment_event_collector.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/collectors/deployment_event_collector.py
@@ -29,7 +29,7 @@ class DeploymentEventCollector(BaseCollector):
         flush_interval_ms: int,
         environment: Optional[str] = None,
         service_name: Optional[str] = None,
-        sdk_version: str = "0.14.2",
+        sdk_version: str = "",
         resource_attributes: Optional[ResourceAttributes] = None,
         otlp_emitter=None,
     ):

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/collectors/endpoint_collector.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/collectors/endpoint_collector.py
@@ -40,7 +40,7 @@ class EndpointMetricCollector(BaseCollector):
         flush_interval_ms: int,
         environment: Optional[str] = None,
         service_name: Optional[str] = None,
-        sdk_version: str = "0.14.2",
+        sdk_version: str = "",
         resource_attributes: Optional[ResourceAttributes] = None,
         otlp_emitter=None,
         suppress_endpoint_summary: bool = False,

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/collectors/endpoint_collector.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/collectors/endpoint_collector.py
@@ -1,0 +1,347 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+EndpointMetricCollector - Collects and exports HTTP endpoint metrics.
+"""
+
+import logging
+import os
+import threading
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Dict, List, Optional
+
+from amazon.opentelemetry.distro.serviceevents.collectors.base_collector import BaseCollector
+from amazon.opentelemetry.distro.serviceevents.models import (
+    DurationMetrics,
+    EndpointMetricEvent,
+    ErrorBreakdownEntry,
+    ErrorDetail,
+    IncidentExemplar,
+    ResourceAttributes,
+)
+from amazon.opentelemetry.distro.serviceevents.utils import get_instance_id
+from amazon.opentelemetry.distro.serviceevents.utils.seh_histogram import SEHHistogram
+
+logger = logging.getLogger(__name__)
+
+
+class EndpointMetricCollector(BaseCollector):
+    """
+    Collector for HTTP endpoint metrics using CloudWatch EMF format.
+
+    Aggregates metrics by operation (method + route) and periodically exports.
+    ServiceEvents endpoint telemetry format for CloudWatch integration.
+    """
+
+    def __init__(
+        self,
+        flush_interval_ms: int,
+        environment: Optional[str] = None,
+        service_name: Optional[str] = None,
+        sdk_version: str = "0.14.2",
+        resource_attributes: Optional[ResourceAttributes] = None,
+        otlp_emitter=None,
+        suppress_endpoint_summary: bool = False,
+    ):
+        """
+        Initialize the endpoint metric collector.
+
+        Args:
+            flush_interval_ms: How often to collect and export data (milliseconds)
+            environment: Deployment environment (e.g., "production", "staging")
+            service_name: Service name from OTEL_SERVICE_NAME
+            sdk_version: ServiceEvents SDK version
+            resource_attributes: AWS platform resource attributes from OTel Resource detectors
+            otlp_emitter: Optional ServiceEventsOtlpEmitter for OTLP export
+            suppress_endpoint_summary: When True, skip emitting EndpointSummary LogRecords
+                (Application Signals already carries equivalent per-endpoint metrics).
+                The collector still runs to feed per-endpoint latency histograms into
+                IncidentSnapshot's threshold triggering and to honor endpoint
+                include/exclude filters.
+        """
+        super().__init__(flush_interval_ms, "EndpointMetricCollector", otlp_emitter)
+        self.suppress_endpoint_summary = suppress_endpoint_summary
+
+        # Environment from config (None/empty when unset — omitted from emitted signals)
+        self.environment = environment
+
+        # Get service name from config or env var
+        self.service_name = service_name or os.getenv("OTEL_SERVICE_NAME", "UnknownService")
+
+        self.sdk_version = sdk_version
+        self.git_commit_sha = os.getenv("OTEL_AWS_SERVICE_EVENTS_GIT_COMMIT_SHA")
+        self.deployment_id = os.getenv("OTEL_AWS_SERVICE_EVENTS_DEPLOYMENT_ID")
+        self.pid = os.getpid()
+        self.resource_attributes = resource_attributes or ResourceAttributes()
+        self.instance_id = get_instance_id()
+
+        # Enhance instance_id: prefer host.id from resource attributes (e.g., EC2 instance ID)
+        if self.resource_attributes.host_id:
+            self.instance_id = self.resource_attributes.host_id
+
+        # Aggregations: operation -> metrics
+        # Structure: {operation: {route, method, count, sketch, error_breakdown}}
+        self._aggregations: Dict[str, Dict] = {}
+        self._aggregations_lock = threading.Lock()
+
+    def _reset_for_fork(self):
+        """Reset collector state after fork.
+
+        The child inherits the parent's accumulated aggregations; left in place the child
+        would re-emit the parent's metrics, double-counting. The aggregations lock may also
+        have been held by a parent daemon thread at fork time (those threads do not survive
+        fork), so it is recreated to avoid an unreleasable-lock deadlock. Safe to mutate
+        without holding the old lock: os.register_at_fork's after_in_child hook runs
+        single-threaded in the child.
+        """
+        super()._reset_for_fork()
+        self.pid = os.getpid()
+        self._aggregations = {}
+        self._aggregations_lock = threading.Lock()
+
+    def record_request(
+        self,
+        route: str,
+        method: str,
+        status_code: int,
+        duration_ns: int,
+        error_info: Optional[Dict] = None,
+    ):
+        """
+        Record an HTTP request with optional error information.
+
+        Args:
+            route: Route pattern (e.g., "/users/<id>")
+            method: HTTP method (e.g., "GET")
+            status_code: HTTP status code (e.g., 200, 500)
+            duration_ns: Request duration in nanoseconds
+            error_info: Optional dict with {error_type, function_name} for errors
+        """
+        # Generate operation key (method + route)
+        operation = f"{method} {route}"
+
+        with self._aggregations_lock:
+            if operation not in self._aggregations:
+                self._aggregations[operation] = {
+                    "route": route,
+                    "method": method,
+                    "count": 0,
+                    "faults": 0,
+                    "errors": 0,
+                    "sum_duration": 0,
+                    "seh_histogram": SEHHistogram(max_buckets=100),
+                    "error_breakdown": defaultdict(
+                        lambda: defaultdict(lambda: {"error_type": "", "function_name": "", "count": 0})
+                    ),
+                    "incidents_exemplar": [],
+                }
+
+            agg = self._aggregations[operation]
+            agg["count"] += 1
+            agg["sum_duration"] += duration_ns
+            agg["seh_histogram"].record(float(duration_ns))
+
+            # Track faults (5xx) and errors (4xx)
+            if status_code >= 500:
+                agg["faults"] += 1
+            elif status_code >= 400:
+                agg["errors"] += 1
+
+            # Track error_breakdown if error occurred
+            if status_code >= 400 and error_info:
+                error_type = error_info.get("error_type", "UnknownError")
+                function_name = error_info.get("function_name", "unknown")
+
+                # Create unique key for this error pattern
+                error_key = f"{error_type}:{function_name}"
+                failure_type = str(status_code)
+
+                # Initialize or increment error count
+                if agg["error_breakdown"][failure_type][error_key]["count"] == 0:
+                    # First time seeing this error pattern
+                    agg["error_breakdown"][failure_type][error_key]["error_type"] = error_type
+                    agg["error_breakdown"][failure_type][error_key]["function_name"] = function_name
+
+                agg["error_breakdown"][failure_type][error_key]["count"] += 1
+
+    def record_incident_exemplar(self, operation: str, exemplar: Dict):
+        """
+        Record an incident exemplar for an endpoint.
+
+        Called from framework hooks when an incident snapshot is created,
+        linking the incident to the endpoint's aggregation window.
+
+        Args:
+            operation: Operation string (e.g., "GET /api/users")
+            exemplar: Dict with snapshot_id, trigger_type, severity, timestamp
+        """
+        with self._aggregations_lock:
+            if operation in self._aggregations:
+                self._aggregations[operation]["incidents_exemplar"].append(exemplar)
+            else:
+                logger.debug("No aggregation entry for operation %s, skipping exemplar", operation)
+
+    def collect(self):
+        """Collect aggregated endpoint metrics and emit them via the OTLP emitter."""
+        # Get and swap aggregations (atomically retrieves and clears)
+        aggregations = self._get_and_swap_aggregations()
+
+        if not aggregations:
+            logger.debug("No endpoint metrics to export")
+            return
+
+        if not self.otlp_emitter:
+            return
+
+        # Format and export
+        endpoint_events = self._format_endpoint_metrics(aggregations)
+
+        if endpoint_events:
+            for event in endpoint_events:
+                # Suppress EndpointSummary when Application Signals is enabled —
+                # App Signals emits equivalent per-endpoint duration + error metrics,
+                # so emitting both would duplicate data on the backend. Error metrics
+                # (EndpointErrorMetric) carry ServiceEvents-specific per-exception-type
+                # breakdown that App Signals doesn't, so those still emit.
+                if not self.suppress_endpoint_summary:
+                    self.otlp_emitter.emit_endpoint_summary(event)
+                error_metrics = event.to_error_type_metrics()
+                if error_metrics:
+                    self.otlp_emitter.emit_endpoint_error_metrics(error_metrics)
+            logger.info("Exported %d endpoint metrics", len(endpoint_events))
+
+    def _get_and_swap_aggregations(self) -> Dict:
+        """
+        Atomically get current aggregations and replace with empty dict.
+
+        Returns:
+            Current aggregations dictionary
+        """
+        with self._aggregations_lock:
+            aggregations = self._aggregations
+            self._aggregations = {}
+            return aggregations
+
+    # pylint: disable-next=too-many-locals
+    def _format_endpoint_metrics(self, aggregations: Dict) -> List[EndpointMetricEvent]:
+        """
+        Format aggregation data into EndpointMetricEvent objects.
+
+        Args:
+            aggregations: Dictionary of operation -> aggregation data
+
+        Returns:
+            List of EndpointMetricEvent objects
+        """
+        events = []
+        timestamp = datetime.now(timezone.utc).isoformat()
+
+        for operation, agg in aggregations.items():
+            count = agg.get("count", 0)
+            if count == 0:
+                continue
+
+            # Convert error_breakdown nested dict to list of ErrorBreakdownEntry
+            error_breakdown_list = []
+            for failure_type, error_dict in agg["error_breakdown"].items():
+                for _error_key, error_data in error_dict.items():
+                    if error_data["count"] > 0:
+                        error_breakdown_list.append(
+                            ErrorBreakdownEntry(
+                                errors=[
+                                    ErrorDetail(
+                                        error_type=error_data["error_type"], function_name=error_data["function_name"]
+                                    )
+                                ],
+                                count=error_data["count"],
+                                failure_type=failure_type,
+                            )
+                        )
+
+            # Convert SEH histogram to duration metrics
+            duration_metrics = self._convert_to_emf_histogram(
+                agg.get("seh_histogram"), agg.get("sum_duration", 0), count
+            )
+
+            # Convert raw exemplar dicts to IncidentExemplar objects
+            raw_exemplars = agg.get("incidents_exemplar", [])
+            exemplar_objects = [
+                IncidentExemplar(
+                    snapshot_id=ex["snapshot_id"],
+                    trigger_type=ex["trigger_type"],
+                    severity=ex["severity"],
+                    timestamp=ex["timestamp"],
+                )
+                for ex in raw_exemplars
+            ]
+
+            # Create EndpointMetricEvent object
+            event = EndpointMetricEvent(
+                environment=self.environment,
+                service_name=self.service_name,
+                sdk_version=self.sdk_version,
+                instance_id=self.instance_id,
+                operation=operation,
+                method=agg.get("method"),
+                route=agg.get("route"),
+                pid=self.pid,
+                timestamp=timestamp,
+                count=count,
+                git_commit_sha=self.git_commit_sha,
+                deployment_id=self.deployment_id,
+                faults=agg.get("faults", 0),
+                errors=agg.get("errors", 0),
+                incident_count=len(exemplar_objects),
+                error_breakdown=error_breakdown_list,
+                incidents_exemplar=exemplar_objects,
+                duration=duration_metrics,
+                resource_attributes=self.resource_attributes,
+            )
+
+            events.append(event)
+
+        return events
+
+    @staticmethod
+    def _convert_to_emf_histogram(seh_histogram, sum_duration: int, count: int) -> DurationMetrics:
+        """
+        Convert SEH histogram to EMF histogram format.
+
+        Args:
+            seh_histogram: SEHHistogram object containing aggregated durations
+            sum_duration: Sum of all durations in nanoseconds (converted to microseconds)
+            count: Total number of invocations
+
+        Returns:
+            DurationMetrics object with EMF histogram data (values in microseconds)
+        """
+        if not seh_histogram or seh_histogram.is_empty():
+            return DurationMetrics(
+                values=[],
+                counts=[],
+                max=0,
+                min=0,
+                count=0,
+                sum=0,
+            )
+
+        # Get aggregated buckets from SEH histogram
+        values, counts_list = seh_histogram.get_values_and_counts()
+        stats = seh_histogram.get_statistics()
+
+        # Convert from nanoseconds to microseconds
+        values_us = [v / 1000.0 for v in values]
+        max_us = stats["max"] / 1000.0
+        min_us = stats["min"] / 1000.0
+        sum_us = sum_duration / 1000.0
+
+        return DurationMetrics(
+            values=values_us,
+            counts=counts_list,
+            max=max_us,
+            min=min_us,
+            count=count,
+            sum=sum_us,
+        )

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/collectors/incident_snapshot_collector.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/collectors/incident_snapshot_collector.py
@@ -67,7 +67,7 @@ class IncidentSnapshotCollector(BaseCollector):
         max_per_period: int,
         environment: Optional[str] = None,
         service_name: Optional[str] = None,
-        sdk_version: str = "0.14.2",
+        sdk_version: str = "",
         capture_request_body: bool = False,
         max_same_error: int = 1,
         resource_attributes: Optional[ResourceAttributes] = None,
@@ -784,7 +784,12 @@ class IncidentSnapshotCollector(BaseCollector):
             error_function_name = exc_data.get("function_name")
             call_path = self._build_call_path(inv_data, error_function_name)
             traceback_info = exc_data.get("traceback_info")
-            if traceback_info:
+            if isinstance(traceback_info, str):
+                # The monitor formats the traceback to a string eagerly (so it does not pin the
+                # frame chain alive in the ContextVar); use it as-is.
+                stack_trace = traceback_info
+            elif traceback_info:
+                # Backward-compatible path: an (exc_type, exc_value, exc_traceback) tuple.
                 try:
                     stack_trace = "".join(traceback.format_exception(*traceback_info))
                 except Exception:  # pylint: disable=broad-exception-caught  # telemetry must never crash host app

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/collectors/incident_snapshot_collector.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/collectors/incident_snapshot_collector.py
@@ -1,0 +1,1021 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+IncidentSnapshotCollector - Triggers and collects deep incident snapshots.
+
+Incident snapshots are triggered when:
+- HTTP status code >= 500 or unhandled exception -> trigger_type: "exception"
+- Request duration > threshold (slow requests) -> trigger_type: "latency"
+
+Latency thresholds can be configured per-endpoint for fine-grained control.
+Rate limiting and deduplication prevent snapshot spam.
+"""
+
+import fnmatch
+import hashlib
+import logging
+import os
+import re
+import sys
+import threading
+import time
+import traceback
+import uuid
+from collections import deque
+from typing import Dict, List, Optional, Pattern, Set, Tuple
+
+from amazon.opentelemetry.distro.serviceevents.ast_transformation import get_function_info
+from amazon.opentelemetry.distro.serviceevents.collectors.base_collector import BaseCollector
+from amazon.opentelemetry.distro.serviceevents.models import (
+    CallPathEntry,
+    ExceptionInfo,
+    IncidentSnapshot,
+    RequestContext,
+    ResourceAttributes,
+    TelemetryCorrelation,
+)
+from amazon.opentelemetry.distro.serviceevents.python_monitor import (
+    _ServiceEventsMonitorState,
+    mark_operation_hot,
+    tick_hot_operations,
+)
+from amazon.opentelemetry.distro.serviceevents.utils import get_instance_id
+from opentelemetry import trace
+
+logger = logging.getLogger(__name__)
+
+# too-many-lines: this collector owns the full incident pipeline (trigger detection,
+# per-endpoint latency thresholds, dedup + rate limiting, fork-safe state reset, trace
+# correlation, and snapshot assembly). Splitting it would scatter tightly-coupled state
+# across modules for no readability gain; the content is all live.
+# pylint: disable=too-many-lines
+
+
+class IncidentSnapshotCollector(BaseCollector):
+    """
+    Collector for incident snapshot events.
+
+    Triggers snapshots based on errors or latency thresholds,
+    applies rate limiting and deduplication, and collects detailed context.
+    """
+
+    def __init__(
+        self,
+        flush_interval_ms: int,
+        duration_threshold_ms: int,
+        max_per_period: int,
+        environment: Optional[str] = None,
+        service_name: Optional[str] = None,
+        sdk_version: str = "0.14.2",
+        capture_request_body: bool = False,
+        max_same_error: int = 1,
+        resource_attributes: Optional[ResourceAttributes] = None,
+        otlp_emitter=None,
+    ):
+        """
+        Initialize the incident snapshot collector.
+
+        Args:
+            flush_interval_ms: How often to collect and export data (milliseconds)
+            duration_threshold_ms: Default duration threshold for triggering (milliseconds)
+            max_per_period: Maximum snapshots per rate-limit window (window fixed at 60s)
+            environment: Deployment environment
+            service_name: Service name
+            sdk_version: SDK version
+            capture_request_body: Whether to capture request body on incidents
+            max_same_error: Maximum occurrences of same error pattern
+            resource_attributes: AWS platform resource attributes from OTel Resource detectors
+            otlp_emitter: Optional ServiceEventsOtlpEmitter for OTLP export
+        """
+        super().__init__(flush_interval_ms, "IncidentSnapshotCollector", otlp_emitter)
+
+        # Default latency threshold (used when no per-endpoint threshold is set)
+        self.default_latency_threshold_ms = duration_threshold_ms
+        # Per-operation latency thresholds: operation -> threshold_ms (for exact matches)
+        self._latency_thresholds: Dict[str, float] = {}
+        self._latency_thresholds_lock = threading.Lock()
+        # Pattern-based latency thresholds: list of (compiled_regex, threshold_ms, original_pattern) tuples
+        # Supports glob patterns like "* /server_request:50" or "GET /api/*:100"
+        # Patterns are pre-compiled to regex at startup for faster per-request matching
+        self._latency_threshold_patterns: List[Tuple[Pattern, float, str]] = []
+        self._latency_patterns_lock = threading.Lock()
+        # `max_per_period` is the max snapshots allowed per rate-limit window. The window
+        # length is now fixed at 60 seconds (no longer configurable); the field/param name
+        # is kept as-is to avoid churning callers and tests.
+        self.max_per_period = max_per_period
+        self.period_seconds = 60
+
+        # Environment and service metadata. None/empty when unset — omitted from the
+        # snapshot rather than emitted as a sentinel.
+        self.environment = environment
+        self.service_name = service_name or os.getenv("OTEL_SERVICE_NAME", "UnknownService")
+        self.sdk_version = sdk_version
+        self.git_commit_sha = os.getenv("OTEL_AWS_SERVICE_EVENTS_GIT_COMMIT_SHA")
+        self.deployment_id = os.getenv("OTEL_AWS_SERVICE_EVENTS_DEPLOYMENT_ID")
+        self.pid = os.getpid()
+        self.resource_attributes = resource_attributes or ResourceAttributes()
+        self.instance_id = get_instance_id()
+
+        # Enhance instance_id: prefer host.id from resource attributes (e.g., EC2 instance ID)
+        if self.resource_attributes.host_id:
+            self.instance_id = self.resource_attributes.host_id
+
+        # Request payload capture settings
+        self.capture_request_body = capture_request_body
+
+        # Rate limiting: track snapshot timestamps
+        self._snapshot_timestamps: deque = deque(maxlen=max_per_period * 2)
+        self._timestamps_lock = threading.Lock()
+
+        # Period-level deduplication: track error hashes with TTL (limits same error over the fixed 60s window)
+        self._error_hashes: Dict[str, List[float]] = {}  # hash -> [timestamp1, timestamp2, ...]
+        self._error_hashes_lock = threading.Lock()
+        self._max_same_error = max_same_error
+
+        # Batch-level deduplication: one snapshot per error type per collection interval
+        # Cleared after each collect() call
+        self._current_batch_hashes: Set[str] = set()
+
+        # Pending snapshots to export
+        self._pending_snapshots: List[IncidentSnapshot] = []
+        self._pending_lock = threading.Lock()
+
+        # Monitor state for getting execution flow
+        self._monitor_state = _ServiceEventsMonitorState.get_instance()
+
+    def update_incident_config(
+        self,
+        capture_request_body: bool,
+        max_per_period: int,
+        max_same_error: int,
+    ) -> None:
+        """Live-update incident config (max-per-window, max-same-error, capture flag).
+
+        Recreates the snapshot_timestamps deque when max_per_period changes
+        since deque maxlen is immutable after construction. The rate-limit window
+        stays fixed at 60s and is not adjustable here.
+
+        NOTE: no longer watcher-driven — the DI watcher syncer was removed. Retained as
+        a public live-setter for callers that mutate the collector directly.
+        """
+        self.capture_request_body = capture_request_body
+        self._max_same_error = max_same_error
+        if max_per_period != self.max_per_period:
+            self.max_per_period = max_per_period
+            with self._timestamps_lock:
+                old = list(self._snapshot_timestamps)
+                self._snapshot_timestamps = deque(old, maxlen=max_per_period * 2)
+
+    def _reset_for_fork(self):
+        """Reset collector state after fork.
+
+        The child inherits the parent's pending snapshots and dedup/rate-limit bookkeeping.
+        Left in place the child would re-emit the parent's pending snapshots (double export)
+        and start life with stale rate-limit/dedup windows that suppress its own early
+        incidents. Locks are recreated because a parent daemon thread may have held one at
+        fork time (those threads do not survive fork), which would otherwise deadlock the
+        child. Safe to mutate without holding the old locks: os.register_at_fork's
+        after_in_child hook runs single-threaded in the child.
+
+        Latency thresholds (exact + pattern) are deliberately preserved — they are
+        configuration, not per-request state, and the child needs the same triggers.
+        """
+        super()._reset_for_fork()
+        self.pid = os.getpid()
+        self._pending_snapshots = []
+        self._pending_lock = threading.Lock()
+        self._snapshot_timestamps = deque(maxlen=self.max_per_period * 2)
+        self._timestamps_lock = threading.Lock()
+        self._error_hashes = {}
+        self._error_hashes_lock = threading.Lock()
+        self._current_batch_hashes = set()
+        self._latency_thresholds_lock = threading.Lock()
+        self._latency_patterns_lock = threading.Lock()
+
+    # Live-setter overrides below (set_latency_threshold*, update_incident_config) are no
+    # longer watcher-driven — the DI watcher syncer was removed. They remain as public
+    # methods for callers that configure the collector directly (e.g. at startup).
+
+    def set_latency_threshold(self, operation: str, threshold_ms: float) -> None:
+        """
+        Set latency threshold for a specific operation (exact match).
+
+        Args:
+            operation: Operation string (e.g., "GET /api/users")
+            threshold_ms: Latency threshold in milliseconds
+        """
+        with self._latency_thresholds_lock:
+            self._latency_thresholds[operation] = threshold_ms
+            logger.info("Set latency threshold for operation %s: %sms", operation, threshold_ms)
+
+    def set_latency_threshold_by_route(self, route: str, method: str, threshold_ms: float) -> str:
+        """
+        Set latency threshold for a specific route/method combination (exact match).
+
+        Args:
+            route: Route pattern (e.g., "/api/users")
+            method: HTTP method (e.g., "GET", "POST")
+            threshold_ms: Latency threshold in milliseconds
+
+        Returns:
+            The operation string that was configured
+        """
+        operation = f"{method} {route}"
+        self.set_latency_threshold(operation, threshold_ms)
+        return operation
+
+    def set_latency_threshold_patterns(self, patterns: List[Tuple[str, float]]) -> None:
+        """
+        Set latency threshold patterns with glob support.
+
+        Patterns are pre-compiled to regex at startup for faster per-request matching.
+        Patterns are matched in order - first match wins.
+
+        Args:
+            patterns: List of (pattern, threshold_ms) tuples.
+                      Pattern format: "METHOD /route" (e.g., "* /server_request", "GET /api/*")
+        """
+        compiled_patterns: List[Tuple[Pattern, float, str]] = []
+        for pattern, threshold_ms in patterns:
+            # Convert glob pattern to regex and compile for faster matching
+            regex = re.compile(fnmatch.translate(pattern))
+            compiled_patterns.append((regex, threshold_ms, pattern))
+            logger.info("Set latency threshold pattern '%s': %sms", pattern, threshold_ms)
+
+        with self._latency_patterns_lock:
+            self._latency_threshold_patterns = compiled_patterns
+
+    def get_latency_threshold(
+        self, operation: Optional[str] = None, route: Optional[str] = None, method: Optional[str] = None
+    ) -> float:
+        """
+        Get latency threshold for an endpoint.
+
+        Lookup order:
+        1. Pattern matching (if route and method provided) - first match wins
+        2. Exact operation match
+        3. Default threshold
+
+        Args:
+            operation: Operation string (e.g., "GET /api/users") for exact match
+            route: Route pattern (e.g., "/server_request") - for pattern matching
+            method: HTTP method (e.g., "GET") - for pattern matching
+
+        Returns:
+            Latency threshold in milliseconds
+        """
+        # Try pattern matching first (if route and method provided)
+        if route is not None and method is not None:
+            endpoint_str = f"{method.upper()} {route}"
+            with self._latency_patterns_lock:
+                for regex, threshold_ms, _ in self._latency_threshold_patterns:
+                    if regex.match(endpoint_str):
+                        return threshold_ms
+
+        # Fall back to exact operation match
+        if operation is not None:
+            with self._latency_thresholds_lock:
+                if operation in self._latency_thresholds:
+                    return self._latency_thresholds[operation]
+
+        return self.default_latency_threshold_ms
+
+    def get_all_latency_thresholds(self) -> Dict[str, float]:
+        """
+        Get all configured per-operation latency thresholds (exact matches).
+
+        Returns:
+            Dictionary of operation -> threshold_ms
+        """
+        with self._latency_thresholds_lock:
+            return dict(self._latency_thresholds)
+
+    def get_all_latency_threshold_patterns(self) -> List[Tuple[str, float]]:
+        """
+        Get all configured latency threshold patterns (original patterns, not compiled).
+
+        Returns:
+            List of (pattern, threshold_ms) tuples
+        """
+        with self._latency_patterns_lock:
+            # Return original patterns (third element of tuple), not compiled regex
+            return [(pattern, threshold_ms) for _, threshold_ms, pattern in self._latency_threshold_patterns]
+
+    def process_potential_incident(  # pylint: disable=too-many-locals
+        self,
+        route: str,
+        method: str,
+        status_code: int,
+        duration_ms: float,
+        exception: Optional[Exception],
+        request_data: Dict,
+    ) -> Optional[Dict]:
+        """
+        Process a potential incident snapshot trigger.
+
+        Args:
+            route: Route pattern
+            method: HTTP method
+            status_code: HTTP status code
+            duration_ms: Request duration
+            exception: Exception object if any
+            request_data: Request metadata (headers, args, etc.)
+
+        Returns:
+            Exemplar dict with snapshot_id, trigger_type, severity, operation,
+            and timestamp when a snapshot is created; None otherwise.
+        """
+        # Capture stack trace IMMEDIATELY while we're still in exception context
+        # sys.exc_info() only works inside an active exception handler
+        captured_stack_trace = None
+        if exception is not None:
+            exc_type, exc_value, exc_tb = sys.exc_info()
+            if exc_tb is not None:
+                captured_stack_trace = "".join(traceback.format_exception(exc_type, exc_value, exc_tb))
+            else:
+                # Fallback: try to format from exception object directly
+                captured_stack_trace = "".join(
+                    traceback.format_exception(type(exception), exception, exception.__traceback__)
+                )
+
+        # Compute operation for threshold lookup and exemplar
+        operation = f"{method} {route}"
+
+        # Check if snapshot should be triggered
+        # Pass route and method for pattern-based threshold matching, and operation for exact match
+        trigger_type = self._determine_trigger_type(status_code, duration_ms, exception, operation, route, method)
+        if trigger_type is None:
+            return None
+
+        # Mark operation hot for adaptive sampling BEFORE dedup checks.
+        # This ensures the hot state is refreshed on every error occurrence,
+        # not just when a snapshot passes dedup. Without this, the hot state
+        # expires after ~16.7 min while dedup blocks snapshots for up to 60 min,
+        # causing the next allowed snapshot to be partial again.
+        mark_operation_hot(operation)
+
+        # Generate error hash for deduplication
+        error_hash = self._generate_error_hash(route, exception)
+
+        # Check batch-level deduplication FIRST (one per error type per collection interval)
+        with self._error_hashes_lock:
+            if error_hash in self._current_batch_hashes:
+                logger.debug("Incident snapshot batch-deduplicated (hash: %s)", error_hash)
+                return None
+            # Add to current batch (will be cleared after collect())
+            self._current_batch_hashes.add(error_hash)
+
+        # Check period-level deduplication (limits same error over the fixed 60s window)
+        if not self._check_deduplication(error_hash):
+            logger.debug("Incident snapshot period-deduplicated (hash: %s)", error_hash)
+            return None
+
+        # Check rate limit AFTER dedup — only non-deduplicated requests consume slots.
+        # Previously this ran before dedup, causing phantom slot consumption:
+        # dedup-blocked requests incremented the counter without producing snapshots.
+        if not self._check_rate_limit():
+            logger.debug("Incident snapshot rate limit exceeded, skipping")
+            return None
+
+        # Collect incident snapshot data
+        try:
+            snapshot = self._collect_incident_snapshot(
+                route=route,
+                method=method,
+                status_code=status_code,
+                duration_ms=duration_ms,
+                exception=exception,
+                request_data=request_data,
+                trigger_type=trigger_type,
+                captured_stack_trace=captured_stack_trace,
+            )
+
+            # Add to pending snapshots
+            with self._pending_lock:
+                self._pending_snapshots.append(snapshot)
+
+            logger.info(
+                "Incident snapshot triggered: %s %s (status=%s, trigger=%s)",
+                route,
+                method,
+                status_code,
+                trigger_type,
+            )
+
+            # Return exemplar for endpoint telemetry correlation
+            return {
+                "snapshot_id": snapshot.snapshot_id,
+                "trigger_type": snapshot.trigger_type,
+                "severity": snapshot.severity,
+                "operation": operation,
+                "timestamp": snapshot.timestamp,
+            }
+
+        except Exception as exc:  # pylint: disable=broad-exception-caught  # telemetry must never crash host app
+            logger.error("Error collecting incident snapshot data: %s", exc, exc_info=True)
+            # Roll back the slots this attempt consumed. The batch/dedup/rate-limit slots
+            # are claimed before collection (claim-then-check is required for the
+            # concurrent-request race protection in _check_deduplication). If collection
+            # then fails, leaving them claimed would suppress a *later* identical error
+            # that could have produced a snapshot — for up to the 60s dedup/rate windows.
+            self._rollback_reservation(error_hash)
+            return None
+
+    def _rollback_reservation(self, error_hash: str) -> None:
+        """Undo the batch/period-dedup/rate-limit slots claimed for a failed collection.
+
+        Best-effort and guarded: this runs on an error path, so it must not raise. Removes
+        the batch hash, the most-recent period-dedup timestamp for this hash, and the
+        most-recent rate-limit timestamp — the three slots claimed earlier in
+        process_potential_incident for this attempt.
+        """
+        try:
+            with self._error_hashes_lock:
+                self._current_batch_hashes.discard(error_hash)
+                timestamps = self._error_hashes.get(error_hash)
+                if timestamps:
+                    timestamps.pop()  # drop the timestamp this attempt added
+                    if not timestamps:
+                        del self._error_hashes[error_hash]
+            with self._timestamps_lock:
+                if self._snapshot_timestamps:
+                    self._snapshot_timestamps.pop()  # drop the slot this attempt added
+        except Exception:  # pylint: disable=broad-exception-caught  # telemetry must never crash host app
+            logger.debug("Failed to roll back incident reservation", exc_info=True)
+
+    def collect(self):
+        """Collect pending snapshots and export to console."""
+        # Countdown hot operation cycles for adaptive sampling
+        tick_hot_operations()
+
+        # Clear batch-level hashes for new collection cycle
+        with self._error_hashes_lock:
+            self._current_batch_hashes.clear()
+
+        # Get pending snapshots
+        with self._pending_lock:
+            snapshots = self._pending_snapshots
+            self._pending_snapshots = []
+
+        if not snapshots:
+            logger.debug("No incident snapshots to export")
+            return
+
+        if not self.otlp_emitter:
+            return
+
+        for snapshot in snapshots:
+            self.otlp_emitter.emit_incident_snapshot(snapshot.to_dict())
+        logger.info("Exported %d incident snapshots", len(snapshots))
+
+    def _determine_trigger_type(
+        self,
+        status_code: int,
+        duration_ms: float,
+        exception: Optional[Exception],
+        operation: Optional[str] = None,
+        route: Optional[str] = None,
+        method: Optional[str] = None,
+    ) -> Optional[str]:
+        """
+        Determine trigger type for incident snapshot.
+
+        Args:
+            status_code: HTTP status code
+            duration_ms: Request duration
+            exception: Exception object if any
+            operation: Operation string for per-operation latency threshold lookup
+            route: Route pattern for pattern-based threshold matching
+            method: HTTP method for pattern-based threshold matching
+
+        Returns:
+            Trigger type string or None if no trigger
+            - "exception": Server error (status >= 500 or unhandled exception)
+            - "latency": Request duration exceeded threshold
+        """
+        # Priority order: exception > latency
+        if exception is not None:
+            return "exception"
+
+        if status_code >= 500:
+            return "exception"
+
+        # Get latency threshold (pattern matching first, then operation, then default)
+        latency_threshold = self.get_latency_threshold(operation, route, method)
+        if duration_ms > latency_threshold:
+            return "latency"
+
+        return None
+
+    @staticmethod
+    def _determine_severity(status_code: int, trigger_type: str) -> str:
+        """
+        Determine severity level based on status code and trigger type.
+
+        Args:
+            status_code: HTTP status code
+            trigger_type: Trigger type
+
+        Returns:
+            Severity level: "critical", "high", "medium", "low"
+        """
+        # Critical: 500-503 (server errors)
+        if 500 <= status_code <= 503:
+            return "critical"
+
+        # High: 504+ (timeouts), exceptions
+        if status_code >= 504 or trigger_type == "exception":
+            return "high"
+
+        # Medium: latency trigger (slow requests)
+        if trigger_type == "latency":
+            return "medium"
+
+        return "low"
+
+    def _check_rate_limit(self) -> bool:
+        """
+        Check if rate limit allows new snapshot.
+
+        Returns:
+            True if snapshot allowed, False if rate limited
+        """
+        current_time = time.time()
+        cutoff_time = current_time - self.period_seconds
+
+        with self._timestamps_lock:
+            # Remove old timestamps outside the window
+            while self._snapshot_timestamps and self._snapshot_timestamps[0] < cutoff_time:
+                self._snapshot_timestamps.popleft()
+
+            # Check if we're at the limit
+            if len(self._snapshot_timestamps) >= self.max_per_period:
+                return False
+
+            # Add current timestamp
+            self._snapshot_timestamps.append(current_time)
+            return True
+
+    @staticmethod
+    def _generate_error_hash(route: str, exception: Optional[Exception]) -> str:
+        """
+        Generate hash for error deduplication.
+
+        Args:
+            route: Route pattern
+            exception: Exception object
+
+        Returns:
+            Hash string
+        """
+        if exception is None:
+            # For non-exception incidents (slow requests), use route only
+            hash_input = f"route:{route}"
+        else:
+            # Include exception type and message
+            exc_type = type(exception).__name__
+            exc_message = str(exception)
+            hash_input = f"route:{route}|exc:{exc_type}:{exc_message}"
+
+        return hashlib.md5(hash_input.encode("utf-8")).hexdigest()
+
+    def _check_deduplication(self, error_hash: str) -> bool:
+        """
+        Check if error should be deduplicated.
+
+        Uses atomic add-then-check to handle concurrent requests correctly.
+
+        Args:
+            error_hash: Error hash
+
+        Returns:
+            True if snapshot allowed, False if deduplicated
+        """
+        current_time = time.time()
+        cutoff_time = current_time - self.period_seconds
+
+        with self._error_hashes_lock:
+            # Clean up old hashes
+            for hash_key in list(self._error_hashes.keys()):
+                timestamps = self._error_hashes[hash_key]
+                # Remove old timestamps
+                timestamps = [ts for ts in timestamps if ts >= cutoff_time]
+                if timestamps:
+                    self._error_hashes[hash_key] = timestamps
+                else:
+                    del self._error_hashes[hash_key]
+
+            # Add timestamp FIRST (atomic add-then-check pattern)
+            # This prevents race conditions where concurrent requests both pass the check
+            if error_hash in self._error_hashes:
+                self._error_hashes[error_hash].append(current_time)
+            else:
+                self._error_hashes[error_hash] = [current_time]
+
+            # Now check if we've exceeded the limit (use > because we already added)
+            if len(self._error_hashes[error_hash]) > self._max_same_error:
+                return False  # Deduplicate
+
+            return True
+
+    def _collect_incident_snapshot(  # pylint: disable=too-many-locals
+        self,
+        route: str,
+        method: str,
+        status_code: int,
+        duration_ms: float,
+        exception: Optional[Exception],
+        request_data: Dict,
+        trigger_type: str,
+        captured_stack_trace: Optional[str] = None,
+    ) -> IncidentSnapshot:
+        """
+        Collect detailed incident snapshot data.
+
+        Args:
+            route: Route pattern
+            method: HTTP method
+            status_code: HTTP status code
+            duration_ms: Request duration
+            exception: Exception object
+            request_data: Request metadata
+            trigger_type: Trigger type
+            captured_stack_trace: Pre-captured stack trace (captured at exception time)
+
+        Returns:
+            IncidentSnapshot object
+        """
+        # Generate snapshot ID
+        snapshot_id = f"snap_{uuid.uuid4()}"
+
+        # Determine severity
+        severity = self._determine_severity(status_code, trigger_type)
+
+        # Compute operation string
+        operation = f"{method} {route}"
+
+        # Collect exception info (pass pre-captured stack trace)
+        exception_info = self._collect_exception_info(exception, captured_stack_trace)
+
+        # Detect if call_path timing data is missing (first incident, sampling was off)
+        is_partial = (
+            any(entry.duration_ns == 0 for exc in exception_info for entry in exc.call_path)
+            if exception_info
+            else False
+        )
+
+        # Lazy request body capture (only if config allows)
+        request_body = None
+        if self.capture_request_body:
+            # Try Flask request object first (lazy loading)
+            flask_request = request_data.get("flask_request")
+            if flask_request is not None:
+                # Lazy import: defer optional Flask instrumentation dependency until
+                # a Flask request is actually present.
+                # pylint: disable=import-outside-toplevel
+                from amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation import (
+                    _get_request_body,
+                )
+
+                request_body = _get_request_body(flask_request)
+            else:
+                # Try cached_body (pre-read by FastAPI middleware)
+                request_body = request_data.get("cached_body")
+
+        # Build request context — payload fields gated by capture_request_body flag
+        request_context = RequestContext(
+            type="http",
+            timestamp=int(time.time() * 1000),
+            status_code=status_code,
+            custom_context=self._extract_custom_context(request_data) if self.capture_request_body else {},
+            request_body=request_body,
+            query_params=request_data.get("args") if self.capture_request_body else None,
+            path_params=request_data.get("view_args") if self.capture_request_body else None,
+            request_headers=(
+                dict(request_data.get("headers")) if self.capture_request_body and request_data.get("headers") else None
+            ),
+        )
+
+        # Build telemetry correlation
+        telemetry_correlation = TelemetryCorrelation(
+            trace_id=self._extract_trace_id(request_data),
+            session_id=self._generate_session_id(request_data),
+            span_id=self._extract_span_id(request_data),
+            request_id=self._generate_request_id(),
+        )
+
+        # Create IncidentSnapshot. Trace correlation (trace_id/span_id) is carried on
+        # the emitted LogRecord so the backend can join it to the request's spans.
+        snapshot = IncidentSnapshot(
+            snapshot_id=snapshot_id,
+            timestamp=int(time.time() * 1000),
+            severity=severity,
+            trigger_type=trigger_type,
+            service=self.service_name,
+            environment=self.environment,
+            instance_id=self.instance_id,
+            operation=operation,
+            sdk_version=self.sdk_version,
+            pid=self.pid,
+            duration_ms=duration_ms,
+            exception_info=exception_info,
+            request_context=request_context,
+            telemetry_correlation=telemetry_correlation,
+            git_commit_sha=self.git_commit_sha,
+            deployment_id=self.deployment_id,
+            is_partial=is_partial,
+            resource_attributes=self.resource_attributes,
+        )
+
+        return snapshot
+
+    def _collect_exception_info(
+        self,
+        exception: Optional[Exception],
+        captured_stack_trace: Optional[str] = None,
+    ) -> List[ExceptionInfo]:
+        """
+        Collect exception information with call path.
+
+        Args:
+            exception: Exception object
+            captured_stack_trace: Pre-captured stack trace (captured at exception time)
+
+        Returns:
+            List of ExceptionInfo objects
+        """
+        # Get investigation data from monitor state (contains call_path and possibly exception)
+        inv_data = self._monitor_state.get_investigation_data()
+
+        # If no explicit exception, check if the per-function monitor captured one
+        if exception is None:
+            if not inv_data or "exception" not in inv_data:
+                # For latency incidents: return call_path even without exception
+                # This allows latency snapshots to show which functions took time
+                call_path = self._build_call_path(inv_data, None)
+                if call_path:
+                    return [
+                        ExceptionInfo(
+                            exception_type="",
+                            exception_message="",
+                            stack_trace="",
+                            call_path=call_path,
+                        )
+                    ]
+                return []
+            # Use exception details captured by per-function monitor
+            exc_data = inv_data["exception"]
+            # Check if exc_data is valid (not None)
+            if exc_data is None:
+                # For latency incidents: return call_path even without exception
+                call_path = self._build_call_path(inv_data, None)
+                if call_path:
+                    return [
+                        ExceptionInfo(
+                            exception_type="",
+                            exception_message="",
+                            stack_trace="",
+                            call_path=call_path,
+                        )
+                    ]
+                return []
+            # Get the function_name that threw the exception (if captured)
+            error_function_name = exc_data.get("function_name")
+            call_path = self._build_call_path(inv_data, error_function_name)
+            traceback_info = exc_data.get("traceback_info")
+            if traceback_info:
+                try:
+                    stack_trace = "".join(traceback.format_exception(*traceback_info))
+                except Exception:  # pylint: disable=broad-exception-caught  # telemetry must never crash host app
+                    stack_trace = f"{exc_data.get('name', 'Unknown')}: {exc_data.get('message', '')}"
+            else:
+                stack_trace = "".join(exc_data.get("traceback", []))
+            exception_info = ExceptionInfo(
+                exception_type=exc_data.get("name", "Unknown"),
+                exception_message=exc_data.get("message", ""),
+                stack_trace=stack_trace,
+                call_path=call_path,
+            )
+            return [exception_info]
+
+        # Get the function_name that threw the exception from investigation data
+        error_function_name = None
+        if inv_data and inv_data.get("exception"):
+            error_function_name = inv_data["exception"].get("function_name")
+
+        # Build call_path entries with error marking
+        call_path = self._build_call_path(inv_data, error_function_name)
+
+        # Use pre-captured stack trace if available, otherwise fall back to str(exception)
+        # Note: captured_stack_trace should be captured in process_potential_incident()
+        # while still in the exception handler context
+        stack_trace = captured_stack_trace if captured_stack_trace else str(exception)
+
+        exception_info = ExceptionInfo(
+            exception_type=type(exception).__name__,
+            exception_message=str(exception),
+            stack_trace=stack_trace,
+            call_path=call_path,
+        )
+
+        return [exception_info]
+
+    @staticmethod
+    def _build_call_path(
+        inv_data: Optional[dict],
+        error_function_name: Optional[str] = None,
+    ) -> List[CallPathEntry]:
+        """Build call path entries from investigation data.
+
+        Args:
+            inv_data: Investigation data containing call_path
+            error_function_name: Function name that threw the exception (to mark with error=True)
+
+        Returns:
+            List of CallPathEntry objects with error flag set appropriately
+        """
+        call_path = []
+        if inv_data and "call_path" in inv_data:
+            for entry in inv_data["call_path"]:
+                if isinstance(entry, dict):
+                    func_name = entry["function_name"]
+                    func_info = get_function_info(func_name)
+                    is_async = func_info.get("is_async", False) if func_info else False
+                    call_path.append(
+                        CallPathEntry(
+                            function_name=func_name,
+                            caller_function_name=entry["caller_function_name"],
+                            duration_ns=entry["duration_ns"],
+                            error=(func_name == error_function_name) if error_function_name else False,
+                            is_async=is_async,
+                        )
+                    )
+                else:
+                    caller, callee = entry
+                    func_info = get_function_info(callee)
+                    is_async = func_info.get("is_async", False) if func_info else False
+                    call_path.append(
+                        CallPathEntry(
+                            function_name=callee,
+                            caller_function_name=caller,
+                            duration_ns=0,
+                            error=(callee == error_function_name) if error_function_name else False,
+                            is_async=is_async,
+                        )
+                    )
+        return call_path
+
+    @staticmethod
+    def _extract_custom_context(request_data: Dict) -> Dict[str, str]:
+        """
+        Extract custom context from request data (e.g., user_id).
+
+        Args:
+            request_data: Request metadata
+
+        Returns:
+            Custom context dictionary
+        """
+        custom_context = {}
+
+        # Extract user_id from query args if present
+        args = request_data.get("args", {})
+        if "user_id" in args:
+            custom_context["user_id"] = str(args["user_id"])
+
+        # Could extract other business context here
+        # e.g., session_id, tenant_id, etc.
+
+        return custom_context
+
+    @staticmethod
+    def _format_trace_id(trace_id) -> Optional[str]:
+        """Format a trace ID as a 0x-prefixed 32-char hex string."""
+        if trace_id is None:
+            return None
+        if isinstance(trace_id, int):
+            return f"0x{trace_id:032x}"
+        return str(trace_id)
+
+    @staticmethod
+    def _format_span_id(span_id) -> Optional[str]:
+        """Format a span ID as a 0x-prefixed 16-char hex string."""
+        if span_id is None:
+            return None
+        if isinstance(span_id, int):
+            return f"0x{span_id:016x}"
+        return str(span_id)
+
+    @staticmethod
+    def _valid_traceparent_id(raw: str, length: int) -> Optional[str]:
+        """Validate a hex id field from an inbound W3C traceparent header.
+
+        The traceparent header is attacker-controllable, so the trace/span id fields
+        are validated before being copied into the snapshot's correlation: they must be
+        exactly `length` hex chars and not the all-zero sentinel (invalid per the W3C
+        trace-context spec). Returns the lowercased hex (no 0x prefix) or None.
+        """
+        if not raw or len(raw) != length:
+            return None
+        lowered = raw.lower()
+        if any(c not in "0123456789abcdef" for c in lowered):
+            return None
+        if lowered == "0" * length:
+            return None
+        return lowered
+
+    def _extract_trace_id(self, request_data: Dict) -> Optional[str]:
+        """Extract trace ID from pre-captured value, OTel context, or request headers."""
+        # FIRST: Check for pre-captured trace_id (from Flask/FastAPI instrumentation)
+        # This is most reliable because it was captured while the span was still active
+        pre_captured = request_data.get("trace_id")
+        if pre_captured:
+            return self._format_trace_id(pre_captured)
+
+        # SECOND: Try to get from current OTel span (may not work in teardown hooks)
+        try:
+            current_span = trace.get_current_span()
+            if current_span:
+                span_context = current_span.get_span_context()
+                if span_context.is_valid:
+                    return self._format_trace_id(span_context.trace_id)
+        except Exception:  # pylint: disable=broad-exception-caught  # telemetry must never crash host app
+            pass
+
+        # FALLBACK: Try request headers (for distributed tracing)
+        headers = request_data.get("headers", {})
+
+        # Try OpenTelemetry traceparent
+        traceparent = headers.get("traceparent")
+        if traceparent:
+            # Extract trace-id from traceparent (format: 00-trace_id-span_id-flags).
+            # The header is untrusted input; validate the 32-char hex trace-id before use.
+            parts = traceparent.split("-")
+            if len(parts) >= 2:
+                trace_id_hex = self._valid_traceparent_id(parts[1], 32)
+                if trace_id_hex:
+                    return f"0x{trace_id_hex}"
+
+        # Try X-Ray trace ID
+        xray_trace = headers.get("X-Amzn-Trace-Id")
+        if xray_trace:
+            return xray_trace
+
+        # Try Datadog
+        dd_trace_id = headers.get("x-datadog-trace-id")
+        if dd_trace_id:
+            return dd_trace_id
+
+        return None
+
+    def _extract_span_id(self, request_data: Dict) -> Optional[str]:
+        """Extract span ID from pre-captured value, OTel context, or request headers."""
+        # FIRST: Check for pre-captured span_id (from Flask/FastAPI instrumentation)
+        # This is most reliable because it was captured while the span was still active
+        pre_captured = request_data.get("span_id")
+        if pre_captured:
+            return self._format_span_id(pre_captured)
+
+        # SECOND: Try to get from current OTel span (may not work in teardown hooks)
+        try:
+            current_span = trace.get_current_span()
+            if current_span:
+                span_context = current_span.get_span_context()
+                if span_context.is_valid:
+                    return self._format_span_id(span_context.span_id)
+        except Exception:  # pylint: disable=broad-exception-caught  # telemetry must never crash host app
+            pass
+
+        # FALLBACK: Try request headers (for distributed tracing)
+        headers = request_data.get("headers", {})
+
+        # OpenTelemetry traceparent
+        traceparent = headers.get("traceparent")
+        if traceparent:
+            # Extract span-id from traceparent (format: 00-trace_id-span_id-flags).
+            # The header is untrusted input; validate the 16-char hex span-id before use.
+            parts = traceparent.split("-")
+            if len(parts) >= 3:
+                span_id_hex = self._valid_traceparent_id(parts[2], 16)
+                if span_id_hex:
+                    return f"0x{span_id_hex}"
+
+        return None
+
+    @staticmethod
+    def _generate_session_id(request_data: Dict) -> Optional[str]:
+        """Generate session ID from request data."""
+        args = request_data.get("args", {})
+        user_id = args.get("user_id")
+
+        if user_id:
+            timestamp = time.strftime("%Y%m%d_%H%M%S")
+            return f"session_{user_id}_{timestamp}"
+
+        return None
+
+    @staticmethod
+    def _generate_request_id() -> str:
+        """Generate unique request ID."""
+        return f"req_{uuid.uuid4()}"

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/config.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/config.py
@@ -1,0 +1,518 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Configuration management for ServiceEvents instrumentation.
+
+Provides environment variable parsing and configuration defaults for all
+ServiceEvents features including AST transformation, collectors, and exporters.
+"""
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple
+
+from amazon.opentelemetry.distro.serviceevents.models.resource_attributes import ResourceAttributes
+from amazon.opentelemetry.distro.version import __version__ as ADOT_VERSION
+
+_logger = logging.getLogger(__name__)
+
+
+def _get_service_name_from_resource_attributes() -> Optional[str]:
+    """Extract service.name from OTEL_RESOURCE_ATTRIBUTES environment variable.
+
+    Parses the comma-separated key=value pairs in OTEL_RESOURCE_ATTRIBUTES
+    looking for 'service.name'.
+
+    Example: OTEL_RESOURCE_ATTRIBUTES='service.name=shoppingcart,deployment.environment=production'
+
+    Returns:
+        Service name if found, None otherwise.
+    """
+    env_resources = os.environ.get("OTEL_RESOURCE_ATTRIBUTES", "")
+    if not env_resources:
+        return None
+
+    for pair in env_resources.split(","):
+        if "=" in pair:
+            key, value = pair.split("=", 1)
+            key = key.strip()
+            value = value.strip()
+            if key == "service.name":
+                return value
+
+    return None
+
+
+def _get_environment_from_resource_attributes() -> Optional[str]:
+    """Extract deployment environment from OTEL_RESOURCE_ATTRIBUTES environment variable.
+
+    Parses the comma-separated key=value pairs in OTEL_RESOURCE_ATTRIBUTES
+    looking for 'deployment.environment.name' (preferred) or 'deployment.environment'.
+
+    Example: OTEL_RESOURCE_ATTRIBUTES='service.name=shoppingcart,deployment.environment=production'
+
+    Returns:
+        Environment name if found, None otherwise.
+    """
+    env_resources = os.environ.get("OTEL_RESOURCE_ATTRIBUTES", "")
+    if not env_resources:
+        return None
+
+    for pair in env_resources.split(","):
+        if "=" in pair:
+            key, value = pair.split("=", 1)
+            key = key.strip()
+            value = value.strip()
+            # Prefer deployment.environment.name (newer OTel convention)
+            if key == "deployment.environment.name":
+                return value
+            # Fallback to deployment.environment (older convention)
+            if key == "deployment.environment":
+                return value
+
+    return None
+
+
+# Internal test-config hook. NOT a customer-facing surface — undocumented, gated, and applied
+# only when DEBUG_SE_TEST_CONFIG is set. Black-box contract/e2e suites run the SDK in a separate
+# process and can only inject configuration via env; this lets them override the small set of
+# internal knobs that no longer have their own env vars. Format is dependency-free delimited
+# "KEY=value;KEY=value" where KEY is the former env-var suffix.
+_TEST_CONFIG_HOOK_ENV = "DEBUG_SE_TEST_CONFIG"
+_test_config_hook_warned = False
+
+
+def _apply_test_config_hook(config: "ServiceEventsConfig") -> None:
+    """Apply internal test-only config overrides from DEBUG_SE_TEST_CONFIG.
+
+    Gated: a literal no-op when the env var is unset or empty. When active it overrides only a
+    fixed allowlist of internal fields and emits a one-time WARN. Unknown keys and unparsable
+    values are silently ignored. This is a test affordance, NOT a supported configuration
+    surface.
+    """
+    raw = os.getenv(_TEST_CONFIG_HOOK_ENV)
+    if not raw:
+        return
+
+    global _test_config_hook_warned  # pylint: disable=global-statement  # module-level singleton warn-once flag
+    if not _test_config_hook_warned:
+        _logger.warning(
+            "ServiceEvents: %s is set — applying internal test config overrides. "
+            "This is a test-only hook and is NOT for production use.",
+            _TEST_CONFIG_HOOK_ENV,
+        )
+        _test_config_hook_warned = True
+
+    def _set_int(field_name: str, value: str) -> None:
+        try:
+            setattr(config, field_name, int(value))
+        except ValueError:
+            pass
+
+    # Recognized keys are the bare env-var suffixes the container/e2e suites need.
+    int_fields = {
+        "ENDPOINT_FLUSH_INTERVAL": "endpoint_flush_interval",
+        "INCIDENT_SNAPSHOT_FLUSH_INTERVAL": "incident_snapshot_flush_interval",
+        "SAMPLE_TIER1_THRESHOLD": "sample_tier1_threshold",
+        "SAMPLE_TIER2_THRESHOLD": "sample_tier2_threshold",
+        "SAMPLE_TIER2_RATE": "sample_tier2_rate",
+        "SAMPLE_TIER3_RATE": "sample_tier3_rate",
+    }
+    str_fields = {
+        "LOG_GROUP": "log_group",
+        "LOG_STREAM": "log_stream",
+    }
+
+    for entry in raw.split(";"):
+        entry = entry.strip()
+        if not entry or "=" not in entry:
+            continue
+        key, value = entry.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if key in int_fields:
+            _set_int(int_fields[key], value)
+        elif key in str_fields:
+            setattr(config, str_fields[key], value)
+        # Unknown keys silently ignored.
+
+
+@dataclass
+class ServiceEventsConfig:
+    """Configuration for ServiceEvents instrumentation."""
+
+    # Enable/Disable. Default false: OTEL_AWS_SERVICE_EVENTS_ENABLED is unset by default,
+    # and the outer bundling gate in aws_opentelemetry_configurator._init_serviceevents
+    # is authoritative for "should ServiceEvents run" (bundled with App Signals, Lambda
+    # excluded, explicit override). Callers that bypass the outer gate must set
+    # enabled=True explicitly.
+    enabled: bool = False  # OTEL_AWS_SERVICE_EVENTS_ENABLED
+
+    # Whether Application Signals is enabled. Used to suppress ServiceEvents signals
+    # that App Signals already covers (e.g. EndpointSummary — App Signals emits
+    # equivalent per-endpoint duration + error metrics). Populated from
+    # OTEL_AWS_APPLICATION_SIGNALS_ENABLED at fromEnv time.
+    application_signals_enabled: bool = False  # OTEL_AWS_APPLICATION_SIGNALS_ENABLED
+
+    # Local-testing file exporter. When set, replaces the OTLP network exporters
+    # (LOGS_ENDPOINT and METRICS_ENDPOINT are ignored). Output is CloudWatch-faithful
+    # NDJSON — one flat line per LogRecord, EMF envelope per metric data point.
+    output_file: str = ""  # OTEL_AWS_SERVICE_EVENTS_OUTPUT_FILE
+    service_name: str = "UnknownService"  # OTEL_SERVICE_NAME or OTEL_RESOURCE_ATTRIBUTES[service.name]
+
+    # Environment and SDK. No default sentinel: when none of the resolution sources
+    # (OTEL_RESOURCE_ATTRIBUTES[deployment.environment(.name)] / ENVIRONMENT) is set,
+    # environment stays None and is omitted from every signal rather than emitting a
+    # placeholder value.
+    environment: Optional[str] = None  # OTEL_RESOURCE_ATTRIBUTES[deployment.environment(.name)] or ENVIRONMENT
+    sdk_version: str = ADOT_VERSION  # Automatically fetched from ADOT package version
+
+    # Flush Intervals (milliseconds). Internal: hardcoded, no env override (test hook may set
+    # endpoint_flush_interval and incident_snapshot_flush_interval).
+    endpoint_flush_interval: int = 30000
+    incident_snapshot_flush_interval: int = 10000
+    deployment_event_flush_interval: int = 86_400_000
+
+    # Incident Snapshot Settings. The rate-limit window is fixed at 1 minute; this is
+    # the max snapshots per that fixed window.
+    incident_snapshot_max_per_minute: int = 100  # OTEL_AWS_SERVICE_EVENTS_INCIDENT_SNAPSHOT_MAX_PER_MINUTE
+    incident_snapshot_duration_threshold_ms: int = (
+        5000  # OTEL_AWS_SERVICE_EVENTS_INCIDENT_SNAPSHOT_DURATION_THRESHOLD_MS
+    )
+    incident_snapshot_max_same_error: int = 1  # OTEL_AWS_SERVICE_EVENTS_INCIDENT_SNAPSHOT_MAX_SAME_ERROR
+
+    # Per-endpoint latency thresholds for latency-triggered incident snapshots
+    # Format: "METHOD /route:threshold_ms,METHOD /route:threshold_ms,..."
+    # Example: "POST /api/checkout:500,GET /api/health:50,GET /api/reports:5000"
+    latency_thresholds: List[str] = field(default_factory=list)  # OTEL_AWS_SERVICE_EVENTS_LATENCY_THRESHOLDS
+
+    # Incident Snapshot Request Payload Capture Settings. Hardcoded off — no longer a
+    # customer-facing env opt-in. The collector capture code stays dormant.
+    incident_snapshot_capture_request_body: bool = False
+
+    # Endpoint Filtering - glob patterns in format "METHOD /route" or "* /route" or "METHOD *"
+    # If include_patterns is set, only track matching endpoints; then exclude_patterns removes from that set
+    # Example: "GET /api/*,POST /api/*" or "* /health,* /metrics"
+    endpoint_include_patterns: List[str] = field(
+        default_factory=list
+    )  # OTEL_AWS_SERVICE_EVENTS_ENDPOINT_INCLUDE_PATTERNS
+    endpoint_exclude_patterns: List[str] = field(
+        default_factory=list
+    )  # OTEL_AWS_SERVICE_EVENTS_ENDPOINT_EXCLUDE_PATTERNS
+
+    # AST Instrumentation — function-instrumentation denylist. Always wins over
+    # PACKAGES_INCLUDE (rule 2 in ast_transformation.py). Empty by default; user
+    # adds patterns to subtract from PACKAGES_INCLUDE.
+    packages_exclude: List[str] = field(default_factory=list)  # OTEL_AWS_SERVICE_EVENTS_PACKAGES_EXCLUDE
+
+    # Sampling Mode: "adaptive" (hot endpoint), "auto" (tiered), "always" (100%), "never" (0%)
+    sampling_mode: str = "adaptive"  # OTEL_AWS_SERVICE_EVENTS_SAMPLING_MODE
+
+    # Sampling Thresholds (for "auto" mode: 3-tier adaptive sampling). Internal: hardcoded, no env
+    # override (test hook may set them).
+    sample_tier1_threshold: int = 100
+    sample_tier2_threshold: int = 1000
+    sample_tier2_rate: int = 10
+    sample_tier3_rate: int = 100
+
+    # Adaptive sampling: number of collector flush cycles an endpoint stays "hot" after an incident.
+    # Internal: hardcoded, no env override.
+    hot_endpoint_cycles: int = 100
+
+    # OTLP Export Settings. Empty here means "unset" — the 4316 default is applied
+    # by the endpoint policy in aws_opentelemetry_configurator._init_serviceevents so it
+    # can require non-empty values when Application Signals is off. ServiceEvents does
+    # NOT fall through to OTEL_EXPORTER_OTLP_*_ENDPOINT.
+    logs_endpoint: str = ""  # OTEL_AWS_OTLP_LOGS_ENDPOINT
+    metrics_endpoint: str = ""  # OTEL_AWS_OTLP_METRICS_ENDPOINT
+    # Logging destination. Internal: hardcoded, no env override (test hook may set them).
+    log_group: str = "/aws/serviceevents/telemetry"
+    log_stream: str = ""  # default: service_name
+
+    # Function instrumentation (AST-based in Python, analogue of Java's bytecode mode).
+    # On by default: function-level instrumentation owns FunctionCall + incident
+    # call_path capture. It only instruments functions matched by packages_include
+    # (empty by default, see below), so with no allowlist it installs the hooks but
+    # instruments nothing until OTEL_AWS_SERVICE_EVENTS_PACKAGES_INCLUDE is set.
+    function_instrument_enabled: bool = True  # OTEL_AWS_SERVICE_EVENTS_FUNCTION_INSTRUMENT_ENABLED
+
+    # Function-instrumentation allowlist.
+    # Empty = no functions instrumented (no implicit default scope). The only way
+    # to opt in. Supported syntax: "foo.*" (prefix); bare "*" is rejected.
+    packages_include: List[str] = field(default_factory=list)  # OTEL_AWS_SERVICE_EVENTS_PACKAGES_INCLUDE
+
+    # Resource attributes from OTel Resource detectors (cloud/host/container/k8s metadata)
+    # Populated by OTel configurator when available, empty for manual init
+    resource_attributes: ResourceAttributes = field(default_factory=ResourceAttributes)
+
+    @classmethod
+    def from_env(cls, resource_attributes: Optional[ResourceAttributes] = None) -> "ServiceEventsConfig":
+        """Build configuration from environment variables.
+
+        Uses class attribute defaults as fallback when environment variables are not set.
+        This ensures the class definition is the single source of truth for default values.
+
+        Args:
+            resource_attributes: Optional ResourceAttributes from OTel Resource detectors.
+                                 Defaults to empty ResourceAttributes() when not provided.
+        """
+        # Create default config instance to get class default values
+        defaults = cls()
+
+        def get_bool(env_var: str, default: bool) -> bool:
+            """Parse boolean environment variable."""
+            return os.getenv(env_var, str(default)).lower() == "true"
+
+        def get_int(env_var: str, default: int) -> int:
+            """Parse integer environment variable."""
+            try:
+                return int(os.getenv(env_var, str(default)))
+            except ValueError:
+                return default
+
+        def get_str(env_var: str, default: str) -> str:
+            """Parse string environment variable."""
+            return os.getenv(env_var, default)
+
+        def get_list(env_var: str, default: List[str]) -> List[str]:
+            """Parse comma-separated list environment variable."""
+            value = os.getenv(env_var, "")
+            if value:
+                return [item.strip() for item in value.split(",") if item.strip()]
+            return default
+
+        def get_pattern_list(env_var: str, default: List[str]) -> List[str]:
+            """Parse a package-pattern list env var, rejecting the bare '*' sentinel.
+
+            Bare `*` is rejected as too broad (it would match every module, defeating
+            the point of an explicit allowlist), so we strip any lone `*` entry and log
+            once per invocation. An empty list instruments nothing — there is no implicit
+            default scope (see the scope rule in ast_transformation.py).
+            """
+            raw = get_list(env_var, default)
+            normalized = []
+            saw_star = False
+            for item in raw:
+                if item == "*":
+                    saw_star = True
+                    continue
+                normalized.append(item)
+            if saw_star:
+                _logger.info(
+                    "ServiceEvents: ignoring bare '*' entry in %s; use specific package "
+                    "prefixes (e.g. myapp). An empty list instruments nothing.",
+                    env_var,
+                )
+            return normalized
+
+        def get_service_name(default: str) -> str:
+            """Get service name with fallback chain.
+
+            Priority:
+            1. OTEL_SERVICE_NAME environment variable
+            2. service.name from OTEL_RESOURCE_ATTRIBUTES
+            3. Default value
+            """
+            # First try OTEL_SERVICE_NAME
+            service_name = os.getenv("OTEL_SERVICE_NAME")
+            if service_name:
+                return service_name
+
+            # Then try OTEL_RESOURCE_ATTRIBUTES
+            service_name = _get_service_name_from_resource_attributes()
+            if service_name:
+                return service_name
+
+            # Fall back to default
+            return default
+
+        def get_environment(default: Optional[str]) -> Optional[str]:
+            """Get environment with fallback chain.
+
+            Priority:
+            1. deployment.environment.name from OTEL_RESOURCE_ATTRIBUTES
+            2. deployment.environment from OTEL_RESOURCE_ATTRIBUTES
+            3. ENVIRONMENT environment variable
+            4. Default value (None) — no sentinel; environment is omitted everywhere when unset
+            """
+            # First try OTEL_RESOURCE_ATTRIBUTES
+            environment = _get_environment_from_resource_attributes()
+            if environment:
+                return environment
+
+            # Then try ENVIRONMENT env var
+            environment = os.getenv("ENVIRONMENT")
+            if environment:
+                return environment
+
+            # Fall back to default (None when unset)
+            return default
+
+        # Build configuration using class defaults as fallback
+        config = cls(
+            # Enable/Disable
+            enabled=get_bool("OTEL_AWS_SERVICE_EVENTS_ENABLED", defaults.enabled),
+            # Mirror aws_opentelemetry_configurator._is_application_signals_enabled precedence:
+            # the new OTEL_AWS_APPLICATION_SIGNALS_ENABLED wins, falling back to the deprecated
+            # OTEL_AWS_APP_SIGNALS_ENABLED when the new var is unset. The outer gate that starts
+            # ServiceEvents honors the deprecated var, so this flag must too — otherwise a
+            # customer who set only the deprecated var would get EndpointSummary emitted
+            # alongside App Signals' equivalent metrics (the suppression is keyed on this flag).
+            application_signals_enabled=get_bool(
+                "OTEL_AWS_APPLICATION_SIGNALS_ENABLED",
+                get_bool("OTEL_AWS_APP_SIGNALS_ENABLED", defaults.application_signals_enabled),
+            ),
+            # Local-testing file exporter (literal path; empty = disabled)
+            output_file=get_str("OTEL_AWS_SERVICE_EVENTS_OUTPUT_FILE", defaults.output_file),
+            service_name=get_service_name(defaults.service_name),
+            # Environment and SDK
+            environment=get_environment(defaults.environment),
+            sdk_version=defaults.sdk_version,
+            # Flush Intervals (internal; hardcoded defaults, reachable only via the test hook)
+            endpoint_flush_interval=defaults.endpoint_flush_interval,
+            incident_snapshot_flush_interval=defaults.incident_snapshot_flush_interval,
+            deployment_event_flush_interval=defaults.deployment_event_flush_interval,
+            # Incident Snapshot Settings (rate-limit window fixed at 1 minute)
+            incident_snapshot_max_per_minute=get_int(
+                "OTEL_AWS_SERVICE_EVENTS_INCIDENT_SNAPSHOT_MAX_PER_MINUTE", defaults.incident_snapshot_max_per_minute
+            ),
+            incident_snapshot_duration_threshold_ms=get_int(
+                "OTEL_AWS_SERVICE_EVENTS_INCIDENT_SNAPSHOT_DURATION_THRESHOLD_MS",
+                defaults.incident_snapshot_duration_threshold_ms,
+            ),
+            incident_snapshot_max_same_error=get_int(
+                "OTEL_AWS_SERVICE_EVENTS_INCIDENT_SNAPSHOT_MAX_SAME_ERROR", defaults.incident_snapshot_max_same_error
+            ),
+            latency_thresholds=get_list("OTEL_AWS_SERVICE_EVENTS_LATENCY_THRESHOLDS", defaults.latency_thresholds),
+            # Incident Snapshot Request Payload Capture Settings: hardcoded off (no env opt-in).
+            # Endpoint Filtering
+            endpoint_include_patterns=get_list(
+                "OTEL_AWS_SERVICE_EVENTS_ENDPOINT_INCLUDE_PATTERNS", defaults.endpoint_include_patterns
+            ),
+            endpoint_exclude_patterns=get_list(
+                "OTEL_AWS_SERVICE_EVENTS_ENDPOINT_EXCLUDE_PATTERNS", defaults.endpoint_exclude_patterns
+            ),
+            # AST Instrumentation — function-instrumentation denylist. Always wins over
+            # PACKAGES_INCLUDE (rule 2 in ast_transformation.py). Bare '*' entries are
+            # normalized away.
+            packages_exclude=get_pattern_list("OTEL_AWS_SERVICE_EVENTS_PACKAGES_EXCLUDE", defaults.packages_exclude),
+            # Sampling Mode
+            sampling_mode=get_str("OTEL_AWS_SERVICE_EVENTS_SAMPLING_MODE", defaults.sampling_mode),
+            # Sampling Thresholds (internal; hardcoded defaults, reachable only via the test hook)
+            sample_tier1_threshold=defaults.sample_tier1_threshold,
+            sample_tier2_threshold=defaults.sample_tier2_threshold,
+            sample_tier2_rate=defaults.sample_tier2_rate,
+            sample_tier3_rate=defaults.sample_tier3_rate,
+            hot_endpoint_cycles=defaults.hot_endpoint_cycles,
+            # OTLP Export Settings
+            logs_endpoint=get_str("OTEL_AWS_OTLP_LOGS_ENDPOINT", defaults.logs_endpoint),
+            metrics_endpoint=get_str("OTEL_AWS_OTLP_METRICS_ENDPOINT", defaults.metrics_endpoint),
+            # Logging destination (internal; hardcoded defaults, reachable only via the test hook)
+            log_group=defaults.log_group,
+            log_stream=defaults.log_stream,
+            # Function instrumentation
+            function_instrument_enabled=get_bool(
+                "OTEL_AWS_SERVICE_EVENTS_FUNCTION_INSTRUMENT_ENABLED", defaults.function_instrument_enabled
+            ),
+            packages_include=get_pattern_list("OTEL_AWS_SERVICE_EVENTS_PACKAGES_INCLUDE", defaults.packages_include),
+            # Resource attributes (from OTel Resource detectors)
+            resource_attributes=resource_attributes if resource_attributes is not None else ResourceAttributes(),
+        )
+        _apply_test_config_hook(config)
+        return config
+
+    def get_latency_threshold_patterns(self) -> List[Tuple[str, float]]:
+        """Parse latency_thresholds list into pattern -> threshold_ms tuples.
+
+        Supports glob patterns using fnmatch (*, ?, [seq], [!seq]).
+        Each entry should be in format "METHOD /route:threshold_ms".
+
+        Examples:
+            - "GET /api/users:500" - exact match
+            - "* /server_request:50" - any method to /server_request
+            - "GET /api/*:100" - any GET to /api/* routes
+            - "* *:200" - all endpoints (catch-all)
+
+        Returns:
+            List of (pattern, threshold_ms) tuples. Order matters - first match wins.
+        """
+        result: List[Tuple[str, float]] = []
+
+        for entry in self.latency_thresholds:
+            entry = entry.strip()
+            if not entry or ":" not in entry:
+                continue
+
+            # Split on last colon to handle routes that might contain colons
+            last_colon_idx = entry.rfind(":")
+            if last_colon_idx <= 0:
+                continue
+
+            api_part = entry[:last_colon_idx].strip()
+            threshold_part = entry[last_colon_idx + 1 :].strip()
+
+            # Parse threshold
+            try:
+                threshold_ms = float(threshold_part)
+            except ValueError:
+                continue
+
+            # Parse "METHOD /route" format
+            parts = api_part.split(" ", 1)
+            if len(parts) != 2:
+                continue
+
+            method = parts[0].strip().upper()
+            route = parts[1].strip()
+
+            # Store as pattern string "METHOD /route"
+            pattern = f"{method} {route}"
+            result.append((pattern, threshold_ms))
+
+        return result
+
+    def should_track_endpoint(self, route: str, method: str) -> bool:
+        """Check if an endpoint should be tracked based on include/exclude patterns.
+
+        Filter logic:
+        1. If include_patterns is empty -> track all endpoints (default)
+        2. If include_patterns is set -> only track endpoints matching at least one include pattern
+        3. Then, if exclude_patterns is set -> remove any endpoints matching exclude patterns
+
+        Patterns use glob-style matching (fnmatch):
+        - "*" matches anything
+        - "?" matches any single character
+        - Format: "METHOD /route" (e.g., "GET /api/*", "* /health", "POST /api/users")
+
+        Args:
+            route: The endpoint route (e.g., "/api/users")
+            method: The HTTP method (e.g., "GET", "POST")
+
+        Returns:
+            True if the endpoint should be tracked, False if filtered out.
+        """
+        # Lazy import: fnmatch is only needed on this filtering path, not at module load.
+        import fnmatch  # pylint: disable=import-outside-toplevel
+
+        endpoint_str = f"{method.upper()} {route}"
+
+        # Step 1: Check include patterns
+        if self.endpoint_include_patterns:
+            # Must match at least one include pattern
+            included = False
+            for pattern in self.endpoint_include_patterns:
+                if fnmatch.fnmatch(endpoint_str, pattern):
+                    included = True
+                    break
+            if not included:
+                return False
+
+        # Step 2: Check exclude patterns
+        if self.endpoint_exclude_patterns:
+            for pattern in self.endpoint_exclude_patterns:
+                if fnmatch.fnmatch(endpoint_str, pattern):
+                    return False
+
+        return True

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/exporter/__init__.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/exporter/__init__.py
@@ -1,0 +1,21 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+ServiceEvents exporters.
+
+- ``ServiceEventsOtlpEmitter``: OTLP LogRecord + metric emitter (primary signal path).
+- ``ServiceEventsCloudWatchLogFileExporter`` / ``ServiceEventsCloudWatchMetricFileExporter``:
+  local-testing file exporter that writes CloudWatch-faithful NDJSON instead of
+  hitting an OTLP endpoint. Enabled via ``OTEL_AWS_SERVICE_EVENTS_OUTPUT_FILE``.
+"""
+
+from amazon.opentelemetry.distro.serviceevents.exporter.cloudwatch_file_exporter import (
+    ServiceEventsCloudWatchLogFileExporter,
+    ServiceEventsCloudWatchMetricFileExporter,
+)
+
+__all__ = [
+    "ServiceEventsCloudWatchLogFileExporter",
+    "ServiceEventsCloudWatchMetricFileExporter",
+]

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/exporter/cloudwatch_file_exporter.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/exporter/cloudwatch_file_exporter.py
@@ -1,0 +1,374 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Local-testing file exporter producing CloudWatch-faithful NDJSON.
+
+When ``OTEL_AWS_SERVICE_EVENTS_OUTPUT_FILE`` is set, ``ServiceEventsInstrumentation``
+wires these exporters into the ServiceEvents ``LoggerProvider`` +
+``MeterProvider`` in place of the OTLP HTTP exporters. The output shape
+matches what users see in CloudWatch Logs Insights:
+
+* Logs: one NDJSON line per LogRecord with top-level
+  ``eventName``/``timeUnixNano``/``attributes``/``body`` plus nested
+  ``resource``.
+* Metrics: one NDJSON line per export batch as a canonical OTLP/JSON
+  ``ExportMetricsServiceRequest`` — byte-identical to the OTLP wire,
+  covering both ``count`` (Sum) and ``service.function.duration``
+  (ExponentialHistogram).
+
+Both exporters append to the same file via a writer singleton keyed on
+absolute path — one ``open(..., "a")`` + ``threading.Lock`` per path, so
+log + metric lines don't interleave.
+"""
+
+import json
+import logging
+import os
+import threading
+from dataclasses import dataclass
+from logging.handlers import RotatingFileHandler
+from typing import Any, Dict, Optional, Sequence
+
+from google.protobuf.json_format import MessageToJson
+
+from opentelemetry.exporter.otlp.proto.common.metrics_encoder import encode_metrics
+from opentelemetry.sdk._logs import ReadableLogRecord
+from opentelemetry.sdk._logs.export import LogRecordExporter, LogRecordExportResult
+from opentelemetry.sdk.metrics import Counter, Histogram
+from opentelemetry.sdk.metrics.export import AggregationTemporality, MetricExporter, MetricExportResult, MetricsData
+from opentelemetry.sdk.metrics.view import Aggregation
+
+logger = logging.getLogger(__name__)
+
+
+# Output-file rotation policy. When the active file reaches MAX_BYTES it is
+# renamed to <file>.1, existing backups shift one slot, and <file>.{BACKUP_COUNT}
+# is dropped. Bounds total disk footprint per output path at
+# (BACKUP_COUNT + 1) * MAX_BYTES.
+MAX_BYTES = 50 * 1024 * 1024
+BACKUP_COUNT = 5
+
+
+class _Utf8RotatingFileHandler(RotatingFileHandler):
+    """``RotatingFileHandler`` that compares against UTF-8 byte length.
+
+    The stdlib version's ``shouldRollover`` uses ``len(msg)`` which returns
+    code points, not bytes. With non-ASCII content (multi-byte UTF-8) the
+    on-disk file can grow well past ``maxBytes`` before rotation triggers.
+    Override to count encoded bytes so the threshold matches what's actually
+    written to disk.
+
+    Preserves the two stdlib guards: never rotate an empty file (gh-116263)
+    and never rotate a non-regular file like a FIFO (bpo-45401).
+    """
+
+    def shouldRollover(self, record):  # noqa: N802 — stdlib API name
+        if self.stream is None:
+            self.stream = self._open()
+        if self.maxBytes <= 0:
+            return False
+        # Preserve stdlib guard: don't rotate non-regular files (FIFOs, /dev/stdout, …).
+        if not os.path.isfile(self.baseFilename):
+            return False
+        try:
+            self.stream.seek(0, 2)  # SEEK_END
+            pos = self.stream.tell()
+        except OSError:
+            return False
+        # Preserve stdlib guard: never rotate an empty file even if the next
+        # message itself exceeds maxBytes — a useless empty backup helps no one.
+        if pos == 0:
+            return False
+        msg = self.format(record) + self.terminator
+        try:
+            msg_bytes = len(msg.encode("utf-8"))
+        except (UnicodeError, AttributeError):
+            msg_bytes = len(msg)
+        return pos + msg_bytes >= self.maxBytes
+
+
+# ─── writer singleton ────────────────────────────────────────────────
+
+
+@dataclass
+class _Writer:
+    handler: RotatingFileHandler
+    lock: threading.Lock
+    ref_count: int
+
+
+_writers: Dict[str, _Writer] = {}
+_writers_mutex = threading.Lock()
+
+
+def _acquire_writer(abs_path: str) -> Optional[_Writer]:
+    """Open or share the writer for ``abs_path``.
+
+    Returns ``None`` if the path can't be opened (permission denied, disk
+    full, etc.). Callers must tolerate a ``None`` return — telemetry-side
+    code MUST NOT propagate I/O failures into the customer application.
+    """
+    try:
+        with _writers_mutex:
+            entry = _writers.get(abs_path)
+            if entry is not None:
+                entry.ref_count += 1
+                return entry
+            os.makedirs(os.path.dirname(abs_path) or ".", exist_ok=True)
+            # RotatingFileHandler enforces the 50MB / 5-backup policy for the
+            # local-testing output file. The handler is shared across
+            # log + metric exporters via this registry; threading.Lock guards
+            # cross-exporter writes so log + metric lines don't interleave.
+            handler = _Utf8RotatingFileHandler(
+                abs_path,
+                mode="a",
+                maxBytes=MAX_BYTES,
+                backupCount=BACKUP_COUNT,
+                encoding="utf-8",
+                delay=False,
+            )
+            # Each emitted record's msg already ends with "\n" — suppress the
+            # default "\n" terminator so the on-disk format is unchanged.
+            handler.terminator = ""
+            handler.setFormatter(logging.Formatter("%(message)s"))
+            entry = _Writer(handler=handler, lock=threading.Lock(), ref_count=1)
+            _writers[abs_path] = entry
+            return entry
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.exception("ServiceEvents: failed to open output file %s", abs_path)
+        return None
+
+
+def _release_writer(abs_path: str) -> None:
+    with _writers_mutex:
+        entry = _writers.get(abs_path)
+        if entry is None:
+            return
+        entry.ref_count -= 1
+        if entry.ref_count > 0:
+            return
+        del _writers[abs_path]
+        try:
+            entry.handler.close()
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
+
+
+def _reset_file_writers() -> None:
+    """Test-only: drop all cached writers and close their files."""
+    with _writers_mutex:
+        for entry in _writers.values():
+            try:
+                entry.handler.close()
+            except Exception:  # pylint: disable=broad-exception-caught
+                pass
+        _writers.clear()
+
+
+def _safe_acquire_writer(output_path: str) -> "tuple[str, Optional[_Writer]]":
+    """Resolve ``output_path`` and acquire its writer without raising.
+
+    Telemetry SDK code MUST NOT propagate failures into the customer
+    application. This wraps both ``os.path.abspath`` (which raises
+    ``TypeError`` on non-string input) and ``_acquire_writer`` (which
+    can fail on permission/disk errors) so exporter constructors are
+    never an exception source.
+    """
+    try:
+        abs_path = os.path.abspath(output_path)
+    except (TypeError, ValueError, OSError):
+        logger.exception("ServiceEvents: invalid output file path %r", output_path)
+        return "", None
+    return abs_path, _acquire_writer(abs_path)
+
+
+def _emit_lines(writer: _Writer, lines: Sequence[str]) -> None:
+    """Write each pre-serialized NDJSON line through the rotating handler.
+
+    Building one logging.LogRecord per line lets RotatingFileHandler.emit()
+    run its size check + rollover between records, so the file is bounded
+    even within a single export batch.
+    """
+    handler = writer.handler
+    for line in lines:
+        record = logging.LogRecord(
+            name="serviceevents",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg=line,
+            args=(),
+            exc_info=None,
+        )
+        handler.emit(record)
+
+
+# ─── serialization ───────────────────────────────────────────────────
+
+
+def _unwrap_body(value: Any) -> Any:
+    """Recursively unwrap nested dicts/lists into JSON-serializable form.
+
+    Python's LogRecord.body is set by the emitter directly to a plain dict
+    or string; this pass is a safety net for anything that slipped through
+    as an ``AnyValue`` wrapper.
+    """
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        return {str(k): _unwrap_body(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_unwrap_body(v) for v in value]
+    return str(value)
+
+
+def serialize_log_record(readable: ReadableLogRecord) -> Dict[str, Any]:
+    """Build the flat CloudWatch-shape JSON for one LogRecord."""
+    record = readable.log_record
+
+    attributes: Dict[str, Any] = {}
+    if record.attributes:
+        for attr_key, attr_value in record.attributes.items():
+            attributes[str(attr_key)] = attr_value
+
+    resource: Dict[str, Any] = {}
+    if readable.resource is not None:
+        for attr_key, attr_value in readable.resource.attributes.items():
+            resource[str(attr_key)] = attr_value
+
+    out: Dict[str, Any] = {
+        "eventName": record.event_name or "",
+        "timeUnixNano": record.timestamp if record.timestamp is not None else 0,
+        "attributes": attributes,
+        "body": _unwrap_body(record.body) or {},
+        "resource": resource,
+    }
+
+    # trace/span context — present only when the LogRecord carries one
+    # (e.g. IncidentSnapshot correlated to an active trace).
+    trace_id = record.trace_id
+    span_id = record.span_id
+    flags = record.trace_flags
+    if trace_id:
+        out["traceId"] = f"{trace_id:032x}" if isinstance(trace_id, int) else str(trace_id)
+    if span_id:
+        out["spanId"] = f"{span_id:016x}" if isinstance(span_id, int) else str(span_id)
+    if flags is not None and trace_id:
+        out["flags"] = int(flags)
+
+    return out
+
+
+# ─── exporters ───────────────────────────────────────────────────────
+
+
+class ServiceEventsCloudWatchLogFileExporter(LogRecordExporter):
+    """LogRecordExporter subclass that writes CloudWatch-faithful NDJSON to a file."""
+
+    def __init__(self, output_path: str):
+        self._abs_path, self._writer = _safe_acquire_writer(output_path)
+        self._shutdown_called = False
+
+    def export(self, batch: Sequence[ReadableLogRecord]) -> LogRecordExportResult:
+        if self._shutdown_called or self._writer is None:
+            return LogRecordExportResult.FAILURE
+        try:
+            lines = [
+                json.dumps(serialize_log_record(record), separators=(",", ":"), default=str) + "\n" for record in batch
+            ]
+            if lines:
+                with self._writer.lock:
+                    _emit_lines(self._writer, lines)
+            return LogRecordExportResult.SUCCESS
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.exception("ServiceEvents: failed to write log records to file")
+            return LogRecordExportResult.FAILURE
+
+    def force_flush(self, timeout_millis: Optional[int] = 30000) -> bool:  # pylint: disable=unused-argument
+        if self._writer is None:
+            return False
+        try:
+            with self._writer.lock:
+                self._writer.handler.flush()
+            return True
+        except Exception:  # pylint: disable=broad-exception-caught
+            return False
+
+    def shutdown(self) -> None:
+        if self._shutdown_called:
+            return
+        self._shutdown_called = True
+        if self._writer is None:
+            return
+        _release_writer(self._abs_path)
+
+
+class ServiceEventsCloudWatchMetricFileExporter(MetricExporter):
+    """MetricExporter subclass that writes canonical OTLP metrics JSON to a file.
+
+    Each ``export()`` batch is written as ONE NDJSON line containing a full
+    OTLP ``ExportMetricsServiceRequest`` (``resourceMetrics[].scopeMetrics[].metrics[]``),
+    byte-identical to what the CloudWatch OTLP metrics endpoint accepts. This
+    mirrors the OTLP HTTP exporter exactly — the file exporter is a pure
+    transport swap, so both ``count`` (Sum) and ``service.function.duration``
+    (ExponentialHistogram) serialize natively with no per-type special-casing.
+    """
+
+    def __init__(self, output_path: str):
+        # Delta temporality preference MUST match the OTLP HTTP exporter's config in
+        # serviceevents_instrumentation.py (Counter+Histogram → DELTA) so the file
+        # mirror is a true transport swap. The MetricReader reads this off the
+        # exporter's `_preferred_temporality`; an empty dict would default to
+        # CUMULATIVE and diverge from the network wire.
+        preferred_temporality = {
+            Counter: AggregationTemporality.DELTA,
+            Histogram: AggregationTemporality.DELTA,
+        }
+        preferred_aggregation: Dict[type, Aggregation] = {}
+        super().__init__(
+            preferred_temporality=preferred_temporality,
+            preferred_aggregation=preferred_aggregation,
+        )
+        self._abs_path, self._writer = _safe_acquire_writer(output_path)
+        self._shutdown_called = False
+
+    def export(
+        self,
+        metrics_data: MetricsData,
+        timeout_millis: float = 10_000,
+        **kwargs: Any,
+    ) -> MetricExportResult:
+        if self._shutdown_called or self._writer is None:
+            return MetricExportResult.FAILURE
+        try:
+            if not metrics_data.resource_metrics:
+                return MetricExportResult.SUCCESS
+            # Encode the whole batch to a single OTLP/JSON ExportMetricsServiceRequest,
+            # exactly as the OTLP HTTP exporter does on the wire. One NDJSON line per batch.
+            request = encode_metrics(metrics_data)
+            line = MessageToJson(request, indent=None) + "\n"
+            with self._writer.lock:
+                _emit_lines(self._writer, [line])
+            return MetricExportResult.SUCCESS
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.exception("ServiceEvents: failed to write metrics to file")
+            return MetricExportResult.FAILURE
+
+    def force_flush(self, timeout_millis: float = 10_000) -> bool:
+        if self._writer is None:
+            return False
+        try:
+            with self._writer.lock:
+                self._writer.handler.flush()
+            return True
+        except Exception:  # pylint: disable=broad-exception-caught
+            return False
+
+    def shutdown(self, timeout_millis: float = 30_000, **kwargs: Any) -> None:
+        if self._shutdown_called:
+            return
+        self._shutdown_called = True
+        if self._writer is None:
+            return
+        _release_writer(self._abs_path)

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/exporter/otlp_emitter.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/exporter/otlp_emitter.py
@@ -1,0 +1,339 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+OTLP emitter for ServiceEvents signals.
+
+Maps collector data models to OTLP LogRecords and OTel Metrics.
+Uses dedicated LoggerProvider and MeterProvider isolated from
+application telemetry.
+
+Signals:
+  - EndpointSummary → OTLP LogRecord (event.name = aws.service_events.endpoint_summary)
+  - FunctionCall → OTel Exponential Histogram (name = service.function.duration)
+  - IncidentSnapshot → OTLP LogRecord (event.name = aws.service_events.incident_snapshot)
+  - DeploymentEvent → OTLP LogRecord (event.name = aws.service_events.deployment_event)
+  - EndpointErrorMetrics → OTel Counter (name = count, unit = Count)
+"""
+
+import logging
+import threading
+import time
+from typing import Any, Dict, Optional
+
+from opentelemetry._logs import LogRecord, SeverityNumber
+
+logger = logging.getLogger(__name__)
+
+INSTRUMENTATION_SCOPE = "serviceevents"
+INSTRUMENTATION_VERSION = "1.0"
+
+
+class ServiceEventsOtlpEmitter:
+    """Emits ServiceEvents signals as OTLP LogRecords and OTel Metrics."""
+
+    def __init__(
+        self,
+        logger_provider,
+        meter_provider,
+        deployment_id: str = "",
+        git_commit_sha: str = "",
+        git_repo_url: str = "",
+    ):
+        self._logger_provider = logger_provider
+        self._meter_provider = meter_provider
+        self._deployment_id = deployment_id or ""
+        self._git_commit_sha = git_commit_sha or ""
+        self._git_repo_url = git_repo_url or ""
+
+        self._otel_logger = None
+        self._error_counter = None
+        self._init_lock = threading.Lock()
+        self._initialized = False
+
+    def _ensure_initialized(self):
+        """Lazy initialization of OTel logger and meter instruments."""
+        if self._initialized:
+            return
+        with self._init_lock:
+            if self._initialized:
+                return
+            try:
+                self._otel_logger = self._logger_provider.get_logger(INSTRUMENTATION_SCOPE, INSTRUMENTATION_VERSION)
+                meter = self._meter_provider.get_meter(INSTRUMENTATION_SCOPE, INSTRUMENTATION_VERSION)
+                self._error_counter = meter.create_counter("count", unit="Count")
+                self._initialized = True
+            # Telemetry must never crash the host app; swallow any init failure.
+            except Exception:  # pylint: disable=broad-exception-caught
+                logger.warning("Failed to initialize OTLP emitter", exc_info=True)
+
+    # ─── EndpointSummary ────────────────────────────────────────────────
+
+    def emit_endpoint_summary(self, event) -> None:
+        """Emit EndpointSummary as OTLP LogRecord."""
+        self._ensure_initialized()
+        if not self._otel_logger:
+            return
+
+        attrs = {
+            "http.request.method": event.method or "",
+            "url.route": event.route or "",
+            "aws.service_events.operation": event.operation or "",
+            "aws.service_events.request.count": event.count or 0,
+            "aws.service_events.request.faults": event.faults or 0,
+            "aws.service_events.request.errors": event.errors or 0,
+            "aws.service_events.incident.count": getattr(event, "incident_count", 0) or 0,
+        }
+        self._put_vcs_and_deployment_attrs(attrs)
+
+        body = {}
+        if event.duration:
+            body["duration"] = self._duration_to_dict(event.duration)
+        body["exception_breakdown"] = self._error_breakdown_to_list(getattr(event, "error_breakdown", None))
+        body["incidents_exemplar"] = self._incidents_exemplar_to_list(getattr(event, "incidents_exemplar", None))
+
+        self._emit_log("aws.service_events.endpoint_summary", attrs, body)
+
+    # ─── IncidentSnapshot ───────────────────────────────────────────────
+
+    def emit_incident_snapshot(self, snapshot_dict: Dict[str, Any]) -> None:
+        """Emit IncidentSnapshot as OTLP LogRecord with trace context.
+
+        Args:
+            snapshot_dict: The full incident snapshot dict (from IncidentSnapshot.to_dict()).
+                          Must have telemetry_correlation, exception_info, request_context, etc.
+        """
+        self._ensure_initialized()
+        if not self._otel_logger:
+            return
+
+        attrs = {
+            "aws.service_events.snapshot_id": snapshot_dict.get("snapshot_id", ""),
+            "aws.service_events.trigger_type": snapshot_dict.get("trigger_type", ""),
+            "aws.service_events.operation": snapshot_dict.get("operation", ""),
+            "aws.service_events.duration_ms": snapshot_dict.get("duration_ms", 0),
+            "aws.service_events.is_partial": snapshot_dict.get("is_partial", False),
+        }
+
+        # HTTP context
+        method = snapshot_dict.get("method", "")
+        route = snapshot_dict.get("route", "")
+        if not method:
+            operation = snapshot_dict.get("operation", "")
+            parts = operation.split(" ", 1) if operation else []
+            method = parts[0] if len(parts) > 0 else ""
+            route = parts[1] if len(parts) > 1 else ""
+        attrs["http.request.method"] = method
+        attrs["url.route"] = route
+
+        request_context = snapshot_dict.get("request_context", {})
+        if isinstance(request_context, dict):
+            status_code = request_context.get("status_code")
+            if status_code is not None:
+                attrs["http.response.status_code"] = int(status_code)
+            attrs["aws.service_events.request.type"] = request_context.get("type", "http")
+
+        self._put_vcs_and_deployment_attrs(attrs)
+
+        # Body: exception_info + request_context.
+        body = {}
+        exception_info = snapshot_dict.get("exception_info")
+        if exception_info is not None:
+            body["exception_info"] = exception_info
+        if request_context:
+            body["request_context"] = request_context
+
+        # Trace context from telemetry_correlation
+        trace_context = None
+        correlation = snapshot_dict.get("telemetry_correlation", {})
+        if isinstance(correlation, dict):
+            trace_id_str = correlation.get("trace_id")
+            span_id_str = correlation.get("span_id")
+            if trace_id_str and span_id_str:
+                trace_context = {"trace_id": trace_id_str, "span_id": span_id_str}
+
+        self._emit_log("aws.service_events.incident_snapshot", attrs, body, trace_context)
+
+    # ─── DeploymentEvent ────────────────────────────────────────────────
+
+    def emit_deployment_event(self, event, trigger: str = "periodic") -> None:
+        """Emit DeploymentEvent as OTLP LogRecord (no body)."""
+        self._ensure_initialized()
+        if not self._otel_logger:
+            return
+
+        attrs = {}
+        # Read from DeploymentEventTelemetry model. Unset DeploymentContext fields
+        # default to empty, so a plain truthiness guard omits them from the wire.
+        ctx = getattr(event, "deployment_context", None)
+        if ctx:
+            if getattr(ctx, "git_commit_sha", None):
+                attrs["vcs.ref.head.revision"] = ctx.git_commit_sha
+            if getattr(ctx, "git_repo_url", None):
+                attrs["vcs.repository.url.full"] = ctx.git_repo_url
+            if getattr(ctx, "deployment_id", None):
+                attrs["aws.service_events.deployment.id"] = ctx.deployment_id
+            if getattr(ctx, "deployment_url", None):
+                attrs["aws.service_events.deployment.url"] = ctx.deployment_url
+            if getattr(ctx, "deployment_timestamp", None):
+                attrs["aws.service_events.deployment.timestamp"] = ctx.deployment_timestamp
+        else:
+            # Fallback to emitter-level config
+            self._put_vcs_and_deployment_attrs(attrs)
+
+        attrs["aws.service_events.deployment.trigger"] = trigger
+
+        # DeploymentEvent has no body
+        self._emit_log("aws.service_events.deployment_event", attrs, None)
+
+    # ─── EndpointErrorMetrics ───────────────────────────────────────────
+
+    def emit_endpoint_error_metrics(self, metrics: list) -> None:
+        """Emit EndpointErrorMetrics as OTel Counter data points."""
+        self._ensure_initialized()
+        if not self._error_counter:
+            return
+
+        for metric in metrics:
+            count = getattr(metric, "count", 0) or 0
+            if count <= 0:
+                continue
+            self._error_counter.add(
+                count,
+                {
+                    "Telemetry.Source": "ServiceEvents",
+                    # `environment` is Optional and is None when unset — coalesce every
+                    # value with `or ""` so a None never reaches the OTel attribute API
+                    # (which rejects None values and drops the dimension).
+                    "service_name": getattr(metric, "service_name", "") or "",
+                    "environment": getattr(metric, "environment", "") or "",
+                    "operation": getattr(metric, "operation", "") or "",
+                    "exception": getattr(metric, "exception", "") or "",
+                },
+            )
+
+    # ─── Shutdown ───────────────────────────────────────────────────────
+
+    def shutdown(self) -> None:
+        """Flush and shutdown owned providers."""
+        try:
+            if self._logger_provider:
+                self._logger_provider.force_flush()
+                self._logger_provider.shutdown()
+        # Telemetry must never crash the host app; swallow any shutdown failure.
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.warning("Error shutting down logger provider", exc_info=True)
+        try:
+            if self._meter_provider:
+                self._meter_provider.force_flush()
+                self._meter_provider.shutdown()
+        # Telemetry must never crash the host app; swallow any shutdown failure.
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.warning("Error shutting down meter provider", exc_info=True)
+
+    # ─── Private helpers ────────────────────────────────────────────────
+
+    def _emit_log(
+        self,
+        event_name: str,
+        attributes: Dict[str, Any],
+        body: Optional[Dict[str, Any]] = None,
+        trace_context: Optional[Dict[str, str]] = None,
+    ) -> None:
+        """Core log emission method."""
+        # CloudWatch workaround: event.name as explicit attribute
+        attributes["event.name"] = event_name
+
+        timestamp_ns = int(time.time() * 1e9)
+
+        # Trace context (IncidentSnapshot only)
+        trace_id = 0
+        span_id = 0
+        trace_flags = 0
+        if trace_context:
+            try:
+                tid = trace_context.get("trace_id", "")
+                sid = trace_context.get("span_id", "")
+                if tid:
+                    trace_id = int(tid, 16) if isinstance(tid, str) else int(tid)
+                if sid:
+                    span_id = int(sid, 16) if isinstance(sid, str) else int(sid)
+                if trace_id and span_id:
+                    trace_flags = 1  # SAMPLED
+            except (ValueError, TypeError):
+                pass
+
+        log_record = LogRecord(
+            timestamp=timestamp_ns,
+            event_name=event_name,
+            trace_id=trace_id,
+            span_id=span_id,
+            trace_flags=trace_flags,
+            severity_number=SeverityNumber.UNSPECIFIED,
+            attributes=attributes,
+            body=body if body is not None else "",
+        )
+
+        try:
+            self._otel_logger.emit(log_record)
+        # Telemetry must never crash the host app; swallow any emit failure.
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.debug("Failed to emit OTLP log: %s", event_name, exc_info=True)
+
+    def _put_vcs_and_deployment_attrs(self, attrs: Dict[str, Any]) -> None:
+        """Add VCS and deployment attributes if set."""
+        if self._git_commit_sha:
+            attrs["vcs.ref.head.revision"] = self._git_commit_sha
+        if self._git_repo_url:
+            attrs["vcs.repository.url.full"] = self._git_repo_url
+        if self._deployment_id:
+            attrs["aws.service_events.deployment.id"] = self._deployment_id
+
+    @staticmethod
+    def _duration_to_dict(duration) -> Dict[str, Any]:
+        """Convert DurationMetrics to CamelCase dict for OTLP body."""
+        return {
+            "Values": list(getattr(duration, "values", []) or []),
+            "Counts": list(getattr(duration, "counts", []) or []),
+            "Max": getattr(duration, "max", 0) or 0,
+            "Min": getattr(duration, "min", 0) or 0,
+            "Count": getattr(duration, "count", 0) or 0,
+            "Sum": getattr(duration, "sum", 0) or 0,
+        }
+
+    @staticmethod
+    def _error_breakdown_to_list(error_breakdown) -> list:
+        """Convert error_breakdown entries to the emitted body format."""
+        if not error_breakdown:
+            return []
+        result = []
+        for entry in error_breakdown:
+            item = {
+                "count": getattr(entry, "count", 0),
+                "failure_type": getattr(entry, "failure_type", ""),
+            }
+            errors = getattr(entry, "errors", [])
+            if errors:
+                item["exceptions"] = [
+                    {
+                        "exception_type": getattr(e, "error_type", ""),
+                        "function_name": getattr(e, "function_name", "") or getattr(e, "origin_function", ""),
+                    }
+                    for e in errors
+                ]
+            result.append(item)
+        return result
+
+    @staticmethod
+    def _incidents_exemplar_to_list(exemplars) -> list:
+        """Convert incidents_exemplar entries to the emitted body format."""
+        if not exemplars:
+            return []
+        return [
+            {
+                "snapshot_id": getattr(ex, "snapshot_id", ""),
+                "trigger_type": getattr(ex, "trigger_type", ""),
+                "timestamp": getattr(ex, "timestamp", 0),
+            }
+            for ex in exemplars
+        ]

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/instrumentation/__init__.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/instrumentation/__init__.py
@@ -1,0 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Framework instrumentation hooks for FastAPI, Flask, Django, and Tornado.
+"""

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/instrumentation/_constants.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/instrumentation/_constants.py
@@ -1,0 +1,19 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared constants for the framework instrumentations (Flask, FastAPI, Django).
+
+Keeping these in one module makes cross-framework behavior structural rather than a
+promise enforced by comments — a single edit here changes every framework at once.
+"""
+
+# Route label for a request that matched no URL rule (unmatched 404s, scanner/bot traffic
+# to nonexistent URLs like /wp-admin or /.env). Recording the raw path for these would make
+# every probed URL its own metric series — a cardinality explosion. Collapsing to one
+# sentinel keeps the 404-rate signal without the cardinality, identically across frameworks.
+#
+# Note: this value also flows through ServiceEventsConfig.should_track_endpoint(route, ...).
+# With the default (empty) endpoint filters every request is tracked, so unmatched requests
+# are still recorded under this label. A customer who sets endpoint_include_patterns scopes
+# tracking to matching routes only, so unmatched requests are intentionally excluded then.
+UNMATCHED_ROUTE = "<unmatched>"

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/instrumentation/_safety.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/instrumentation/_safety.py
@@ -1,0 +1,51 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Crash-safety helpers for ServiceEvents code that runs on the customer's
+request thread.
+
+Invariant: ServiceEvents telemetry must NEVER propagate an exception into the
+customer application's control flow. A telemetry defect may lose its own data,
+but it must not crash, fail, or alter the result of a customer request.
+
+``never_raises`` wraps a synchronous request-thread hook so that any exception
+raised inside it is swallowed and a safe value is returned to the caller. The
+failure is intentionally silent — on telemetry failure we lose telemetry, not
+the request. Apply it uniformly to every hook that runs on a customer-observable
+path so a future hook cannot reintroduce the gap.
+"""
+
+import functools
+from typing import Any, Callable, TypeVar
+
+_F = TypeVar("_F", bound=Callable[..., Any])
+
+
+def never_raises(return_value: Any = None) -> Callable[[_F], _F]:
+    """Decorate a sync request-thread hook so it can never raise into customer code.
+
+    On any ``Exception`` the wrapped call returns ``return_value`` instead of
+    propagating. ``BaseException`` (KeyboardInterrupt, SystemExit) is left to
+    propagate so process-level signals still work.
+
+    Args:
+        return_value: Value to return when the wrapped hook raises. Defaults to
+            None. Use a passthrough (e.g. the response object) for hooks whose
+            return value matters to the framework — but when the safe return
+            value is computed inside the body, prefer an inline try/except and
+            keep the ``return`` outside it.
+    """
+
+    def deco(fn: _F) -> _F:
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            try:
+                return fn(*args, **kwargs)
+            # This decorator exists precisely to swallow everything; telemetry must never crash the host app.
+            except Exception:  # pylint: disable=broad-exception-caught
+                return return_value
+
+        return wrapper  # type: ignore[return-value]
+
+    return deco

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/instrumentation/django_instrumentation.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/instrumentation/django_instrumentation.py
@@ -1,0 +1,443 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Django instrumentation for ServiceEvents EndpointMetric and IncidentSnapshot events.
+
+This module installs hooks into Django applications to:
+- Track endpoint metrics (requests, duration, status codes)
+- Trigger incident snapshots on errors or slow requests
+- Propagate endpoint context to function monitors
+
+Note: Django uses middleware for request processing hooks.
+"""
+
+import json
+import logging
+import time
+from typing import Any, Optional
+
+from amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation import (
+    _extract_error_from_call_path,
+)
+from amazon.opentelemetry.distro.serviceevents.python_monitor import (
+    _ServiceEventsMonitorState,
+    clear_current_operation,
+    set_current_operation,
+)
+
+logger = logging.getLogger(__name__)
+
+# Global reference to collectors and config (set during initialization)
+_endpoint_collector = None
+_incident_snapshot_collector = None
+_serviceevents_config = None
+
+# Route label for requests that matched no urlpattern. Django only calls process_view
+# after a URL resolves to a view, so an unmatched 404 never gets a route stored. Recording
+# the raw path for these would make every probed URL (/wp-admin, /.env, scanner noise) its
+# own metric series — a cardinality explosion. Collapsing to one sentinel keeps the
+# 404-rate signal without the cardinality. See _finalize_request.
+_UNMATCHED_ROUTE = "<unmatched>"
+
+
+def _get_request_body(request) -> Optional[Any]:
+    """
+    Safely extract request body from Django request with fallback chain.
+
+    Args:
+        request: Django HttpRequest object
+
+    Returns:
+        Request body as JSON dict, form dict, raw string, or None
+    """
+    try:
+        # Try JSON first (most common for APIs)
+        content_type = request.content_type or ""
+        if "json" in content_type:
+            body = json.loads(request.body)
+            if body is not None:
+                return body
+    except Exception:  # pylint: disable=broad-exception-caught
+        pass
+
+    try:
+        # Try form data
+        if request.POST:
+            return request.POST.dict()
+    except Exception:  # pylint: disable=broad-exception-caught
+        pass
+
+    try:
+        # Try raw data (with 10KB limit)
+        data = request.body
+        if data:
+            if len(data) <= 10240:  # 10KB limit
+                return data.decode("utf-8", errors="replace")
+            return f"<payload too large: {len(data)} bytes>"
+    except Exception:  # pylint: disable=broad-exception-caught
+        pass
+
+    return None
+
+
+def _get_route_pattern(request) -> str:
+    """
+    Get the route pattern (e.g. /users/<int:id>/) from the Django request.
+
+    Args:
+        request: Django HttpRequest object
+
+    Returns:
+        Route pattern string (e.g., "/users/<int:id>/")
+    """
+    # Try to get the route pattern from resolver_match (available after URL resolution)
+    if hasattr(request, "resolver_match") and request.resolver_match is not None:
+        # resolver_match.route is the URL pattern (e.g., "users/<int:id>/")
+        route = getattr(request.resolver_match, "route", None)
+        if route:
+            if not route.startswith("/"):
+                route = "/" + route
+            return route
+
+    # Fallback to path_info
+    path = getattr(request, "path_info", None) or getattr(request, "path", "/unknown")
+    return path
+
+
+def _get_endpoint_name(request) -> str:
+    """
+    Get the endpoint/view name from the Django request.
+
+    Args:
+        request: Django HttpRequest object
+
+    Returns:
+        View name string (e.g., "myapp.views.user_detail") or "unknown"
+    """
+    if hasattr(request, "resolver_match") and request.resolver_match is not None:
+        view_name = getattr(request.resolver_match, "view_name", None)
+        if view_name:
+            return view_name
+    return "unknown"
+
+
+def _finalize_request(request, response, exception):  # pylint: disable=too-many-branches,too-many-locals
+    """
+    Finalize request processing: record metrics and check for incidents.
+
+    Called from the middleware __call__ finally block after the request
+    has been fully processed (or errored).
+
+    Args:
+        request: Django HttpRequest object
+        response: Django HttpResponse object (may be None if exception occurred)
+        exception: Exception that was raised (or None)
+    """
+    try:
+        # Skip if endpoint is filtered out or middleware __call__ was not entered
+        if getattr(request, "_serviceevents_skip", False):
+            return
+
+        # Skip if no start time was recorded
+        if not hasattr(request, "_serviceevents_start_time"):
+            return
+
+        # Prefer exception stored by process_exception (innermost exception)
+        exc = getattr(request, "_serviceevents_exception", None) or exception
+
+        # Determine status code
+        if response is not None:
+            status_code = response.status_code
+        elif exc is not None:
+            status_code = 500
+        else:
+            status_code = 200
+
+        # Calculate duration
+        end_time = time.perf_counter_ns()
+        duration_ns = end_time - request._serviceevents_start_time
+        duration_ms = duration_ns / 1_000_000
+
+        # Get route and method from stored values (set in process_view). A missing
+        # _serviceevents_route means process_view never ran — i.e. the URL matched no
+        # urlpattern (unmatched 404). Use a single sentinel for those instead of the raw
+        # path so scanner/bot traffic to nonexistent URLs can't explode metric cardinality.
+        route = getattr(request, "_serviceevents_route", None)
+        if route is None:
+            route = _UNMATCHED_ROUTE
+        method = getattr(request, "_serviceevents_method", request.method)
+
+        # Extract error info if error occurred
+        error_info = None
+        if status_code >= 400:
+            error_info = _extract_error_from_call_path(exc, route, method)
+
+        # Record endpoint metric
+        if _endpoint_collector:
+            try:
+                _endpoint_collector.record_request(
+                    route=route,
+                    method=method,
+                    status_code=status_code,
+                    duration_ns=duration_ns,
+                    error_info=error_info,
+                )
+            except Exception as record_err:  # pylint: disable=broad-exception-caught
+                # Use a distinct name: `exc` holds the request exception still needed below.
+                logger.error("Error recording endpoint metric: %s", record_err, exc_info=True)
+
+        # Check if incident snapshot should be triggered
+        if _incident_snapshot_collector:
+            try:
+                # Build request data for incident snapshot
+                resolver_match = getattr(request, "resolver_match", None)
+                request_data = {
+                    "path": getattr(request, "_serviceevents_path", request.path),
+                    "endpoint": getattr(request, "_serviceevents_endpoint", "unknown"),
+                    "method": getattr(request, "_serviceevents_method", request.method),
+                    "headers": dict(request.headers) if hasattr(request, "headers") else {},
+                    "args": request.GET.dict() if hasattr(request, "GET") else {},
+                    "view_args": resolver_match.kwargs if resolver_match else {},
+                    "cached_body": _get_request_body(request),
+                    # Pre-captured trace correlation (captured in process_view while span was active)
+                    "trace_id": getattr(request, "_serviceevents_trace_id", None),
+                    "span_id": getattr(request, "_serviceevents_span_id", None),
+                }
+
+                exemplar = _incident_snapshot_collector.process_potential_incident(
+                    route=route,
+                    method=method,
+                    status_code=status_code,
+                    duration_ms=duration_ms,
+                    exception=exc,
+                    request_data=request_data,
+                )
+                if exemplar and _endpoint_collector:
+                    _endpoint_collector.record_incident_exemplar(exemplar["operation"], exemplar)
+            except Exception as snapshot_err:  # pylint: disable=broad-exception-caught
+                logger.error("Error processing incident snapshot: %s", snapshot_err, exc_info=True)
+    finally:
+        # Always clear operation context, even if there's an error
+        clear_current_operation()
+
+
+class ServiceEventsDjangoMiddleware:
+    """
+    Django middleware for ServiceEvents instrumentation.
+
+    This middleware:
+    1. Tracks request timing and status codes
+    2. Captures request context for incident snapshots
+    3. Records endpoint metrics
+    4. Triggers incident snapshots on errors/slow requests
+    5. Propagates endpoint context to function monitors
+
+    Middleware ordering: This should be prepended to the BEGINNING of
+    settings.MIDDLEWARE (outermost) so that __call__ wraps the entire
+    request lifecycle including all other middleware.
+
+    Hook execution order:
+    - __call__: Starts timing (before any middleware runs)
+    - process_view: Sets route context (after URL resolution, OTel span is active)
+    - process_exception: Captures exceptions
+    - __call__ finally: Finalizes metrics and snapshots (after everything)
+    """
+
+    def __init__(self, get_response):
+        """
+        Standard Django middleware init.
+
+        Args:
+            get_response: The next middleware or view in the chain
+        """
+        self.get_response = get_response
+
+    def __call__(self, request):
+        """
+        Process the request through the middleware chain.
+
+        Wraps the entire request lifecycle with timing and error capture.
+        """
+        # Start timing before any other middleware runs
+        request._serviceevents_start_time = time.perf_counter_ns()
+        request._serviceevents_skip = False
+        request._serviceevents_exception = None
+
+        response = None
+        try:
+            response = self.get_response(request)
+        except Exception as exc:
+            request._serviceevents_exception = exc
+            raise
+        finally:
+            _finalize_request(request, response, request._serviceevents_exception)
+
+        return response
+
+    # no-self-use: Django middleware hook called as a bound method on the instance.
+    def process_view(self, request, view_func, view_args, view_kwargs):  # pylint: disable=no-self-use
+        """
+        Called after URL resolution, before the view is called.
+
+        This is where we know the resolved route pattern. The OTel middleware
+        has already created the span at this point, so we can capture trace
+        correlation IDs.
+
+        Args:
+            request: Django HttpRequest object
+            view_func: The view function that will be called
+            view_args: Positional arguments to the view
+            view_kwargs: Keyword arguments to the view
+
+        Returns:
+            None to continue normal processing
+        """
+        # Crash-safety: process_view runs on the request path before the view.
+        # A telemetry failure here must not abort the request, so the setup block
+        # is guarded; on failure we mark the request skipped and return None so
+        # the view runs untracked.
+        try:
+            # Extract route pattern (resolver_match is available here)
+            route = _get_route_pattern(request)
+            method = request.method
+
+            # Check endpoint filter - skip tracking if endpoint is filtered out
+            if _serviceevents_config and not _serviceevents_config.should_track_endpoint(route, method):
+                request._serviceevents_skip = True
+                return None
+
+            # Store request context for finalization
+            request._serviceevents_route = route
+            request._serviceevents_method = method
+            request._serviceevents_path = request.path
+            request._serviceevents_endpoint = _get_endpoint_name(request)
+
+            # Set operation context for function monitors
+            operation = f"{method} {route}"
+            set_current_operation(operation)
+
+            # Begin investigation tracking for this request (always-on mode for incident capture)
+            # This enables call_path capture for potential incident snapshots
+            monitor_state = _ServiceEventsMonitorState.get_instance()
+            monitor_state.begin_investigation()
+        except Exception:  # pylint: disable=broad-exception-caught
+            request._serviceevents_skip = True
+            return None
+
+        # Capture trace_id and span_id NOW while OTel span is active
+        # The OTel middleware runs before our process_view, so the span context is available
+        try:
+            # Lazy import: defer OTel import to avoid import-time coupling on the request path.
+            # pylint: disable=import-outside-toplevel
+            from opentelemetry import trace
+
+            span_context = None
+
+            # PRIMARY: Try OTel context API
+            current_span = trace.get_current_span()
+            if current_span:
+                sc = current_span.get_span_context()
+                if sc and sc.is_valid:
+                    span_context = sc
+
+            # FALLBACK: Read span directly from OTel Django middleware's request.META storage
+            # The OTel middleware stores the span at this key during process_request()
+            # and removes it in process_response(). During process_view, it's always present.
+            if span_context is None:
+                otel_span = request.META.get("opentelemetry-instrumentor-django.span_key")
+                if otel_span:
+                    sc = otel_span.get_span_context()
+                    if sc and sc.is_valid:
+                        span_context = sc
+
+            if span_context is not None:
+                request._serviceevents_trace_id = span_context.trace_id
+                request._serviceevents_span_id = span_context.span_id
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
+
+        return None
+
+    # no-self-use: Django middleware hook called as a bound method on the instance.
+    def process_exception(self, request, exception):  # pylint: disable=useless-return,no-self-use
+        """
+        Called when a view raises an exception.
+
+        Args:
+            request: Django HttpRequest object
+            exception: The exception that was raised
+
+        Returns:
+            None to let Django handle the exception normally
+        """
+        request._serviceevents_exception = exception
+        return None
+
+
+def install_django_hooks(endpoint_collector=None, incident_snapshot_collector=None, config=None):
+    """
+    Install Django instrumentation hooks.
+
+    This monkey-patches Django's BaseHandler.load_middleware() to automatically
+    prepend ServiceEvents middleware to all Django application instances.
+
+    Args:
+        endpoint_collector: EndpointMetricCollector instance
+        incident_snapshot_collector: IncidentSnapshotCollector instance
+        config: ServiceEventsConfig instance for endpoint filtering
+    """
+    # global-statement: module-level singletons set once during instrumentation install.
+    # pylint: disable=global-statement
+    global _endpoint_collector, _incident_snapshot_collector, _serviceevents_config
+
+    try:
+        # Lazy import: defer optional heavy dependency (Django) until install time.
+        # pylint: disable=import-outside-toplevel
+        from django.core.handlers.base import BaseHandler
+    except ImportError:
+        logger.warning("Django not installed, skipping Django instrumentation")
+        return
+
+    _endpoint_collector = endpoint_collector
+    _incident_snapshot_collector = incident_snapshot_collector
+    _serviceevents_config = config
+
+    # Middleware dotted path for Django settings
+    # invalid-name: module/contract constant, not a regular local variable.
+    _SERVICE_EVENTS_MIDDLEWARE_PATH = (  # pylint: disable=invalid-name
+        "amazon.opentelemetry.distro.serviceevents.instrumentation.django_instrumentation.ServiceEventsDjangoMiddleware"
+    )
+
+    # Store original load_middleware to wrap it
+    original_load_middleware = BaseHandler.load_middleware
+
+    def instrumented_load_middleware(self, *args, **kwargs):
+        """Wrap BaseHandler.load_middleware to prepend ServiceEvents middleware."""
+        # Call original load_middleware first
+        original_load_middleware(self, *args, **kwargs)
+
+        # Now inject our middleware into settings.MIDDLEWARE
+        try:
+            # Lazy import: defer optional heavy dependency (Django) until install time.
+            # pylint: disable=import-outside-toplevel
+            from django.conf import settings
+
+            middleware_list = list(getattr(settings, "MIDDLEWARE", []))
+
+            if _SERVICE_EVENTS_MIDDLEWARE_PATH not in middleware_list:
+                # Prepend to beginning (outermost middleware)
+                middleware_list.insert(0, _SERVICE_EVENTS_MIDDLEWARE_PATH)
+                settings.MIDDLEWARE = middleware_list
+
+                # Reload middleware to pick up our addition
+                original_load_middleware(self, *args, **kwargs)
+
+                logger.info("ServiceEvents Django middleware prepended to settings.MIDDLEWARE")
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.error("Error injecting ServiceEvents Django middleware: %s", exc, exc_info=True)
+
+    # Replace BaseHandler.load_middleware with instrumented version
+    BaseHandler.load_middleware = instrumented_load_middleware
+
+    logger.info("ServiceEvents Django instrumentation installed")

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/instrumentation/django_instrumentation.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/instrumentation/django_instrumentation.py
@@ -414,10 +414,10 @@ def install_django_hooks(endpoint_collector=None, incident_snapshot_collector=No
 
     def instrumented_load_middleware(self, *args, **kwargs):
         """Wrap BaseHandler.load_middleware to prepend ServiceEvents middleware."""
-        # Call original load_middleware first
-        original_load_middleware(self, *args, **kwargs)
-
-        # Now inject our middleware into settings.MIDDLEWARE
+        # Inject our middleware into settings.MIDDLEWARE BEFORE building the stack so the
+        # stack is built exactly once. load_middleware re-instantiates every middleware on
+        # each call, so a second call would double-init every third-party middleware on
+        # first startup (duplicate signal handlers, threads, connections, etc.).
         try:
             # Lazy import: defer optional heavy dependency (Django) until install time.
             # pylint: disable=import-outside-toplevel
@@ -430,12 +430,14 @@ def install_django_hooks(endpoint_collector=None, incident_snapshot_collector=No
                 middleware_list.insert(0, _SERVICE_EVENTS_MIDDLEWARE_PATH)
                 settings.MIDDLEWARE = middleware_list
 
-                # Reload middleware to pick up our addition
-                original_load_middleware(self, *args, **kwargs)
-
                 logger.info("ServiceEvents Django middleware prepended to settings.MIDDLEWARE")
         except Exception as exc:  # pylint: disable=broad-exception-caught
             logger.error("Error injecting ServiceEvents Django middleware: %s", exc, exc_info=True)
+
+        # Build the middleware stack exactly once, now that settings.MIDDLEWARE includes ours.
+        # Called unconditionally so handler init still builds a chain when SE middleware was
+        # already present (e.g. pre-configured in user settings) or when injection failed.
+        original_load_middleware(self, *args, **kwargs)
 
     # Replace BaseHandler.load_middleware with instrumented version
     BaseHandler.load_middleware = instrumented_load_middleware

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/instrumentation/django_instrumentation.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/instrumentation/django_instrumentation.py
@@ -17,6 +17,7 @@ import logging
 import time
 from typing import Any, Optional
 
+from amazon.opentelemetry.distro.serviceevents.instrumentation._constants import UNMATCHED_ROUTE
 from amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation import (
     _extract_error_from_call_path,
 )
@@ -33,12 +34,9 @@ _endpoint_collector = None
 _incident_snapshot_collector = None
 _serviceevents_config = None
 
-# Route label for requests that matched no urlpattern. Django only calls process_view
-# after a URL resolves to a view, so an unmatched 404 never gets a route stored. Recording
-# the raw path for these would make every probed URL (/wp-admin, /.env, scanner noise) its
-# own metric series — a cardinality explosion. Collapsing to one sentinel keeps the
-# 404-rate signal without the cardinality. See _finalize_request.
-_UNMATCHED_ROUTE = "<unmatched>"
+# Django only calls process_view after a URL resolves to a view, so an unmatched 404 never
+# gets a route stored and _finalize_request falls back to the shared UNMATCHED_ROUTE sentinel
+# (see _constants for why the raw path is not used).
 
 
 def _get_request_body(request) -> Optional[Any]:
@@ -165,7 +163,7 @@ def _finalize_request(request, response, exception):  # pylint: disable=too-many
         # path so scanner/bot traffic to nonexistent URLs can't explode metric cardinality.
         route = getattr(request, "_serviceevents_route", None)
         if route is None:
-            route = _UNMATCHED_ROUTE
+            route = UNMATCHED_ROUTE
         method = getattr(request, "_serviceevents_method", request.method)
 
         # Extract error info if error occurred
@@ -220,6 +218,11 @@ def _finalize_request(request, response, exception):  # pylint: disable=too-many
     finally:
         # Always clear operation context, even if there's an error
         clear_current_operation()
+        # Drop request-scoped investigation data. The incident path clears it via
+        # get_investigation_data(), but the normal path returns early and never does, so
+        # clear it unconditionally here to avoid leaking a stale dict (and any captured
+        # traceback) onto pooled worker threads.
+        _ServiceEventsMonitorState.get_instance().clear_investigation_data()
 
 
 class ServiceEventsDjangoMiddleware:
@@ -413,31 +416,52 @@ def install_django_hooks(endpoint_collector=None, incident_snapshot_collector=No
     original_load_middleware = BaseHandler.load_middleware
 
     def instrumented_load_middleware(self, *args, **kwargs):
-        """Wrap BaseHandler.load_middleware to prepend ServiceEvents middleware."""
-        # Inject our middleware into settings.MIDDLEWARE BEFORE building the stack so the
-        # stack is built exactly once. load_middleware re-instantiates every middleware on
-        # each call, so a second call would double-init every third-party middleware on
-        # first startup (duplicate signal handlers, threads, connections, etc.).
+        """Wrap BaseHandler.load_middleware to prepend ServiceEvents middleware for the build.
+
+        Django reads settings.MIDDLEWARE only here, to materialize the middleware chain (and
+        register each middleware's process_view/process_exception hooks) into the handler; it
+        does not consult settings.MIDDLEWARE again per request. So we prepend our path at the
+        front for the duration of this single build, then restore the customer's original
+        MIDDLEWARE in the finally. Net result: ServiceEvents is wired outermost, but
+        settings.MIDDLEWARE is left exactly as the customer defined it — no persistent global
+        side effect for code/introspection that reads it, and apps that validate/freeze
+        settings post-build aren't tripped.
+
+        The stack is still built exactly once. load_middleware re-instantiates every
+        middleware on each call, so a second build would double-init every third-party
+        middleware on first startup (duplicate signal handlers, threads, connections, etc.).
+        """
+        settings = None
+        original_middleware = None
+        injected = False
         try:
             # Lazy import: defer optional heavy dependency (Django) until install time.
             # pylint: disable=import-outside-toplevel
-            from django.conf import settings
+            from django.conf import settings  # pylint: disable=redefined-outer-name
 
-            middleware_list = list(getattr(settings, "MIDDLEWARE", []))
-
-            if _SERVICE_EVENTS_MIDDLEWARE_PATH not in middleware_list:
-                # Prepend to beginning (outermost middleware)
-                middleware_list.insert(0, _SERVICE_EVENTS_MIDDLEWARE_PATH)
-                settings.MIDDLEWARE = middleware_list
-
-                logger.info("ServiceEvents Django middleware prepended to settings.MIDDLEWARE")
+            original_middleware = list(getattr(settings, "MIDDLEWARE", []) or [])
+            if _SERVICE_EVENTS_MIDDLEWARE_PATH not in original_middleware:
+                # Prepend to the front (outermost) just for this build.
+                settings.MIDDLEWARE = [_SERVICE_EVENTS_MIDDLEWARE_PATH, *original_middleware]
+                injected = True
+                logger.info("ServiceEvents Django middleware injected for the middleware-stack build")
         except Exception as exc:  # pylint: disable=broad-exception-caught
             logger.error("Error injecting ServiceEvents Django middleware: %s", exc, exc_info=True)
 
-        # Build the middleware stack exactly once, now that settings.MIDDLEWARE includes ours.
-        # Called unconditionally so handler init still builds a chain when SE middleware was
-        # already present (e.g. pre-configured in user settings) or when injection failed.
-        original_load_middleware(self, *args, **kwargs)
+        try:
+            # Build the middleware stack exactly once, now that settings.MIDDLEWARE includes ours.
+            # Called unconditionally so the handler still builds a chain when SE middleware was
+            # already present (e.g. pre-configured in user settings) or when injection failed.
+            original_load_middleware(self, *args, **kwargs)
+        finally:
+            # Restore the customer's MIDDLEWARE so our injection leaves no persistent global
+            # change. Only when we actually injected; the chain is already materialized above,
+            # so removing our entry from settings here does not unwire the middleware.
+            if injected and settings is not None:
+                try:
+                    settings.MIDDLEWARE = original_middleware
+                except Exception:  # pylint: disable=broad-exception-caught
+                    logger.debug("Failed to restore settings.MIDDLEWARE after ServiceEvents injection", exc_info=True)
 
     # Replace BaseHandler.load_middleware with instrumented version
     BaseHandler.load_middleware = instrumented_load_middleware

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/instrumentation/fastapi_instrumentation.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/instrumentation/fastapi_instrumentation.py
@@ -1,0 +1,434 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+FastAPI instrumentation for ServiceEvents EndpointMetric and IncidentSnapshot events.
+
+This module installs hooks into FastAPI applications to:
+- Track endpoint metrics (requests, duration, status codes)
+- Trigger incident snapshots on errors or slow requests
+- Propagate endpoint context to function monitors
+
+Note: FastAPI is async/ASGI-based, so this uses middleware instead of decorators.
+"""
+
+import logging
+import time
+from typing import Any, Dict, Optional
+from urllib.parse import parse_qs
+
+from amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation import (
+    _capture_active_trace_context,
+    _extract_error_from_call_path,
+)
+from amazon.opentelemetry.distro.serviceevents.python_monitor import (
+    _ServiceEventsMonitorState,
+    clear_current_operation,
+    set_current_operation,
+)
+
+logger = logging.getLogger(__name__)
+
+# Global reference to collectors and config (set during initialization)
+_endpoint_collector = None
+_incident_snapshot_collector = None
+_serviceevents_config = None
+
+
+async def _get_request_body(request) -> Optional[Any]:
+    """
+    Safely extract request body from FastAPI request with fallback chain.
+
+    Note: This is async because FastAPI body reading is async.
+    The body is cached after first read, so this is safe to call multiple times.
+
+    Args:
+        request: FastAPI Request object
+
+    Returns:
+        Request body as JSON dict, form dict, raw string, or None
+    """
+    try:
+        # Try JSON first (most common for APIs)
+        body = await request.json()
+        if body is not None:
+            return body
+    except Exception:  # pylint: disable=broad-exception-caught
+        pass
+
+    try:
+        # Try form data
+        form = await request.form()
+        if form:
+            return dict(form)
+    except Exception:  # pylint: disable=broad-exception-caught
+        pass
+
+    try:
+        # Try raw data (with 10KB limit)
+        data = await request.body()
+        if data:
+            if len(data) <= 10240:  # 10KB limit
+                return data.decode("utf-8", errors="replace")
+            return f"<payload too large: {len(data)} bytes>"
+    except Exception:  # pylint: disable=broad-exception-caught
+        pass
+
+    return None
+
+
+def _get_route_pattern(scope) -> str:
+    """
+    Get the route pattern (e.g. /users/{id}) from the ASGI scope.
+
+    Args:
+        scope: ASGI scope dictionary
+
+    Returns:
+        Route pattern string (e.g., "/api/users/{id}")
+    """
+    # Try to get the route pattern from the scope
+    route = scope.get("route")
+    if route and hasattr(route, "path"):
+        return route.path  # e.g., "/api/users/{id}"
+
+    # Not yet routed: try to pre-resolve the template against the app's routes.
+    resolved = _resolve_route_template(scope)
+    if resolved is not None:
+        return resolved
+
+    # Fallback to path
+    return scope.get("path", "/unknown")
+
+
+def _resolve_route_template(scope) -> Optional[str]:
+    """Pre-resolve the matching route template before Starlette routing runs.
+
+    At middleware entry ``scope["route"]`` is unset (routing happens inside the inner
+    app), so the raw URL path is all that's available. But the per-request *operation*
+    (used for adaptive hot-endpoint sampling and incident correlation) and the endpoint
+    aggregation are both keyed on the route *template* (e.g. ``/users/{id}``). Without
+    resolving the template here, every distinct param value (``/users/1``, ``/users/2``)
+    would be a different operation, so adaptive sampling — which marks the *template*
+    hot — would never match, and FunctionCall sampling for param routes would silently
+    stay off.
+
+    Starlette sets ``scope["app"]`` before the middleware stack runs, so its routes are
+    available. We match the scope against them (the same matching the router does moments
+    later) and return the matched template, or None if nothing matches / anything goes
+    wrong. Crash-safety: telemetry must never break the request, so this is fully guarded.
+    """
+    try:
+        app = scope.get("app")
+        routes = getattr(app, "routes", None)
+        if not routes:
+            return None
+        # Lazy import: Starlette is an optional dependency, resolved on the request path.
+        from starlette.routing import Match  # pylint: disable=import-outside-toplevel
+
+        for route in routes:
+            matches = getattr(route, "matches", None)
+            path = getattr(route, "path", None)
+            if matches is None or path is None:
+                continue
+            match, _child_scope = matches(scope)
+            if match == Match.FULL:
+                return path
+    except Exception:  # pylint: disable=broad-exception-caught
+        return None
+    return None
+
+
+def _parse_query_string(query_string: bytes) -> Dict:
+    """
+    Parse ASGI query string bytes into a dictionary.
+
+    Args:
+        query_string: Raw query string bytes from scope
+
+    Returns:
+        Dictionary of query parameters
+    """
+    if not query_string:
+        return {}
+
+    try:
+        # parse_qs returns lists as values, flatten to single values
+        parsed = parse_qs(query_string.decode("utf-8"))
+        return {k: v[0] if len(v) == 1 else v for k, v in parsed.items()}
+    except Exception:  # pylint: disable=broad-exception-caught
+        return {}
+
+
+class ServiceEventsFastAPIMiddleware:
+    """
+    ASGI middleware for FastAPI instrumentation.
+
+    This middleware:
+    1. Tracks request timing and status codes
+    2. Captures request body for incident snapshots
+    3. Records endpoint metrics
+    4. Triggers incident snapshots on errors/slow requests
+    5. Propagates endpoint context to function monitors
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+    async def __call__(self, scope, receive, send):
+        """ASGI middleware entry point."""
+        # Only instrument HTTP requests
+        if scope["type"] != "http":
+            return await self.app(scope, receive, send)
+
+        # Before request: capture timing and route info
+        method = scope["method"]
+        path = scope["path"]
+        route = _get_route_pattern(scope)
+
+        # Check endpoint filter - skip tracking if endpoint is filtered out
+        if _serviceevents_config and not _serviceevents_config.should_track_endpoint(route, method):
+            return await self.app(scope, receive, send)
+
+        # Track this endpoint.
+        # Crash-safety: this pre-await setup runs on the request path before the
+        # app is invoked. A telemetry failure here must not stop the request, so
+        # the whole block is guarded; on failure we run the app plainly (with the
+        # original unwrapped receive/send) and emit no telemetry for this request.
+        try:
+            start_time = time.perf_counter_ns()
+
+            # Set operation context for function monitors
+            operation = f"{method} {route}"
+            set_current_operation(operation)
+
+            # Begin investigation tracking for this request
+            monitor_state = _ServiceEventsMonitorState.get_instance()
+            monitor_state.begin_investigation()
+        except Exception:  # pylint: disable=broad-exception-caught
+            return await self.app(scope, receive, send)
+
+        # Cache request body for incident snapshots
+        # This reads and stores the body so it can be accessed later
+        body_bytes = b""
+        body_received = False
+
+        async def receive_wrapper():
+            """Intercept receive to cache request body.
+
+            Crash-safety: this sits in the customer's ASGI receive chain, so the
+            message must always be returned even if body caching fails.
+            """
+            nonlocal body_bytes, body_received
+            message = await receive()
+
+            try:
+                if message["type"] == "http.request":
+                    chunk = message.get("body", b"")
+                    if chunk:
+                        # Respect 10KB limit for body caching
+                        if len(body_bytes) + len(chunk) <= 10240:
+                            body_bytes += chunk
+                    body_received = message.get("more_body", False) is False
+            except Exception:  # pylint: disable=broad-exception-caught
+                pass
+
+            return message
+
+        # Track status code and exception
+        status_code = 200
+        exception = None
+        response_started = False
+        # Pre-captured trace correlation (captured while span is active)
+        captured_trace_id = None
+        captured_span_id = None
+
+        async def send_wrapper(message):
+            """Intercept send to capture response status code and trace correlation."""
+            nonlocal status_code, response_started, captured_trace_id, captured_span_id
+
+            if message["type"] == "http.response.start":
+                status_code = message.get("status", 200)
+                response_started = True
+
+                # Capture trace_id and span_id NOW while span is still active
+                # By the time we reach the finally block, the OTel span context will be cleared
+                trace_id, span_id = _capture_active_trace_context()
+                if trace_id is not None:
+                    captured_trace_id = trace_id
+                    captured_span_id = span_id
+
+            await send(message)
+
+        try:
+            # Call the app with wrapped receive/send
+            await self.app(scope, receive_wrapper, send_wrapper)
+        except Exception as exc:
+            exception = exc
+            status_code = 500
+
+            # If response hasn't started, send a 500 error response
+            if not response_started:
+                await send(
+                    {
+                        "type": "http.response.start",
+                        "status": 500,
+                        "headers": [(b"content-type", b"text/plain")],
+                    }
+                )
+                await send(
+                    {
+                        "type": "http.response.body",
+                        "body": b"Internal Server Error",
+                    }
+                )
+
+            # Re-raise to maintain error propagation
+            raise
+        finally:
+            # After request: record metrics and check for incidents
+            end_time = time.perf_counter_ns()
+            duration_ns = end_time - start_time
+            duration_ms = duration_ns / 1_000_000
+
+            # Re-resolve the route now that the app has run. At middleware entry
+            # scope["route"] is unset, so `route` held the raw URL path (e.g.
+            # /users/42). Starlette/FastAPI routing populates scope["route"] in place
+            # during dispatch, so by here it resolves to the template (/users/{id}).
+            # Use the template for the exported endpoint telemetry below to avoid a
+            # per-URL metric cardinality explosion. (The pre-await operation context
+            # can't see the template yet — routing hasn't happened — so the FunctionCall
+            # dimension keeps the entry-time value.)
+            route = _get_route_pattern(scope)
+
+            # Fallback trace correlation for the error path: send_wrapper captures
+            # trace_id/span_id at http.response.start, but an unhandled exception never
+            # starts a response, so nothing is captured there. If the OTel server span is
+            # still active here (depends on middleware nesting order), recover it so
+            # IncidentSnapshot stays joinable on the error path.
+            if captured_trace_id is None:
+                trace_id, span_id = _capture_active_trace_context()
+                if trace_id is not None:
+                    captured_trace_id = trace_id
+                    captured_span_id = span_id
+
+            # Extract error info if error occurred
+            error_info = None
+            if status_code >= 400:
+                try:
+                    error_info = _extract_error_from_call_path(exception, route, method)
+                except Exception:  # pylint: disable=broad-exception-caught
+                    logger.debug("Error extracting error info from call path", exc_info=True)
+
+            # Record endpoint metric
+            if _endpoint_collector:
+                try:
+                    _endpoint_collector.record_request(
+                        route=route,
+                        method=method,
+                        status_code=status_code,
+                        duration_ns=duration_ns,
+                        error_info=error_info,
+                    )
+                except Exception as exc:  # pylint: disable=broad-exception-caught
+                    logger.error("Error recording endpoint metric: %s", exc, exc_info=True)
+
+            # Check if incident snapshot should be triggered
+            if _incident_snapshot_collector:
+                try:
+                    # Parse headers
+                    headers_dict = {
+                        k.decode("utf-8", errors="replace"): v.decode("utf-8", errors="replace")
+                        for k, v in scope.get("headers", [])
+                    }
+
+                    # Parse query parameters
+                    query_params = _parse_query_string(scope.get("query_string", b""))
+
+                    # Path parameters
+                    path_params = scope.get("path_params", {})
+
+                    # Parse cached body (if any)
+                    cached_body = None
+                    if body_bytes:
+                        try:
+                            # Try to decode as UTF-8
+                            cached_body = body_bytes.decode("utf-8", errors="replace")
+                        except Exception:  # pylint: disable=broad-exception-caught
+                            cached_body = f"<binary data: {len(body_bytes)} bytes>"
+
+                    exemplar = _incident_snapshot_collector.process_potential_incident(
+                        route=route,
+                        method=method,
+                        status_code=status_code,
+                        duration_ms=duration_ms,
+                        exception=exception,
+                        request_data={
+                            "path": path,
+                            "endpoint": route,  # FastAPI doesn't have separate endpoint name
+                            "method": method,
+                            "headers": headers_dict,
+                            "args": query_params,  # Query parameters
+                            "view_args": path_params,  # Path parameters
+                            "cached_body": cached_body,  # Pre-read body
+                            # Pre-captured trace correlation (captured in send_wrapper while span was active)
+                            "trace_id": captured_trace_id,
+                            "span_id": captured_span_id,
+                        },
+                    )
+                    if exemplar and _endpoint_collector:
+                        _endpoint_collector.record_incident_exemplar(exemplar["operation"], exemplar)
+                except Exception as exc:  # pylint: disable=broad-exception-caught
+                    logger.error("Error processing incident snapshot: %s", exc, exc_info=True)
+
+            # Always clear operation context
+            clear_current_operation()
+
+
+def install_fastapi_hooks(endpoint_collector=None, incident_snapshot_collector=None, config=None):
+    """
+    Install FastAPI instrumentation hooks.
+
+    This monkey-patches FastAPI.__init__ to automatically add ServiceEvents middleware
+    to all FastAPI application instances.
+
+    Args:
+        endpoint_collector: EndpointMetricCollector instance
+        incident_snapshot_collector: IncidentSnapshotCollector instance
+        config: ServiceEventsConfig instance for endpoint filtering
+    """
+    # global-statement: module-level singletons set once during instrumentation install.
+    # pylint: disable=global-statement
+    global _endpoint_collector, _incident_snapshot_collector, _serviceevents_config
+
+    try:
+        # Lazy import: defer optional heavy dependency (FastAPI) until install time.
+        # pylint: disable=import-outside-toplevel
+        from fastapi import FastAPI
+    except ImportError:
+        logger.warning("FastAPI not installed, skipping FastAPI instrumentation")
+        return
+
+    _endpoint_collector = endpoint_collector
+    _incident_snapshot_collector = incident_snapshot_collector
+    _serviceevents_config = config
+
+    # Store original FastAPI.__init__ to wrap it
+    original_init = FastAPI.__init__
+
+    def instrumented_init(self, *args, **kwargs):
+        """Wrap FastAPI.__init__ to install middleware after app creation."""
+        # Call original init
+        original_init(self, *args, **kwargs)
+
+        # Add ServiceEvents middleware to the FastAPI app
+        # Note: Middleware is added first so it wraps all other middleware
+        self.add_middleware(ServiceEventsFastAPIMiddleware)
+
+        logger.info("ServiceEvents FastAPI hooks installed on app: %s", self.title)
+
+    # Replace FastAPI.__init__ with instrumented version
+    FastAPI.__init__ = instrumented_init
+
+    logger.info("ServiceEvents FastAPI instrumentation installed")

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/instrumentation/fastapi_instrumentation.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/instrumentation/fastapi_instrumentation.py
@@ -270,21 +270,29 @@ class ServiceEventsFastAPIMiddleware:
             exception = exc
             status_code = 500
 
-            # If response hasn't started, send a 500 error response
+            # If response hasn't started, send a 500 error response. Crash-safety: these
+            # sends are best-effort and guarded — if send() itself raises (client
+            # disconnect, broken pipe, ASGI shutdown mid-error), that must NOT replace the
+            # original application exception, so the failure is swallowed and the original
+            # exc still propagates via the bare `raise` below. Telemetry must never alter
+            # which exception the host application sees.
             if not response_started:
-                await send(
-                    {
-                        "type": "http.response.start",
-                        "status": 500,
-                        "headers": [(b"content-type", b"text/plain")],
-                    }
-                )
-                await send(
-                    {
-                        "type": "http.response.body",
-                        "body": b"Internal Server Error",
-                    }
-                )
+                try:
+                    await send(
+                        {
+                            "type": "http.response.start",
+                            "status": 500,
+                            "headers": [(b"content-type", b"text/plain")],
+                        }
+                    )
+                    await send(
+                        {
+                            "type": "http.response.body",
+                            "body": b"Internal Server Error",
+                        }
+                    )
+                except Exception:  # pylint: disable=broad-exception-caught
+                    pass
 
             # Re-raise to maintain error propagation
             raise

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/instrumentation/fastapi_instrumentation.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/instrumentation/fastapi_instrumentation.py
@@ -419,14 +419,31 @@ def install_fastapi_hooks(endpoint_collector=None, incident_snapshot_collector=N
 
     def instrumented_init(self, *args, **kwargs):
         """Wrap FastAPI.__init__ to install middleware after app creation."""
-        # Call original init
+        # Call original init first and outside the guard below: this is the real
+        # FastAPI constructor and must always run. Only OUR added work is guarded,
+        # so a telemetry failure can never break FastAPI app construction.
         original_init(self, *args, **kwargs)
 
-        # Add ServiceEvents middleware to the FastAPI app
-        # Note: Middleware is added first so it wraps all other middleware
-        self.add_middleware(ServiceEventsFastAPIMiddleware)
+        # Crash-safety: telemetry must never break the host app. Installing the
+        # middleware runs inside the customer's FastAPI.__init__, so any failure
+        # here is swallowed and the app is constructed as if uninstrumented.
+        try:
+            # Add ServiceEvents middleware to the FastAPI app.
+            # Known limitation: middleware is installed during FastAPI.__init__, the
+            # earliest possible point. Under Starlette's add_middleware semantics
+            # (insert(0, ...) + reversed-wrap when the stack is built), the last
+            # middleware added becomes the OUTERMOST. So any user middleware added
+            # after construction wraps ours, leaving ServiceEvents INNERMOST relative
+            # to user middleware. Consequence: end-to-end duration may exclude time
+            # spent in outer user middleware, and status/response changes made by
+            # outer user middleware are not observed. We do not rework this to be
+            # outermost because doing so reliably requires framework-internal hooks
+            # that are version-fragile.
+            self.add_middleware(ServiceEventsFastAPIMiddleware)
 
-        logger.info("ServiceEvents FastAPI hooks installed on app: %s", self.title)
+            logger.info("ServiceEvents FastAPI hooks installed on app: %s", self.title)
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.debug("Failed to install ServiceEvents FastAPI middleware", exc_info=True)
 
     # Replace FastAPI.__init__ with instrumented version
     FastAPI.__init__ = instrumented_init

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/instrumentation/fastapi_instrumentation.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/instrumentation/fastapi_instrumentation.py
@@ -17,6 +17,7 @@ import time
 from typing import Any, Dict, Optional
 from urllib.parse import parse_qs
 
+from amazon.opentelemetry.distro.serviceevents.instrumentation._constants import UNMATCHED_ROUTE
 from amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation import (
     _capture_active_trace_context,
     _extract_error_from_call_path,
@@ -97,8 +98,9 @@ def _get_route_pattern(scope) -> str:
     if resolved is not None:
         return resolved
 
-    # Fallback to path
-    return scope.get("path", "/unknown")
+    # No route matched (404 / scanner traffic). Collapse to a single sentinel rather than
+    # the raw path so probed URLs can't explode metric cardinality. Matches Flask/Django.
+    return UNMATCHED_ROUTE
 
 
 def _resolve_route_template(scope) -> Optional[str]:
@@ -293,9 +295,10 @@ class ServiceEventsFastAPIMiddleware:
             duration_ms = duration_ns / 1_000_000
 
             # Re-resolve the route now that the app has run. At middleware entry
-            # scope["route"] is unset, so `route` held the raw URL path (e.g.
-            # /users/42). Starlette/FastAPI routing populates scope["route"] in place
-            # during dispatch, so by here it resolves to the template (/users/{id}).
+            # scope["route"] is unset, so `route` was whatever _get_route_pattern could
+            # determine pre-routing: a pre-resolved template, or the <unmatched> sentinel
+            # when nothing matched. Starlette/FastAPI routing populates scope["route"] in
+            # place during dispatch, so by here it resolves to the template (/users/{id}).
             # Use the template for the exported endpoint telemetry below to avoid a
             # per-URL metric cardinality explosion. (The pre-await operation context
             # can't see the template yet — routing hasn't happened — so the FunctionCall
@@ -384,6 +387,11 @@ class ServiceEventsFastAPIMiddleware:
 
             # Always clear operation context
             clear_current_operation()
+            # Drop request-scoped investigation data. The incident path clears it via
+            # get_investigation_data(), but the normal path returns early and never does, so
+            # clear it unconditionally here to avoid leaking a stale dict (and any captured
+            # traceback) onto pooled worker threads.
+            _ServiceEventsMonitorState.get_instance().clear_investigation_data()
 
 
 def install_fastapi_hooks(endpoint_collector=None, incident_snapshot_collector=None, config=None):

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/instrumentation/flask_instrumentation.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/instrumentation/flask_instrumentation.py
@@ -1,0 +1,397 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Flask instrumentation for ServiceEvents EndpointMetric and IncidentSnapshot events.
+
+This module installs hooks into Flask applications to:
+- Track endpoint metrics (requests, duration, status codes)
+- Trigger incident snapshots on errors or slow requests
+- Propagate endpoint context to function monitors
+"""
+
+import logging
+import time
+from typing import Any, Dict, Optional
+
+from amazon.opentelemetry.distro.serviceevents.instrumentation._safety import never_raises
+from amazon.opentelemetry.distro.serviceevents.python_monitor import (
+    _ServiceEventsMonitorState,
+    clear_current_operation,
+    set_current_operation,
+)
+
+logger = logging.getLogger(__name__)
+
+# Global reference to collectors and config (set during initialization)
+_endpoint_collector = None
+_incident_snapshot_collector = None
+_serviceevents_config = None
+
+
+def _get_request_body(request) -> Optional[Any]:
+    """
+    Safely extract request body from Flask request with fallback chain.
+
+    Flask caches these values after first access, so reading is cheap if
+    the application code has already accessed the request body.
+
+    Args:
+        request: Flask request object
+
+    Returns:
+        Request body as JSON dict, form dict, raw string, or None
+    """
+    try:
+        # Try JSON first (most common for APIs)
+        body = request.get_json()
+        if body is not None:
+            return body
+    # Telemetry must never crash the host app; any body-read failure is non-fatal.
+    except Exception:  # pylint: disable=broad-exception-caught
+        pass
+
+    try:
+        # Try form data
+        if request.form:
+            return request.form.to_dict()
+    # Telemetry must never crash the host app; any body-read failure is non-fatal.
+    except Exception:  # pylint: disable=broad-exception-caught
+        pass
+
+    try:
+        # Try raw data (with 10KB limit)
+        data = request.get_data()
+        if data:
+            if len(data) <= 10240:  # 10KB limit
+                return data.decode("utf-8", errors="replace")
+            return f"<payload too large: {len(data)} bytes>"
+    # Telemetry must never crash the host app; any body-read failure is non-fatal.
+    except Exception:  # pylint: disable=broad-exception-caught
+        pass
+
+    return None
+
+
+def install_flask_hooks(endpoint_collector=None, incident_snapshot_collector=None, config=None):
+    """
+    Install Flask instrumentation hooks.
+
+    Args:
+        endpoint_collector: EndpointMetricCollector instance
+        incident_snapshot_collector: IncidentSnapshotCollector instance
+        config: ServiceEventsConfig instance for endpoint filtering
+    """
+    # Singleton instrumentation state shared across Flask request hooks.
+    # pylint: disable-next=global-statement
+    global _endpoint_collector, _incident_snapshot_collector, _serviceevents_config
+
+    # Lazy import: flask is an optional heavy dependency, imported only when hooks install.
+    try:
+        from flask import Flask  # pylint: disable=import-outside-toplevel
+    except ImportError:
+        logger.warning("Flask not installed, skipping Flask instrumentation")
+        return
+
+    _endpoint_collector = endpoint_collector
+    _incident_snapshot_collector = incident_snapshot_collector
+    _serviceevents_config = config
+
+    # Store original Flask.__init__ to wrap it
+    original_init = Flask.__init__
+
+    def instrumented_init(self, *args, **kwargs):
+        """Wrap Flask.__init__ to install hooks after app creation."""
+        # Call original init
+        original_init(self, *args, **kwargs)
+
+        # Install before_request and after_request hooks
+        self.before_request(_before_request_hook)
+        self.after_request(_after_request_hook)
+        self.teardown_request(_teardown_request_hook)
+
+        logger.info("ServiceEvents Flask hooks installed on app: %s", self.name)
+
+    # Replace Flask.__init__ with instrumented version
+    Flask.__init__ = instrumented_init
+
+    logger.info("ServiceEvents Flask instrumentation installed")
+
+
+@never_raises()
+def _before_request_hook():
+    """Hook called before each request.
+
+    Guarded by @never_raises: a telemetry failure here must not turn into a 500
+    before the customer's view runs. On failure the request proceeds untracked.
+    """
+    # Lazy import: flask is an optional heavy dependency, resolved at request time.
+    from flask import g, request  # pylint: disable=import-outside-toplevel
+
+    # Store request info for later
+    g.serviceevents_method = request.method
+    g.serviceevents_path = request.path
+    g.serviceevents_endpoint = request.endpoint or "unknown"
+    g.serviceevents_route = _get_route_pattern(request)
+
+    # Check endpoint filter - skip tracking if endpoint is filtered out
+    if _serviceevents_config and not _serviceevents_config.should_track_endpoint(
+        g.serviceevents_route, g.serviceevents_method
+    ):
+        g.serviceevents_skip = True
+        return
+
+    # Store request start time (only for tracked endpoints)
+    g.serviceevents_start_time = time.perf_counter_ns()
+    g.serviceevents_skip = False
+
+    # Set operation context for function monitors
+    operation = f"{g.serviceevents_method} {g.serviceevents_route}"
+    set_current_operation(operation)
+    g.serviceevents_operation = operation
+
+    # Begin investigation tracking for this request (always-on mode for incident capture)
+    # This enables call_path capture for potential incident snapshots
+    monitor_state = _ServiceEventsMonitorState.get_instance()
+    monitor_state.begin_investigation()
+
+
+def _after_request_hook(response):
+    """Hook called after each request (before response is sent).
+
+    Crash-safety: the response must always pass through unchanged even if
+    telemetry fails, so the body is guarded and ``return response`` sits outside
+    the try.
+    """
+    # Lazy import: flask is an optional heavy dependency, resolved at request time.
+    from flask import g  # pylint: disable=import-outside-toplevel
+
+    try:
+        # Skip if endpoint is filtered out
+        if getattr(g, "serviceevents_skip", False):
+            return response
+
+        # Calculate duration
+        if hasattr(g, "serviceevents_start_time"):
+            end_time = time.perf_counter_ns()
+            duration_ms = (end_time - g.serviceevents_start_time) / 1_000_000
+
+            # Store in g for teardown hook
+            g.serviceevents_duration_ms = duration_ms
+            g.serviceevents_status_code = response.status_code
+
+        # Capture trace_id and span_id NOW while span is still active
+        # By teardown_request, the OTel span context will have been cleared
+        trace_id, span_id = _capture_active_trace_context()
+        if trace_id is not None:
+            g.serviceevents_trace_id = trace_id
+            g.serviceevents_span_id = span_id
+    # Never let telemetry replace the customer's response with a 500.
+    except Exception:  # pylint: disable=broad-exception-caught
+        pass
+
+    return response
+
+
+def _teardown_request_hook(exception=None):  # pylint: disable=too-many-branches
+    """Hook called at the end of request (even if there's an exception)."""
+    # Lazy import: flask is an optional heavy dependency, resolved at request time.
+    from flask import g, request  # pylint: disable=import-outside-toplevel
+
+    try:
+        # Skip if endpoint is filtered out
+        if getattr(g, "serviceevents_skip", False):
+            return
+
+        # Check if we have the required data
+        if not hasattr(g, "serviceevents_start_time"):
+            return
+
+        # Prevent duplicate incident processing (Flask may call teardown multiple times)
+        if hasattr(g, "serviceevents_incident_processed"):
+            return
+
+        # Fallback trace correlation for the error path. _after_request_hook normally
+        # captures trace_id/span_id, but Flask skips after_request when an unhandled
+        # exception propagates with PROPAGATE_EXCEPTIONS=True (debug/testing). The OTel
+        # server span is still active in teardown, so recover it here if unset — keeps
+        # IncidentSnapshot joinable on the error path.
+        if not hasattr(g, "serviceevents_trace_id"):
+            trace_id, span_id = _capture_active_trace_context()
+            if trace_id is not None:
+                g.serviceevents_trace_id = trace_id
+                g.serviceevents_span_id = span_id
+
+        # Get status code (may be set in after_request or need to infer from exception)
+        status_code = getattr(g, "serviceevents_status_code", None)
+
+        if status_code is None:
+            # Infer from exception
+            if exception is not None:
+                status_code = 500
+            else:
+                status_code = 200  # Default
+
+        # Get duration
+        if not hasattr(g, "serviceevents_duration_ms"):
+            end_time = time.perf_counter_ns()
+            duration_ms = (end_time - g.serviceevents_start_time) / 1_000_000
+        else:
+            duration_ms = g.serviceevents_duration_ms
+
+        # Convert duration to nanoseconds
+        duration_ns = int(duration_ms * 1_000_000)
+
+        # Extract error info if error occurred
+        error_info = None
+        if status_code >= 400:
+            error_info = _extract_error_from_call_path(exception, g.serviceevents_route, g.serviceevents_method)
+
+        # Record endpoint metric
+        if _endpoint_collector:
+            try:
+                _endpoint_collector.record_request(
+                    route=g.serviceevents_route,
+                    method=g.serviceevents_method,
+                    status_code=status_code,
+                    duration_ns=duration_ns,
+                    error_info=error_info,
+                )
+            # Telemetry must never crash the host app; metric recording is best-effort.
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                logger.error("Error recording endpoint metric: %s", exc, exc_info=True)
+
+        # Check if incident snapshot should be triggered
+        if _incident_snapshot_collector:
+            try:
+                exemplar = _incident_snapshot_collector.process_potential_incident(
+                    route=g.serviceevents_route,
+                    method=g.serviceevents_method,
+                    status_code=status_code,
+                    duration_ms=duration_ms,
+                    exception=exception,
+                    request_data={
+                        "path": g.serviceevents_path,
+                        "endpoint": g.serviceevents_endpoint,
+                        "method": g.serviceevents_method,
+                        "headers": dict(request.headers),
+                        "args": dict(request.args),
+                        "view_args": request.view_args,
+                        "flask_request": request,
+                        # Pre-captured trace correlation (captured in after_request while span was active)
+                        "trace_id": getattr(g, "serviceevents_trace_id", None),
+                        "span_id": getattr(g, "serviceevents_span_id", None),
+                    },
+                )
+                if exemplar and _endpoint_collector:
+                    _endpoint_collector.record_incident_exemplar(exemplar["operation"], exemplar)
+                # Mark incident as processed to prevent duplicate snapshots
+                g.serviceevents_incident_processed = True
+            # Telemetry must never crash the host app; snapshot processing is best-effort.
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                logger.error("Error processing incident snapshot: %s", exc, exc_info=True)
+    finally:
+        # Always clear operation context, even if there's an error
+        clear_current_operation()
+
+
+def _capture_active_trace_context():
+    """Return (trace_id, span_id) of the active OTel span, or (None, None).
+
+    Both are raw OTel integers. Returns (None, None) when there is no valid span
+    or the OTel API is unavailable. Telemetry must never crash the host app, so
+    any failure is swallowed.
+    """
+    try:
+        # Lazy import: defer the OTel trace API until span correlation is needed.
+        from opentelemetry import trace  # pylint: disable=import-outside-toplevel
+
+        current_span = trace.get_current_span()
+        if current_span:
+            span_context = current_span.get_span_context()
+            if span_context.is_valid:
+                return span_context.trace_id, span_context.span_id
+    except Exception:  # pylint: disable=broad-exception-caught
+        pass
+    return None, None
+
+
+def _get_route_pattern(request) -> str:
+    """
+    Get the route pattern (e.g. /users/<id>) from the request.
+
+    Args:
+        request: Flask request object
+
+    Returns:
+        Route pattern string (e.g., "/users/<id>")
+    """
+    # Try to get the route pattern from the URL rule
+    if request.url_rule:
+        return request.url_rule.rule
+
+    # Fallback to endpoint name
+    if request.endpoint:
+        return f"/{request.endpoint}"
+
+    # Last resort: use path
+    return request.path
+
+
+def _extract_error_from_call_path(exception, route, method) -> Optional[Dict]:
+    """
+    Extract primary error and origin function_name from investigation data.
+
+    Track LAST/PRIMARY error only (the one that caused the HTTP error status),
+    not all errors from the call path, to avoid noise in telemetry.
+
+    IMPORTANT: This function only READS the investigation data without clearing it,
+    so that it remains available for the incident snapshot collector.
+
+    Args:
+        exception: The exception that was raised (or None)
+        route: Route pattern
+        method: HTTP method
+
+    Returns:
+        Dictionary with {error_type, function_name} or None if no error
+    """
+    # Get investigation data WITHOUT clearing it
+    # Use peek_investigation_data() instead of get_investigation_data()
+    # which would clear the data before incident_snapshot_collector can use it
+    monitor_state = _ServiceEventsMonitorState.get_instance()
+    inv_data = monitor_state.peek_investigation_data()
+
+    # Resolve the error type. Prefer the passed-in exception; otherwise recover the type the
+    # monitor captured. This matters for FastAPI/Starlette: a global exception_handler
+    # converts the error to a 500 response *before* it reaches our middleware, so `exception`
+    # is None there even though a real error occurred — without this recovery the breakdown
+    # would mislabel every such error as "UnknownError".
+    exc_data = inv_data.get("exception") if inv_data else None
+    if exception is not None:
+        error_type = exception.__class__.__name__
+    elif isinstance(exc_data, dict) and exc_data.get("name"):
+        error_type = exc_data["name"]
+    else:
+        error_type = "UnknownError"
+
+    # Find the origin function_name.
+    function_name = "unknown"
+
+    # Prefer the function the monitor recorded as the actual thrower. call_path[0] is the
+    # innermost frame the monitor *entered*, which is not necessarily where the exception
+    # was raised (e.g. it caught-and-reraised, or the deepest frame was uninstrumented), so
+    # the captured exception origin is the authoritative source when present.
+    if isinstance(exc_data, dict) and exc_data.get("function_name"):
+        function_name = exc_data["function_name"]
+
+    # Fall back to the innermost call_path entry when no exception origin was captured.
+    if function_name == "unknown" and inv_data and inv_data.get("call_path"):
+        call_path = inv_data["call_path"]
+        if call_path and len(call_path) > 0:
+            # call_path is ordered from innermost to outermost.
+            first_entry = call_path[0]
+            if isinstance(first_entry, dict):
+                function_name = first_entry.get("function_name", "unknown")
+
+    return {"error_type": error_type, "function_name": function_name}

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/instrumentation/flask_instrumentation.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/instrumentation/flask_instrumentation.py
@@ -14,6 +14,7 @@ import logging
 import time
 from typing import Any, Dict, Optional
 
+from amazon.opentelemetry.distro.serviceevents.instrumentation._constants import UNMATCHED_ROUTE
 from amazon.opentelemetry.distro.serviceevents.instrumentation._safety import never_raises
 from amazon.opentelemetry.distro.serviceevents.python_monitor import (
     _ServiceEventsMonitorState,
@@ -102,15 +103,23 @@ def install_flask_hooks(endpoint_collector=None, incident_snapshot_collector=Non
 
     def instrumented_init(self, *args, **kwargs):
         """Wrap Flask.__init__ to install hooks after app creation."""
-        # Call original init
+        # Call original init first and outside the guard below: this is the real
+        # Flask constructor and must always run. Only OUR added work is guarded,
+        # so a telemetry failure can never break Flask app construction.
         original_init(self, *args, **kwargs)
 
-        # Install before_request and after_request hooks
-        self.before_request(_before_request_hook)
-        self.after_request(_after_request_hook)
-        self.teardown_request(_teardown_request_hook)
+        # Crash-safety: telemetry must never break the host app. Registering the
+        # hooks runs inside the customer's Flask.__init__, so any failure here is
+        # swallowed and the app is constructed as if uninstrumented.
+        try:
+            # Install before_request and after_request hooks
+            self.before_request(_before_request_hook)
+            self.after_request(_after_request_hook)
+            self.teardown_request(_teardown_request_hook)
 
-        logger.info("ServiceEvents Flask hooks installed on app: %s", self.name)
+            logger.info("ServiceEvents Flask hooks installed on app: %s", self.name)
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.debug("Failed to install ServiceEvents Flask hooks", exc_info=True)
 
     # Replace Flask.__init__ with instrumented version
     Flask.__init__ = instrumented_init
@@ -293,6 +302,11 @@ def _teardown_request_hook(exception=None):  # pylint: disable=too-many-branches
     finally:
         # Always clear operation context, even if there's an error
         clear_current_operation()
+        # Drop request-scoped investigation data. The incident path clears it via
+        # get_investigation_data(), but the normal path returns early and never does, so
+        # clear it unconditionally here to avoid leaking a stale dict (and any captured
+        # traceback) onto pooled worker threads. Runs even on the early returns above.
+        _ServiceEventsMonitorState.get_instance().clear_investigation_data()
 
 
 def _capture_active_trace_context():
@@ -330,12 +344,14 @@ def _get_route_pattern(request) -> str:
     if request.url_rule:
         return request.url_rule.rule
 
-    # Fallback to endpoint name
+    # Fallback to endpoint name (still a bounded, registered label)
     if request.endpoint:
         return f"/{request.endpoint}"
 
-    # Last resort: use path
-    return request.path
+    # No url_rule and no endpoint means the URL matched no route (404 / scanner traffic).
+    # Collapse to a single sentinel rather than the raw path so probed URLs can't explode
+    # metric cardinality.
+    return UNMATCHED_ROUTE
 
 
 def _extract_error_from_call_path(exception, route, method) -> Optional[Dict]:

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/models/__init__.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/models/__init__.py
@@ -1,0 +1,60 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Data models for ServiceEvents telemetry events.
+
+This module re-exports all data models from the sub-modules for backward compatibility.
+Existing code can continue to import from `serviceevents.models` without changes.
+"""
+
+# Deployment event telemetry models
+from amazon.opentelemetry.distro.serviceevents.models.deployment_telemetry import (
+    DeploymentContext,
+    DeploymentEventTelemetry,
+)
+
+# Endpoint telemetry models
+from amazon.opentelemetry.distro.serviceevents.models.endpoint_telemetry import (
+    EndpointErrorMetric,
+    EndpointMetricEvent,
+    ErrorBreakdownEntry,
+    ErrorDetail,
+    IncidentExemplar,
+)
+
+# Function call duration model
+from amazon.opentelemetry.distro.serviceevents.models.function_telemetry import DurationMetrics
+
+# Incident snapshot telemetry models
+from amazon.opentelemetry.distro.serviceevents.models.incident_telemetry import (
+    CallPathEntry,
+    ExceptionInfo,
+    IncidentSnapshot,
+    RequestContext,
+    TelemetryCorrelation,
+)
+
+# Resource attributes model
+from amazon.opentelemetry.distro.serviceevents.models.resource_attributes import ResourceAttributes
+
+__all__ = [
+    # Function call duration model
+    "DurationMetrics",
+    "ErrorDetail",
+    "ErrorBreakdownEntry",
+    "IncidentExemplar",
+    "EndpointMetricEvent",
+    "EndpointErrorMetric",
+    # Incident snapshot models
+    "CallPathEntry",
+    "ExceptionInfo",
+    "RequestContext",
+    "TelemetryCorrelation",
+    "IncidentSnapshot",
+    # Deployment event models
+    "DeploymentContext",
+    "DeploymentEventTelemetry",
+    # Resource attributes
+    "ResourceAttributes",
+]

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/models/deployment_telemetry.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/models/deployment_telemetry.py
@@ -114,7 +114,7 @@ class DeploymentEventTelemetry:
         service_name: str = "unknown-service",
         environment: Optional[str] = None,
         instance_id: Optional[str] = None,
-        sdk_version: str = "0.14.2",
+        sdk_version: str = "",
         pid: Optional[int] = None,
         include_deployment_context: bool = True,
         resource_attributes: Optional["ResourceAttributes"] = None,

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/models/deployment_telemetry.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/models/deployment_telemetry.py
@@ -1,0 +1,179 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Data models for DeploymentEvent telemetry.
+
+DeploymentEvent telemetry captures deployment metadata (git commit, CI/CD info)
+for the instrumented service. Emitted once at startup and whenever deployment
+context changes.
+"""
+
+import os
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+if TYPE_CHECKING:
+    from amazon.opentelemetry.distro.serviceevents.models.resource_attributes import ResourceAttributes
+
+
+@dataclass
+class DeploymentContext:
+    """
+    Git repository context for the deployment event.
+
+    Provides traceability from instrumented functions back to source code
+    in version control.
+    """
+
+    # Default to empty (not a sentinel): an unset field is absent, so downstream
+    # emitters omit it rather than shipping a placeholder value onto the wire.
+    git_repo_url: str = ""  # Repository URL (e.g., "https://github.com/org/repo")
+    git_commit_sha: str = ""  # Commit SHA hash
+    deployment_url: str = ""  # CI/CD workflow run URL
+    deployment_timestamp: str = ""  # CI/CD workflow run timestamp
+    deployment_id: str = ""  # CI/CD deployment identifier (e.g., run ID)
+
+    @classmethod
+    def from_environment(cls) -> "DeploymentContext":
+        """
+        Create DeploymentContext from environment variables.
+
+        Reads from standard Git/CI environment variables:
+        - OTEL_AWS_SERVICE_EVENTS_GIT_REPO_URL
+        - OTEL_AWS_SERVICE_EVENTS_GIT_COMMIT_SHA
+        - OTEL_AWS_SERVICE_EVENTS_DEPLOYMENT_URL
+        - OTEL_AWS_SERVICE_EVENTS_DEPLOYMENT_TIMESTAMP
+        - OTEL_AWS_SERVICE_EVENTS_DEPLOYMENT_ID
+        """
+        return cls(
+            git_repo_url=os.getenv("OTEL_AWS_SERVICE_EVENTS_GIT_REPO_URL", ""),
+            git_commit_sha=os.getenv("OTEL_AWS_SERVICE_EVENTS_GIT_COMMIT_SHA", ""),
+            deployment_url=os.getenv("OTEL_AWS_SERVICE_EVENTS_DEPLOYMENT_URL", ""),
+            deployment_timestamp=os.getenv("OTEL_AWS_SERVICE_EVENTS_DEPLOYMENT_TIMESTAMP", ""),
+            deployment_id=os.getenv("OTEL_AWS_SERVICE_EVENTS_DEPLOYMENT_ID", ""),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return asdict(self)
+
+
+@dataclass
+class DeploymentEventTelemetry:
+    """
+    DeploymentEvent telemetry event.
+
+    Captures deployment metadata (git commit, CI/CD info, SDK version) for the
+    instrumented service. Emitted once at startup.
+
+    Example output:
+    {
+        "telemetry_type": "DeploymentEvent",
+        "timestamp": "2026-02-04T00:10:00.000000+00:00",
+        "service_name": "serviceevents-demo",
+        "environment": "prod",
+        "instance_id": "ip-172-31-42-123",
+        "sdk_version": "0.14.2.dev0",
+        "pid": 12956,
+        "deployment_context": {
+            "git_repo_url": "https://github.com/org/repo",
+            "git_commit_sha": "abc123",
+            "deployment_url": "https://github.com/org/repo/actions/runs/12345",
+            "deployment_timestamp": "2026-02-04T00:00:00Z",
+            "deployment_id": "12345"
+        }
+    }
+    """
+
+    # Required fields
+    service_name: str  # Service name from OTEL_SERVICE_NAME
+    environment: Optional[str]  # Deployment environment; None/empty when unset (omitted from output)
+    instance_id: str  # Host/instance identifier (hostname or container ID)
+    sdk_version: str  # ServiceEvents SDK version
+    pid: int  # Process ID
+
+    # Optional fields with defaults
+    telemetry_type: str = "DeploymentEvent"  # Static telemetry type identifier
+    sdk_lang: str = "python"  # SDK language identifier
+    timestamp: str = ""  # ISO 8601 timestamp (set in __post_init__ if empty)
+    deployment_context: Optional[DeploymentContext] = None  # Git repository context
+
+    # AWS platform resource attributes (cloud, host, container, k8s)
+    resource_attributes: Optional["ResourceAttributes"] = None
+
+    def __post_init__(self):
+        """Set timestamp if not provided."""
+        if not self.timestamp:
+            self.timestamp = datetime.now(timezone.utc).isoformat()
+
+    @classmethod
+    def create(
+        cls,
+        service_name: str = "unknown-service",
+        environment: Optional[str] = None,
+        instance_id: Optional[str] = None,
+        sdk_version: str = "0.14.2",
+        pid: Optional[int] = None,
+        include_deployment_context: bool = True,
+        resource_attributes: Optional["ResourceAttributes"] = None,
+    ) -> "DeploymentEventTelemetry":
+        """
+        Create a DeploymentEventTelemetry instance.
+
+        Args:
+            service_name: Service name for the telemetry metadata.
+            environment: Environment name for the telemetry metadata.
+            instance_id: Host/instance identifier (defaults to get_instance_id()).
+            sdk_version: SDK version string.
+            pid: Process ID (defaults to current process).
+            include_deployment_context: Whether to include deployment context from environment.
+            resource_attributes: Optional ResourceAttributes from OTel Resource detectors.
+
+        Returns:
+            DeploymentEventTelemetry instance.
+        """
+        # Lazy import to break the circular dependency between models and utils.
+        from amazon.opentelemetry.distro.serviceevents.utils import (  # pylint: disable=import-outside-toplevel
+            get_instance_id,
+        )
+
+        return cls(
+            service_name=service_name,
+            environment=environment,
+            instance_id=instance_id if instance_id is not None else get_instance_id(),
+            sdk_version=sdk_version,
+            pid=pid if pid is not None else os.getpid(),
+            deployment_context=DeploymentContext.from_environment() if include_deployment_context else None,
+            resource_attributes=resource_attributes,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Convert to dictionary for JSON serialization.
+
+        Returns:
+            Dictionary representation suitable for telemetry export.
+        """
+        result = {
+            "telemetry_type": self.telemetry_type,
+            "sdk_lang": self.sdk_lang,
+            "timestamp": self.timestamp,
+            "service_name": self.service_name,
+            "instance_id": self.instance_id,
+            "sdk_version": self.sdk_version,
+            "pid": self.pid,
+        }
+
+        # Omit environment entirely when unset (no sentinel value)
+        if self.environment:
+            result["environment"] = self.environment
+
+        if self.deployment_context:
+            result["deployment_context"] = self.deployment_context.to_dict()
+
+        if self.resource_attributes is not None and not self.resource_attributes.is_empty():
+            result["resource_attributes"] = self.resource_attributes.to_dict()
+
+        return result

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/models/endpoint_telemetry.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/models/endpoint_telemetry.py
@@ -1,0 +1,184 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Data models for endpoint telemetry.
+
+Defines structured schemas for EndpointMetricEvent that captures
+aggregated HTTP endpoint metrics including error breakdown, duration histograms,
+fault/error counts, and incident exemplars.
+"""
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, List, Optional
+
+from amazon.opentelemetry.distro.serviceevents.models.function_telemetry import DurationMetrics
+
+if TYPE_CHECKING:
+    from amazon.opentelemetry.distro.serviceevents.models.resource_attributes import ResourceAttributes
+
+
+@dataclass
+class ErrorDetail:
+    """
+    Single error detail with type and origin function.
+
+    Links an error type to the specific function where it originated.
+    """
+
+    error_type: str  # Exception class name (e.g., "ValueError", "TimeoutException")
+    function_name: str  # Composite name of function where error originated
+
+
+@dataclass
+class ErrorBreakdownEntry:
+    """
+    Error breakdown entry grouping errors by HTTP status code.
+
+    Represents a specific error pattern (error type + function + status code)
+    and how many times it occurred during the aggregation period.
+
+    Note: Each entry contains ONE primary error (not all errors from call path)
+    to avoid noise in telemetry data.
+    """
+
+    errors: List[ErrorDetail]  # List with single error (primary/last error only)
+    count: int  # Number of occurrences of this error pattern
+    failure_type: str  # HTTP status code as string (e.g., "500", "404")
+
+
+@dataclass
+class IncidentExemplar:
+    """
+    Lightweight reference to an incident snapshot.
+
+    Embedded in EndpointSummary telemetry to link endpoint metrics
+    to incidents that occurred during the collection period.
+    """
+
+    snapshot_id: str  # Links to full IncidentSnapshot for detail lookup
+    trigger_type: str  # "exception", "latency"
+    severity: str  # "critical", "high", "medium", "low"
+    timestamp: int  # Epoch milliseconds when incident occurred
+
+
+@dataclass
+class EndpointMetricEvent:
+    """
+    Endpoint metric telemetry event.
+
+    Represents aggregated metrics for an HTTP endpoint over a collection period,
+    emitted as an EndpointSummary OTLP LogRecord (plus per-error-type counter
+    data points via to_error_type_metrics).
+
+    Example JSON output:
+    {
+      "telemetry_type": "EndpointSummary",
+      "operation": "GET /api/users/profile",
+      "count": 1523,
+      "faults": 5,
+      "errors": 12,
+      "incident_count": 2,
+      "environment": "production",
+      "service_name": "user-service",
+      "instance_id": "ip-172-31-42-123",
+      "sdk_version": "0.14.2",
+      "git_commit_sha": "abc123def456",
+      "deployment_id": "12345",
+      "pid": 23165,
+      "timestamp": "2026-01-21T00:02:37.189806+00:00",
+      "duration": {
+        "Values": [100.5, 200.3],
+        "Counts": [10, 5],
+        "Max": 500.0,
+        "Min": 10.0,
+        "Count": 1523,
+        "Sum": 150000.0
+      },
+      "error_breakdown": [...],
+      "incidents_exemplar": [
+        {"snapshot_id": "snap_abc123", "trigger_type": "exception", "severity": "critical", "timestamp": 1706745600000}
+      ]
+    }
+    """
+
+    # Metadata (non-default fields first)
+    environment: Optional[str]  # Deployment environment; None/empty when unset (omitted from output)
+    service_name: str  # Service name from OTEL_SERVICE_NAME
+    sdk_version: str  # ServiceEvents SDK version
+    instance_id: str  # Host/instance identifier (hostname or container ID)
+
+    # Endpoint Identification
+    operation: str  # HTTP method + route (e.g., "GET /api/users/<id>")
+
+    # Process and Timing
+    pid: int  # Process ID
+    timestamp: str  # ISO 8601 timestamp of collection
+
+    # Core Metrics
+    count: int  # Total number of requests to this endpoint
+
+    # Metadata (default fields)
+    telemetry_type: str = "EndpointSummary"  # Static telemetry type identifier
+    sdk_lang: str = "python"  # SDK language identifier
+    method: Optional[str] = None  # HTTP method (e.g., "GET", "POST")
+    route: Optional[str] = None  # Route pattern (e.g., "/api/users/<id>")
+
+    # Deployment Metadata
+    git_commit_sha: Optional[str] = None  # Git commit SHA from deployment
+    deployment_id: Optional[str] = None  # CI/CD deployment identifier
+
+    faults: int = 0  # Count of HTTP 5xx responses
+    errors: int = 0  # Count of HTTP 4xx responses
+    incident_count: int = 0  # Number of incidents during this collection period
+    error_breakdown: List[ErrorBreakdownEntry] = field(default_factory=list)
+    incidents_exemplar: List[IncidentExemplar] = field(default_factory=list)  # Incident references
+
+    # Duration histogram
+    duration: Optional[DurationMetrics] = None
+
+    # AWS platform resource attributes (cloud, host, container, k8s)
+    resource_attributes: Optional["ResourceAttributes"] = None
+
+    def to_error_type_metrics(self) -> List["EndpointErrorMetric"]:
+        """Generate EndpointErrorMetric instances from error_breakdown.
+
+        Returns:
+            List of EndpointErrorMetric, one per error type. Empty list if no errors.
+        """
+        results = []
+        for entry in self.error_breakdown:
+            for error_detail in entry.errors:
+                results.append(
+                    EndpointErrorMetric(
+                        environment=self.environment,
+                        service_name=self.service_name,
+                        operation=self.operation,
+                        instance_id=self.instance_id,
+                        pid=self.pid,
+                        exception=error_detail.error_type,
+                        count=entry.count,
+                    )
+                )
+        return results
+
+
+@dataclass
+class EndpointErrorMetric:
+    """
+    Per-error-type metric event.
+
+    Each instance represents a single error type observed at an endpoint
+    during a collection period. Emitted as OTel Counter data points via
+    ServiceEventsOtlpEmitter.emit_endpoint_error_metrics.
+    """
+
+    environment: Optional[str]
+    service_name: str
+    operation: str
+    instance_id: str
+    pid: int
+    exception: str
+    count: int
+    telemetry_type: str = "EndpointErrorMetric"
+    sdk_lang: str = "python"  # SDK language identifier

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/models/function_telemetry.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/models/function_telemetry.py
@@ -1,0 +1,32 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Data model for function call duration metrics.
+
+Defines the DurationMetrics schema used for the endpoint telemetry duration
+histogram body.
+"""
+
+from dataclasses import dataclass
+from typing import List, Union
+
+
+@dataclass
+class DurationMetrics:
+    """
+    Duration metrics in EMF histogram format.
+
+    Represents aggregated duration measurements over a collection period.
+    Uses CloudWatch EMF histogram format with Values and Counts arrays.
+
+    Note: Values and Counts can be floats due to SEH (Sparse Exponential Histogram)
+    aggregation which may produce float bucket midpoints and weighted counts.
+    """
+
+    values: List[Union[int, float]]  # Bucket midpoints or duration samples (microseconds)
+    counts: List[Union[int, float]]  # Count for each value (can be weighted floats from SEH)
+    max: Union[int, float]  # Maximum duration (microseconds)
+    min: Union[int, float]  # Minimum duration (microseconds)
+    count: Union[int, float]  # Total number of invocations
+    sum: Union[int, float]  # Sum of all durations (microseconds)

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/models/incident_telemetry.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/models/incident_telemetry.py
@@ -1,0 +1,188 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Data models for incident snapshot telemetry.
+
+Defines structured schemas for IncidentSnapshot events that capture
+comprehensive context when errors, timeouts, or anomalies occur.
+Uses custom JSON format (not CloudWatch EMF).
+"""
+
+from dataclasses import asdict, dataclass, field
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+if TYPE_CHECKING:
+    from amazon.opentelemetry.distro.serviceevents.models.resource_attributes import ResourceAttributes
+
+
+@dataclass
+class CallPathEntry:
+    """
+    Single function call in the execution path.
+
+    Captures timing and caller information for each function invocation
+    during request processing.
+    """
+
+    function_name: str  # Composite function identifier (e.g., "module/path.func")
+    caller_function_name: Optional[str]  # Function that called this one (None if entry point)
+    duration_ns: int  # Duration of function execution in nanoseconds
+    error: bool = False  # True if this function threw the exception
+    is_async: bool = False  # True if this is an async function
+
+
+@dataclass
+class ExceptionInfo:
+    """
+    Exception details with full call path.
+
+    Captures exception type, message, stack trace, and the sequence of
+    function calls that led to the exception.
+    """
+
+    exception_type: str  # Exception class name (e.g., "ValueError")
+    exception_message: str  # Exception message
+    stack_trace: str  # Formatted stack trace as single string
+    call_path: List[CallPathEntry]  # Execution path leading to this exception
+
+
+@dataclass
+class RequestContext:
+    """
+    HTTP request context information.
+
+    Captures details about the HTTP request that triggered the incident,
+    including custom business context and request payload data.
+    """
+
+    type: str  # Request type (e.g., "http")
+    timestamp: int  # Milliseconds since epoch when request started
+    status_code: int  # HTTP status code
+    custom_context: Dict[str, Any] = field(default_factory=dict)  # User-defined context
+
+    # Request payload fields (captured only on incident triggers with lazy loading)
+    request_body: Optional[Any] = None  # Request payload (JSON, form, or raw string)
+    query_params: Optional[Dict[str, Any]] = None  # URL query parameters
+    path_params: Optional[Dict[str, Any]] = None  # URL path parameters
+    request_headers: Optional[Dict[str, str]] = None  # HTTP headers
+
+
+@dataclass
+class TelemetryCorrelation:
+    """
+    APM trace and business correlation identifiers.
+
+    Links incidents to distributed traces, sessions, and business transactions
+    for cross-system correlation.
+    """
+
+    trace_id: Optional[str] = None  # Distributed trace ID (OpenTelemetry, X-Ray, etc.)
+    session_id: Optional[str] = None  # User session identifier
+    span_id: Optional[str] = None  # Span ID within the trace
+    request_id: Optional[str] = None  # Unique request identifier
+    correlation_ids: Optional[Dict[str, str]] = None  # Business IDs
+
+
+@dataclass
+class IncidentSnapshot:
+    """
+    Incident snapshot telemetry event.
+
+    Captures comprehensive context when errors, timeouts, or anomalies occur.
+    Includes execution flow, exception details, request context, and correlation IDs.
+
+    Example JSON output:
+    {
+      "snapshot_id": "snap_7f3e9a2c-4b1d-4e8f-9c5a-2d6b8e4f1a3c",
+      "timestamp": 1706745600000,
+      "severity": "critical",
+      "trigger_type": "exception",
+      "service": "user-service",
+      "environment": "production",
+      "instance_id": "ip-172-31-42-123",
+      "operation": "GET /api/users/profile",
+      "sdk_version": "0.14.2",
+      "git_commit_sha": "abc123def456",
+      "deployment_id": "12345",
+      "pid": 25464,
+      "duration_ms": 1250.5,
+      "exception_info": [{...}],
+      "request_context": {...},
+      "telemetry_correlation": {...}
+    }
+    """
+
+    # Non-default fields first
+    snapshot_id: str  # Unique identifier for this incident (UUID)
+    timestamp: int  # Milliseconds since epoch when incident occurred
+    severity: str  # "critical", "high", "medium", "low"
+    trigger_type: str  # "exception", "latency"
+    service: str  # Service name
+    environment: Optional[str]  # Deployment environment; None/empty when unset (omitted from output)
+    instance_id: str  # Host/instance identifier (hostname or container ID)
+    operation: str  # HTTP method + route (e.g., "GET /api/users/<id>")
+    sdk_version: str  # ServiceEvents SDK version
+    pid: int  # Process ID
+    duration_ms: float  # Total request duration in milliseconds
+    exception_info: List[ExceptionInfo]  # Exception details (may be multiple)
+    request_context: RequestContext  # HTTP request context
+    telemetry_correlation: TelemetryCorrelation  # APM and business correlation IDs
+
+    # Default fields
+    telemetry_type: str = "IncidentSnapshot"  # Static telemetry type identifier
+    sdk_lang: str = "python"  # SDK language identifier
+
+    # Deployment Metadata
+    git_commit_sha: Optional[str] = None  # Git commit SHA from deployment
+    deployment_id: Optional[str] = None  # CI/CD deployment identifier
+
+    # True when call_path timing data is missing (first incident on endpoint, sampling was off)
+    # Only present in serialized JSON when True (sparse pattern)
+    is_partial: bool = False
+
+    # AWS platform resource attributes (cloud, host, container, k8s)
+    resource_attributes: Optional["ResourceAttributes"] = None
+
+    def to_dict(self) -> Dict:
+        """
+        Convert to dictionary for JSON serialization.
+
+        Applies sparse pattern: is_async is omitted from call_path entries when False.
+        Serializes resource_attributes using OTel dot-notation keys.
+
+        Returns:
+            Dictionary representation suitable for JSON export
+        """
+        result = asdict(self)
+        # Omit environment entirely when unset (no sentinel value)
+        if not self.environment:
+            result.pop("environment", None)
+        # Strip is_async=False from call_path entries (sparse pattern)
+        for exc_info in result.get("exception_info", []):
+            for entry in exc_info.get("call_path", []):
+                if not entry.get("is_async"):
+                    entry.pop("is_async", None)
+
+        # Strip only the misleading zero durations from a partial snapshot. A partial
+        # snapshot mixes sampled frames (real duration_ns) with unsampled ones (duration_ns
+        # == 0, which reads as "instantaneous" and is misleading). Drop only the zeros so the
+        # genuine per-frame timings that WERE captured are preserved.
+        if self.is_partial:
+            for exc_info in result.get("exception_info", []):
+                for entry in exc_info.get("call_path", []):
+                    if not entry.get("duration_ns"):
+                        entry.pop("duration_ns", None)
+
+        # Strip correlation_ids from telemetry_correlation when None
+        tc = result.get("telemetry_correlation", {})
+        if tc.get("correlation_ids") is None:
+            tc.pop("correlation_ids", None)
+
+        # Serialize resource_attributes using OTel dot-notation keys
+        if self.resource_attributes is not None:
+            result["resource_attributes"] = self.resource_attributes.to_dict()
+        else:
+            result["resource_attributes"] = {}
+
+        return result

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/models/resource_attributes.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/models/resource_attributes.py
@@ -1,0 +1,98 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Data model for AWS platform resource attributes.
+
+Encapsulates a curated set of OTel resource attributes from AWS detectors
+(EC2, ECS, EKS) that provide platform context for serviceevents telemetry.
+"""
+
+from dataclasses import dataclass, fields
+from typing import Dict, Optional
+
+# Mapping from OTel semantic convention keys to dataclass field names
+_OTEL_KEY_MAP = {
+    "cloud.provider": "cloud_provider",
+    "cloud.platform": "cloud_platform",
+    "cloud.region": "cloud_region",
+    "cloud.account.id": "cloud_account_id",
+    "cloud.availability_zone": "cloud_availability_zone",
+    "host.id": "host_id",
+    "host.type": "host_type",
+    "container.id": "container_id",
+    "k8s.cluster.name": "k8s_cluster_name",
+    "k8s.pod.name": "k8s_pod_name",
+    "k8s.namespace.name": "k8s_namespace_name",
+}
+
+# Reverse mapping: field name -> OTel key
+_FIELD_TO_OTEL_KEY = {v: k for k, v in _OTEL_KEY_MAP.items()}
+
+
+@dataclass
+class ResourceAttributes:
+    """
+    AWS platform resource attributes from OTel Resource detectors.
+
+    Contains a curated set of cloud, host, container, and Kubernetes attributes
+    that provide platform context in serviceevents telemetry output.
+
+    Serialization uses OTel semantic convention dot-notation keys (e.g., "cloud.region")
+    and is sparse (only non-None values are included).
+    """
+
+    cloud_provider: Optional[str] = None  # e.g., "aws"
+    cloud_platform: Optional[str] = None  # e.g., "aws_ec2", "aws_ecs", "aws_eks"
+    cloud_region: Optional[str] = None  # e.g., "us-east-1"
+    cloud_account_id: Optional[str] = None  # e.g., "123456789012"
+    cloud_availability_zone: Optional[str] = None  # e.g., "us-east-1a"
+    host_id: Optional[str] = None  # e.g., "i-0abc123def456"
+    host_type: Optional[str] = None  # e.g., "t3.medium"
+    container_id: Optional[str] = None  # e.g., "abcdef123..."
+    k8s_cluster_name: Optional[str] = None  # e.g., "my-cluster"
+    k8s_pod_name: Optional[str] = None  # e.g., "my-pod-xyz"
+    k8s_namespace_name: Optional[str] = None  # e.g., "default"
+
+    @classmethod
+    def from_otel_resource(cls, resource) -> "ResourceAttributes":
+        """
+        Create from OTel Resource object, extracting known attributes.
+
+        Args:
+            resource: OTel Resource object (opentelemetry.sdk.resources.Resource).
+                      Only attributes in the allowlist are extracted.
+
+        Returns:
+            ResourceAttributes instance with detected values.
+        """
+        if resource is None:
+            return cls()
+
+        kwargs = {}
+        for otel_key, field_name in _OTEL_KEY_MAP.items():
+            value = resource.attributes.get(otel_key)
+            if value is not None and str(value).strip():
+                kwargs[field_name] = str(value)
+        return cls(**kwargs)
+
+    def to_dict(self) -> Dict[str, str]:
+        """
+        Serialize to dict using OTel dot-notation keys.
+
+        Only includes non-None values (sparse serialization).
+
+        Returns:
+            Dict mapping OTel attribute keys to string values.
+            Example: {"cloud.region": "us-east-1", "host.id": "i-0abc123"}
+        """
+        result = {}
+        for field_info in fields(self):
+            value = getattr(self, field_info.name)
+            if value is not None and field_info.name in _FIELD_TO_OTEL_KEY:
+                result[_FIELD_TO_OTEL_KEY[field_info.name]] = value
+        return result
+
+    def is_empty(self) -> bool:
+        """Return True if no attributes are set."""
+        return all(getattr(self, f.name) is None for f in fields(self))

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/python_monitor.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/python_monitor.py
@@ -1,0 +1,60 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+ServiceEvents function monitoring - Interface module.
+
+This module provides a context manager for tracking function invocations,
+durations, exceptions, and caller relationships, backed by a pure-Python
+implementation.
+
+All external code should import from this module:
+    from .python_monitor import _ServiceEventsMonitorState, PythonServiceEventsMonitor
+    from .python_monitor import set_current_operation, get_current_operation
+"""
+
+# ============================================================================
+# Implementation
+# ============================================================================
+
+# The monitor is backed by a single pure-Python implementation. (An experimental
+# native C++ backend was retired; this module is now a thin re-export of the
+# pure-Python implementation kept for import-path stability.)
+from amazon.opentelemetry.distro.serviceevents.python_monitor_impl import (
+    PythonServiceEventsMonitor,
+    _ServiceEventsMonitorState,
+    clear_current_operation,
+    get_call_stack,
+    get_current_operation,
+    get_sampling_mode,
+    mark_operation_hot,
+    reset_after_fork,
+    set_current_operation,
+    set_sampling_mode,
+    set_sampling_thresholds,
+    tick_hot_operations,
+)
+
+# ============================================================================
+# Public API
+# ============================================================================
+
+__all__ = [
+    # Classes
+    "_ServiceEventsMonitorState",
+    "PythonServiceEventsMonitor",
+    # Operation functions
+    "set_current_operation",
+    "get_current_operation",
+    "clear_current_operation",
+    # Sampling mode functions
+    "set_sampling_mode",
+    "get_sampling_mode",
+    "set_sampling_thresholds",
+    # State management functions
+    "reset_after_fork",
+    "get_call_stack",
+    # Adaptive sampling functions
+    "mark_operation_hot",
+    "tick_hot_operations",
+]

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/python_monitor_impl.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/python_monitor_impl.py
@@ -358,6 +358,19 @@ class _ServiceEventsMonitorState:
         """Peek at investigation data WITHOUT clearing it."""
         return self._investigation_data.get()
 
+    def clear_investigation_data(self) -> None:
+        """Drop any investigation data captured for the current request.
+
+        begin_investigation() seeds a dict at the start of every request, but only the
+        incident path consumes (and clears) it via get_investigation_data(). On the normal
+        path process_potential_incident returns early, so without this the dict — including
+        a captured traceback string on error paths — would linger in the ContextVar on
+        pooled worker threads until the next request on that thread overwrites it. Each
+        framework calls this unconditionally in its request-finalize path. Idempotent: a
+        no-op when already cleared (e.g. an incident was collected this request).
+        """
+        self._investigation_data.set(None)
+
     def record_execution_flow(self, caller: Optional[str], callee: str):
         """
         Record a function call edge for investigation.

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/python_monitor_impl.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/python_monitor_impl.py
@@ -11,6 +11,7 @@ which handles native/Python implementation selection.
 
 import threading
 import time
+import traceback
 from contextvars import ContextVar
 from typing import Dict, Optional
 
@@ -418,7 +419,6 @@ class PythonServiceEventsMonitor:
         self.function_name = function_name
         self.start_time = None
         self.caller = None
-        self.exception_info = None
         self.is_sampled = False
         # Whether __enter__ actually pushed this frame onto _call_stack. __exit__
         # pops only when this is True, so a failed/partial __enter__ never causes
@@ -500,16 +500,19 @@ class PythonServiceEventsMonitor:
             exception_name = None
             if exc_type is not None:
                 exception_name = exc_type.__name__
-                self.exception_info = {
-                    "type": exc_type,
-                    "value": exc_value,
-                    "traceback": exc_traceback,
-                }
 
-                # Record in investigation data (defer traceback formatting for performance).
-                # str(exc_value) runs the customer's exception __str__ — guarded by the
+                # Format the traceback to a string eagerly rather than stashing the
+                # (exc_type, exc_value, exc_traceback) tuple: holding exc_traceback pins the
+                # entire frame chain (every local in every frame) alive in the ContextVar until
+                # the next request overwrites the investigation data. On the common non-incident
+                # path that window can be arbitrarily long under low request rates. str()/
+                # format_exception run the customer's exception __str__ — guarded by the
                 # surrounding try so a misbehaving __str__ can't escape here.
-                #
+                try:
+                    stack_trace = "".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
+                except Exception:  # pylint: disable=broad-exception-caught
+                    stack_trace = f"{exception_name}: {exc_value}"
+
                 # First-writer-wins: __exit__ unwinds innermost-first, so the first frame to
                 # observe a propagating exception is the one closest to the raise (the true
                 # origin). Outer frames re-observe the same exception as it propagates out; they
@@ -520,7 +523,7 @@ class PythonServiceEventsMonitor:
                     inv_data["exception"] = {
                         "name": exception_name,
                         "message": str(exc_value),
-                        "traceback_info": (exc_type, exc_value, exc_traceback),
+                        "traceback_info": stack_trace,
                         "function_name": self.function_name,  # Capture which function threw the exception
                     }
 

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/python_monitor_impl.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/python_monitor_impl.py
@@ -1,0 +1,560 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Pure Python implementation of ServiceEvents function monitoring.
+
+This module contains the pure Python fallback implementation.
+Do NOT import from this module directly - use python_monitor.py instead
+which handles native/Python implementation selection.
+"""
+
+import threading
+import time
+from contextvars import ContextVar
+from typing import Dict, Optional
+
+from amazon.opentelemetry.distro.serviceevents.ast_transformation import get_function_info_unlocked
+
+# ============================================================================
+# Sampling Configuration
+# ============================================================================
+
+_sample_tier1_threshold: int = 100
+_sample_tier2_threshold: int = 1000
+_sample_tier2_rate: int = 10
+_sample_tier3_rate: int = 100
+_HOT_ENDPOINT_CYCLES: int = 100
+
+_sampling_mode: str = "always"  # "auto", "always", "never", or "adaptive"
+_call_counters: Dict[str, int] = {}
+_call_counters_lock = threading.Lock()
+
+
+def set_sampling_mode(mode: str) -> None:
+    """Set sampling mode: 'always', 'never', 'auto', or 'adaptive'."""
+    # Singleton module-level sampling state.
+    global _sampling_mode  # pylint: disable=global-statement
+    if mode not in ("always", "never", "auto", "adaptive"):
+        raise ValueError(f"Invalid sampling mode: '{mode}'")
+    _sampling_mode = mode
+
+
+def get_sampling_mode() -> str:
+    """Get current sampling mode."""
+    return _sampling_mode
+
+
+def set_sampling_thresholds(
+    tier1_threshold: int = 100,
+    tier2_threshold: int = 1000,
+    tier2_rate: int = 10,
+    tier3_rate: int = 100,
+    hot_endpoint_cycles: int = 100,
+) -> None:
+    """Set sampling thresholds for auto/adaptive mode."""
+    # Singleton module-level sampling state.
+    global _sample_tier1_threshold, _sample_tier2_threshold  # pylint: disable=global-statement
+    global _sample_tier2_rate, _sample_tier3_rate, _HOT_ENDPOINT_CYCLES  # pylint: disable=global-statement
+    _sample_tier1_threshold = tier1_threshold
+    _sample_tier2_threshold = tier2_threshold
+    _sample_tier2_rate = tier2_rate
+    _sample_tier3_rate = tier3_rate
+    _HOT_ENDPOINT_CYCLES = hot_endpoint_cycles
+
+
+def _should_sample(total_calls: int) -> bool:  # pylint: disable=too-many-return-statements
+    """Determine if a call should be sampled based on current mode and call count."""
+    if _sampling_mode == "always":
+        return True
+    if _sampling_mode == "never":
+        return False
+    if _sampling_mode == "adaptive":
+        # O(1) cached check - computed once per request, ~50ns per subsequent call
+        cached = _adaptive_sample_cache.get()
+        if cached is not None:
+            return cached
+        operation = _current_operation.get()
+        result = operation is not None and operation in _hot_operations
+        _adaptive_sample_cache.set(result)
+        return result
+    # AUTO: adaptive 3-tier sampling. Rates are "1-in-N"; a non-positive N is degenerate
+    # (it can only arrive via the internal test-config hook, which doesn't validate) and
+    # would otherwise raise ZeroDivisionError on the modulo. Treat N <= 0 as "sample none
+    # in this tier" so a misconfigured rate degrades gracefully instead of crashing the
+    # guarded monitor __enter__ on every call.
+    if total_calls <= _sample_tier1_threshold:
+        return True
+    if total_calls <= _sample_tier2_threshold:
+        return _sample_tier2_rate > 0 and total_calls % _sample_tier2_rate == 0
+    return _sample_tier3_rate > 0 and total_calls % _sample_tier3_rate == 0
+
+
+def _increment_call_counter(function_name: str) -> int:
+    """Increment and return the call counter for a function."""
+    with _call_counters_lock:
+        _call_counters[function_name] = _call_counters.get(function_name, 0) + 1
+        return _call_counters[function_name]
+
+
+# ============================================================================
+# Context Variables
+# ============================================================================
+
+# Thread-local call stack for tracking caller relationships
+_call_stack: ContextVar[list] = ContextVar("serviceevents_call_stack", default=[])
+
+# Thread-local operation for associating functions with HTTP endpoints
+_current_operation: ContextVar[Optional[str]] = ContextVar("serviceevents_operation", default=None)
+
+
+# ============================================================================
+# Operation Functions
+# ============================================================================
+
+
+def set_current_operation(operation: str):
+    """Set the current operation (e.g., 'POST /users') for the request context."""
+    _current_operation.set(operation)
+    # Reset adaptive sampling cache so it re-evaluates with the new operation.
+    # This prevents cache poisoning if _should_sample() was called before the
+    # operation was set (e.g., by monitored middleware running before before_request).
+    _adaptive_sample_cache.set(None)
+
+
+def get_current_operation() -> Optional[str]:
+    """Get the current operation from the request context."""
+    return _current_operation.get()
+
+
+def clear_current_operation():
+    """Clear the current operation from the request context."""
+    _current_operation.set(None)
+    _adaptive_sample_cache.set(None)
+
+
+# ============================================================================
+# Hot Operation Tracking (for "adaptive" sampling mode)
+# ============================================================================
+
+_hot_operations: Dict[str, int] = {}  # operation -> remaining flush cycles
+_hot_operations_lock = threading.Lock()
+
+# Per-request cache for adaptive sampling decision (cleared per request)
+_adaptive_sample_cache: ContextVar[Optional[bool]] = ContextVar("serviceevents_adaptive_cache", default=None)
+
+
+def mark_operation_hot(operation: str) -> None:
+    """Mark operation as hot after incident. Resets countdown to full cycle count."""
+    with _hot_operations_lock:
+        _hot_operations[operation] = _HOT_ENDPOINT_CYCLES
+
+
+def tick_hot_operations() -> None:
+    """Decrement hot operation counters. Called once per collector flush cycle."""
+    with _hot_operations_lock:
+        expired = []
+        for op in _hot_operations:
+            _hot_operations[op] -= 1
+            if _hot_operations[op] <= 0:
+                expired.append(op)
+        for op in expired:
+            del _hot_operations[op]
+
+
+def get_call_stack() -> list:
+    """Get the current call stack as a list of function names."""
+    stack = _call_stack.get()
+    if stack is None:
+        return []
+    return list(stack)
+
+
+def reset_after_fork() -> None:
+    """Reset all module state after fork. Important for multiprocessing.
+
+    The singleton's identity is preserved — only mutable state is cleared.
+    This avoids two hazards inherent to "null and recreate" semantics:
+
+    - A publication race where a freshly-recreated singleton is briefly visible
+      without its OTel instruments wired, causing a few post-fork calls to
+      silently no-op and miss the metric.
+    - Stale caches: collectors and PythonServiceEventsMonitor instances cache
+      `_ServiceEventsMonitorState.get_instance()` at construction time. If we
+      replaced the singleton, those caches would point at a discarded object
+      and writes/reads would diverge from what `_reinitialize_after_fork`
+      re-wires.
+    """
+    # Singleton module-level sampling state.
+    global _sampling_mode  # pylint: disable=global-statement
+
+    # Reset sampling mode to default (always)
+    _sampling_mode = "always"
+
+    # Clear call counters
+    with _call_counters_lock:
+        _call_counters.clear()
+
+    # Clear hot operations
+    with _hot_operations_lock:
+        _hot_operations.clear()
+
+    # Clear thread-local state
+    _call_stack.set([])
+    _current_operation.set(None)
+    _adaptive_sample_cache.set(None)
+
+    # Clear the existing singleton's mutable state in place. The OTel
+    # instrument (histogram) and its base attrs are intentionally left intact —
+    # the histogram is owned by the parent's MeterProvider, which survives fork,
+    # and re-wiring it would only widen the un-wired window for no benefit. If
+    # the parent never wired it, the field stays None and recording simply
+    # no-ops, as before.
+    with _ServiceEventsMonitorState._lock:
+        inst = _ServiceEventsMonitorState._instance
+        if inst is not None:
+            inst._investigation_data.set(None)
+
+
+# ============================================================================
+# ServiceEventsMonitorState Class
+# ============================================================================
+
+
+class _ServiceEventsMonitorState:
+    """
+    Singleton class that holds global state for all monitored functions.
+    This is separate from the context manager to maintain a single metric
+    recording path and investigation store.
+    """
+
+    _instance = None
+    _lock = threading.Lock()
+
+    def __init__(self):
+        # For investigation capture
+        self._investigation_data: ContextVar[Optional[dict]] = ContextVar("investigation_data", default=None)
+
+        # Direct OTel histogram recording for function-call durations.
+        self._function_duration_histogram = None
+        # Shared attributes for the duration Histogram. Stored as a plain dict
+        # (write-once during init, never mutated) so __exit__ can build per-call
+        # attrs by copying this dict and adding per-call keys.
+        self._metric_base_attrs: Dict = {}
+
+    @classmethod
+    def get_instance(cls):
+        """Get or create the singleton instance."""
+        if cls._instance is None:
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = cls()
+        return cls._instance
+
+    def set_metric_base_attrs(self, base_attrs: Dict) -> None:
+        """
+        Store the shared attribute set used by the function-duration metric.
+
+        ``service.function.duration`` (Histogram) builds its per-call attribute
+        dict on top of these base attrs. Should be called before the instrument
+        is wired so the first recorded call sees a fully-populated attribute set.
+
+        Args:
+            base_attrs: Signal-level attributes (e.g. ``Telemetry.Source``).
+                Service identity, deployment, and VCS metadata live on the OTel
+                Resource and ride along with every data point automatically, so
+                they are not part of this dict. Snapshotted into a plain dict so
+                external mutation can't poison readers; never mutated after.
+        """
+        self._metric_base_attrs = dict(base_attrs)
+
+    def set_function_duration_histogram(self, histogram) -> None:
+        """
+        Wire the OTel histogram instrument for direct recording at call time.
+
+        Called once during ServiceEventsInstrumentation initialization after the
+        MeterProvider and histogram are created. Enables PythonServiceEventsMonitor
+        to record raw durations directly into the OTel Exponential Histogram.
+
+        Args:
+            histogram: OTel Histogram instrument (service.function.duration)
+        """
+        self._function_duration_histogram = histogram
+
+    def record_function_call_metrics(
+        self,
+        function_name: str,
+        duration_ns: int,
+        caller: Optional[str] = None,
+        exception_name: Optional[str] = None,
+        is_sampled: bool = True,
+    ) -> None:
+        """
+        Record a function call into the OTel metrics pipeline, if the histogram
+        is wired.
+
+        ``service.function.duration`` (Histogram) is recorded only when
+        ``is_sampled=True`` so latency stats (sum, min, percentiles) aren't
+        polluted by zero-duration placeholders. The per-call attribute dict is
+        built on top of ``_metric_base_attrs``, populated separately via
+        ``set_metric_base_attrs``.
+
+        No-ops when the histogram is not wired (no OTLP emitter configured).
+
+        Args:
+            function_name: Composite function name (e.g., "myapp/server.my_func")
+            duration_ns: Measured duration in nanoseconds (only used when sampled)
+            caller: Calling function name (None if entry point)
+            exception_name: Exception class name if the call raised, else None
+            is_sampled: Whether timing was actually captured for this call
+        """
+        histogram = self._function_duration_histogram
+        if histogram is None:
+            return
+
+        # Latency histogram: sampled calls only. Non-sampled calls would record
+        # duration_ns=0, polluting sum/min/percentiles, so we skip them entirely.
+        if not is_sampled:
+            return
+
+        # Copy the write-once base dict and add per-call keys directly.
+        attrs = self._metric_base_attrs.copy()
+        attrs["function.name"] = function_name
+        if caller:
+            attrs["aws.service_events.caller"] = caller
+
+        # Lock-free best-effort lookup of function metadata.
+        # Safe because the registry is write-once (populated at import time)
+        # and dict.get() is protected by CPython's internal dict locking on
+        # both GIL and free-threaded (PEP 703) builds.
+        func_info = get_function_info_unlocked(function_name)
+        if func_info:
+            line = func_info.get("line")
+            if line is not None:
+                attrs["aws.service_events.function_at_line"] = line
+            if func_info.get("is_async"):
+                attrs["aws.service_events.async"] = True
+
+        if exception_name:
+            attrs["status"] = "error"
+        else:
+            attrs["status"] = "success"
+
+        duration_us = duration_ns / 1000.0
+        histogram.record(duration_us, attrs)
+
+    def begin_investigation(self):
+        """Start capturing investigation data for current request."""
+        self._investigation_data.set({"call_path": [], "exception": None, "start_time": time.time()})
+
+    def get_investigation_data(self) -> Optional[dict]:
+        """Get and clear investigation data."""
+        data = self._investigation_data.get()
+        self._investigation_data.set(None)
+        return data
+
+    def peek_investigation_data(self) -> Optional[dict]:
+        """Peek at investigation data WITHOUT clearing it."""
+        return self._investigation_data.get()
+
+    def record_execution_flow(self, caller: Optional[str], callee: str):
+        """
+        Record a function call edge for investigation.
+
+        DEPRECATED: Use record_call_path_entry() for richer timing data.
+        Kept for backward compatibility.
+        """
+        inv_data = self._investigation_data.get()
+        if inv_data is not None:
+            inv_data["call_path"].append((caller, callee))
+
+    def record_call_path_entry(self, function_name: str, caller: Optional[str], duration_ns: int):
+        """
+        Record a function call with timing information for investigation.
+
+        Args:
+            function_name: Composite function name (e.g., "module/path.func")
+            caller: Function name that called this one (None if entry point)
+            duration_ns: Duration in nanoseconds
+        """
+        inv_data = self._investigation_data.get()
+        if inv_data is not None:
+            inv_data["call_path"].append(
+                {
+                    "function_name": function_name,
+                    "caller_function_name": caller,
+                    "duration_ns": duration_ns,
+                }
+            )
+
+
+# ============================================================================
+# PythonServiceEventsMonitor Class
+# ============================================================================
+
+
+class PythonServiceEventsMonitor:
+    """
+    Context manager for monitoring individual function invocations.
+
+    This is instantiated for each function call via AST transformation:
+        with PythonServiceEventsMonitor("module/path.my_function"):
+            # function body
+
+    Usage:
+        def my_function():
+            with PythonServiceEventsMonitor("myapp/server.my_function"):
+                # original function body
+                pass
+    """
+
+    def __init__(self, function_name: str):
+        """
+        Initialize the monitor for a specific function invocation.
+
+        Args:
+            function_name: Composite function name (e.g., "myapp/server.my_func")
+        """
+        self.function_name = function_name
+        self.start_time = None
+        self.caller = None
+        self.exception_info = None
+        self.is_sampled = False
+        # Whether __enter__ actually pushed this frame onto _call_stack. __exit__
+        # pops only when this is True, so a failed/partial __enter__ never causes
+        # __exit__ to pop a frame it didn't push (which would corrupt caller
+        # attribution for sibling/parent calls).
+        self._pushed = False
+        self._state = _ServiceEventsMonitorState.get_instance()
+
+    def __enter__(self):
+        """Called when entering the context manager.
+
+        Crash-safety invariant: this wraps the entire body of every instrumented
+        customer function, so it must never raise into customer code. All
+        telemetry setup is guarded; on failure we mark the call un-sampled and
+        still return self so the customer body runs and __exit__ no-ops cleanly.
+        The ``return self`` is outside the try so control is guaranteed.
+        """
+        try:
+            # The per-function call counter only drives AUTO-mode tiered sampling. Only AUTO
+            # reads it, so for every other mode (including the default "adaptive") skip the
+            # lock acquisition and the unbounded counter-dict growth on this hot path.
+            if _sampling_mode == "auto":
+                call_count = _increment_call_counter(self.function_name)
+            else:
+                call_count = 0
+            self.is_sampled = _should_sample(call_count)
+
+            # Only record perf_counter for sampled calls (used for duration calculation)
+            if self.is_sampled:
+                self.start_time = time.perf_counter_ns()
+
+            # Get current call stack from context var
+            stack = _call_stack.get()
+            if stack is None:
+                stack = []
+
+            # Determine caller (last item on stack)
+            self.caller = stack[-1] if stack else None
+
+            # Push current function to stack
+            new_stack = stack + [self.function_name]  # Create new list to avoid mutation issues
+            _call_stack.set(new_stack)
+            self._pushed = True  # Set last: __exit__ pops iff the push succeeded.
+        except Exception:  # pylint: disable=broad-exception-caught
+            # Telemetry must never crash the customer app; swallow all errors.
+            # Telemetry setup failed — disable timing/recording for this call so
+            # the (also-guarded) __exit__ stays a no-op. Never propagate.
+            self.is_sampled = False
+            self.start_time = None
+
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        """Called when exiting the context manager.
+
+        Crash-safety invariant: telemetry must never alter the customer's control
+        flow. We do NOT touch the customer's exception — when the body raises,
+        Python passes it in as exc_* args and re-raises it after this returns
+        False; it is never inside our try, so it cannot be caught or changed. We
+        only swallow exceptions raised by our own telemetry code, and only
+        ``Exception`` (not ``BaseException``): KeyboardInterrupt/SystemExit/
+        GeneratorExit are not ours to suppress. ``return False`` is outside the
+        try so the customer's exception always propagates untouched.
+        """
+        try:
+            # Calculate duration only for sampled calls
+            duration_ns = 0
+            if self.is_sampled:
+                end_time = time.perf_counter_ns()
+                duration_ns = end_time - self.start_time
+
+            # Record call path entry for investigations (with timing data)
+            # For non-sampled calls, duration_ns will be 0
+            self._state.record_call_path_entry(
+                function_name=self.function_name, caller=self.caller, duration_ns=duration_ns
+            )
+
+            # Record exception if any
+            exception_name = None
+            if exc_type is not None:
+                exception_name = exc_type.__name__
+                self.exception_info = {
+                    "type": exc_type,
+                    "value": exc_value,
+                    "traceback": exc_traceback,
+                }
+
+                # Record in investigation data (defer traceback formatting for performance).
+                # str(exc_value) runs the customer's exception __str__ — guarded by the
+                # surrounding try so a misbehaving __str__ can't escape here.
+                #
+                # First-writer-wins: __exit__ unwinds innermost-first, so the first frame to
+                # observe a propagating exception is the one closest to the raise (the true
+                # origin). Outer frames re-observe the same exception as it propagates out; they
+                # must NOT overwrite the origin with their own (outer) function_name — otherwise
+                # the recorded thrower is always the outermost instrumented frame.
+                inv_data = self._state._investigation_data.get()
+                if inv_data is not None and inv_data.get("exception") is None:
+                    inv_data["exception"] = {
+                        "name": exception_name,
+                        "message": str(exc_value),
+                        "traceback_info": (exc_type, exc_value, exc_traceback),
+                        "function_name": self.function_name,  # Capture which function threw the exception
+                    }
+
+            # Record the call duration into the OTel histogram (sampled calls only).
+            self._state.record_function_call_metrics(
+                function_name=self.function_name,
+                duration_ns=duration_ns,
+                caller=self.caller,
+                exception_name=exception_name,
+                is_sampled=self.is_sampled,
+            )
+        except Exception:  # pylint: disable=broad-exception-caught
+            # Telemetry must never crash the customer app; swallow all errors.
+            # Swallow only exceptions raised by our own telemetry code above.
+            # The customer's in-flight exception is not in this try (Python
+            # re-raises it after return), so it is unaffected.
+            pass
+        finally:
+            # Always balance the stack: pop iff __enter__ pushed this frame, and
+            # do it in finally so a failure in the recording calls above can't
+            # skip the pop (which would leak this frame) — keeping caller
+            # attribution correct for subsequent calls on this thread/context.
+            if self._pushed:
+                try:
+                    stack = _call_stack.get()
+                    if stack:
+                        _call_stack.set(stack[:-1])  # Remove last element
+                except Exception:  # pylint: disable=broad-exception-caught
+                    # Telemetry must never crash the customer app; swallow all errors.
+                    pass
+
+        return False
+
+    @classmethod
+    def get_instance(cls):
+        """Get the global monitor state (for collectors)."""
+        return _ServiceEventsMonitorState.get_instance()

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/serviceevents_instrumentation.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/serviceevents_instrumentation.py
@@ -1,0 +1,622 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Main entry point for ServiceEvents instrumentation.
+
+This module manages the lifecycle of AST hooks, Python monitor, and collectors
+for deep observability of Python applications.
+"""
+
+import atexit
+import logging
+import os
+from typing import List, Optional
+
+from amazon.opentelemetry.distro.serviceevents.ast_transformation import install_ast_hooks
+from amazon.opentelemetry.distro.serviceevents.collectors.deployment_event_collector import DeploymentEventCollector
+from amazon.opentelemetry.distro.serviceevents.collectors.endpoint_collector import EndpointMetricCollector
+from amazon.opentelemetry.distro.serviceevents.collectors.incident_snapshot_collector import IncidentSnapshotCollector
+from amazon.opentelemetry.distro.serviceevents.config import ServiceEventsConfig
+from amazon.opentelemetry.distro.serviceevents.python_monitor import _ServiceEventsMonitorState
+
+logger = logging.getLogger(__name__)
+
+# Module-level singleton instance
+_serviceevents_instance: Optional["ServiceEventsInstrumentation"] = None
+
+
+def _build_log_otlp_exporter(logs_endpoint: str, headers: dict, compression):
+    """Build an OTLP log exporter for the configured logs endpoint.
+
+    When the endpoint matches the CloudWatch Logs OTLP pattern
+    (``https://logs.{region}.amazonaws.com/v1/logs``), wrap the upstream
+    ``OTLPLogExporter`` with ADOT's ``OTLPAwsLogRecordExporter`` so
+    requests are SigV4-signed. The ``x-aws-log-group`` / ``x-aws-log-stream``
+    headers travel with every batch (already populated in ``headers``).
+    Otherwise return a plain upstream ``OTLPLogExporter`` pointing at the
+    collector-proxied endpoint.
+
+    Mirrors the Java SDK's behavior in ``ServiceEventsInstrumentation.java:557``.
+    Imports are deferred so this module stays importable without OTel SDK
+    and boto3 at import time.
+    """
+    # Module-local imports to preserve the file's lazy-import posture (defer OTel SDK / boto3).
+    # pylint: disable=import-outside-toplevel
+    import re
+
+    from amazon.opentelemetry.distro.aws_opentelemetry_configurator import AWS_LOGS_OTLP_ENDPOINT_PATTERN
+    from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+
+    is_cw_endpoint = bool(re.match(AWS_LOGS_OTLP_ENDPOINT_PATTERN, (logs_endpoint or "").lower()))
+    if not is_cw_endpoint:
+        return OTLPLogExporter(endpoint=logs_endpoint, headers=headers, compression=compression)
+
+    # Direct-to-CloudWatch path: import AWS extras lazily (boto3 is only
+    # required when we actually take the SigV4 path).
+    # pylint: disable=import-outside-toplevel
+    import boto3
+
+    from amazon.opentelemetry.distro.exporter.otlp.aws.logs.otlp_aws_log_record_exporter import OTLPAwsLogRecordExporter
+
+    region = (logs_endpoint or "").lower().split(".")[1]
+    # OTLPAwsLogRecordExporter hardcodes compression=Gzip (matches ADOT design —
+    # CloudWatch OTLP ingestion assumes gzip for LLO batching). The `compression`
+    # argument is honored only on the collector-proxied branch above.
+    _ = compression  # suppress unused-kwarg lint on this branch
+    return OTLPAwsLogRecordExporter(
+        aws_region=region,
+        session=boto3.Session(),
+        endpoint=logs_endpoint,
+        headers=headers,
+    )
+
+
+def get_serviceevents_instrumentation(
+    config: Optional["ServiceEventsConfig"] = None,
+) -> Optional["ServiceEventsInstrumentation"]:
+    """
+    Get or create the singleton ServiceEventsInstrumentation instance.
+
+    This ensures only one instance is ever created, preventing duplicate
+    initialization (e.g., from both manual init and auto-configurator).
+
+    Args:
+        config: ServiceEventsConfig instance. Required on first call, optional afterwards.
+                If provided after first call, it is ignored (first config wins).
+
+    Returns:
+        The singleton ServiceEventsInstrumentation instance, or None if no config provided
+        on first call.
+    """
+    # Singleton instrumentation state — module-level by design.
+    global _serviceevents_instance  # pylint: disable=global-statement
+
+    if _serviceevents_instance is not None:
+        if config is not None:
+            logger.debug(
+                "ServiceEventsInstrumentation singleton already exists "
+                "(service=%s), ignoring new config (service=%s)",
+                _serviceevents_instance.config.service_name,
+                config.service_name,
+            )
+        return _serviceevents_instance
+
+    if config is None:
+        logger.debug("No ServiceEventsInstrumentation instance exists and no config provided")
+        return None
+
+    _serviceevents_instance = ServiceEventsInstrumentation(config)
+    return _serviceevents_instance
+
+
+class ServiceEventsInstrumentation:
+    """
+    Main entry point for ServiceEvents instrumentation.
+    Manages lifecycle of AST hooks, Python monitor, and framework instrumentations.
+    """
+
+    def __init__(self, config: ServiceEventsConfig):
+        """
+        Initialize ServiceEvents instrumentation with configuration.
+
+        Args:
+            config: ServiceEventsConfig instance with all settings
+        """
+        self.config = config
+        self.monitor_state = None
+        self.collectors: List = []  # Will be populated in Phase 2-4
+        self._initialized = False
+        # Guards against registering more than one atexit hook across re-init cycles.
+        self._atexit_registered = False
+        # OTLP components
+        self._otlp_emitter = None
+        self._otlp_logger_provider = None
+        self._otlp_meter_provider = None
+
+    # Sequential, tested startup routine — kept whole rather than fragmented.
+    def initialize(self) -> None:  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+        """
+        Initialize ServiceEvents instrumentation.
+
+        Steps:
+        1. Configure logging level from config
+        2. Initialize Python monitor (singleton for aggregation)
+        3. Install AST import hooks (if enabled)
+        4. Initialize framework instrumentations (Phase 3)
+        5. Start periodic collectors (Phase 2-4)
+        """
+        if self._initialized:
+            logger.warning("ServiceEvents instrumentation already initialized, skipping")
+            return
+
+        # Configure ServiceEvents logging — reuse OTEL_PYTHON_LOG_LEVEL (default: INFO)
+        otel_log_level = os.getenv("OTEL_PYTHON_LOG_LEVEL", "info").upper()
+        log_level = getattr(logging, otel_log_level, logging.INFO)
+        serviceevents_logger = logging.getLogger("amazon.opentelemetry.distro.serviceevents")
+        serviceevents_logger.setLevel(log_level)
+
+        if not serviceevents_logger.handlers:
+            handler = logging.StreamHandler()
+            handler.setLevel(log_level)
+            formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+            handler.setFormatter(formatter)
+            serviceevents_logger.addHandler(handler)
+
+        if not self.config.enabled:
+            logger.info("ServiceEvents instrumentation disabled via configuration")
+            return
+
+        try:
+            logger.info("Initializing ServiceEvents instrumentation (Python implementation)")
+
+            # Initialize Python monitor singleton for aggregation
+            self.monitor_state = _ServiceEventsMonitorState.get_instance()
+            logger.debug("ServiceEvents monitor state initialized")
+
+            # Configure sampling mode from config
+            if self.config.sampling_mode != "auto":
+                # Lazy import to avoid import-time coupling with python_monitor.
+                # pylint: disable=import-outside-toplevel
+                from amazon.opentelemetry.distro.serviceevents.python_monitor import set_sampling_mode
+
+                set_sampling_mode(self.config.sampling_mode)
+                logger.info("ServiceEvents sampling mode set to: %s", self.config.sampling_mode)
+
+            # Configure sampling thresholds from config
+            # Lazy import to avoid import-time coupling with python_monitor.
+            # pylint: disable=import-outside-toplevel
+            from amazon.opentelemetry.distro.serviceevents.python_monitor import set_sampling_thresholds
+
+            set_sampling_thresholds(
+                tier1_threshold=self.config.sample_tier1_threshold,
+                tier2_threshold=self.config.sample_tier2_threshold,
+                tier2_rate=self.config.sample_tier2_rate,
+                tier3_rate=self.config.sample_tier3_rate,
+                hot_endpoint_cycles=self.config.hot_endpoint_cycles,
+            )
+
+            # Initialize OTLP emitter when either `output_file` (local-testing
+            # file exporter) OR `logs_endpoint` (OTLP network exporter) is set.
+            # If both are set, `output_file` wins — it replaces the network
+            # exporter, with LOGS_ENDPOINT and METRICS_ENDPOINT ignored.
+            otlp_emitter = None
+            if self.config.output_file:
+                logger.info(
+                    "ServiceEvents OUTPUT_FILE mode: %s (LOGS_ENDPOINT and METRICS_ENDPOINT ignored)",
+                    self.config.output_file,
+                )
+                otlp_emitter = self._create_otlp_emitter()
+            elif self.config.logs_endpoint:
+                otlp_emitter = self._create_otlp_emitter()
+            else:
+                logger.info(
+                    "No ServiceEvents OTLP endpoint or output file configured — telemetry will be written to console"
+                )
+
+            # AST hooks for FunctionCall telemetry. Gated on config.function_instrument_enabled:
+            # when enabled, bytecode-style AST instrumentation owns FunctionCall plus
+            # synchronous incident call_path capture.
+            if self.config.function_instrument_enabled:
+                # Wire the OTel histogram directly into monitor state for real-time recording.
+                # PythonServiceEventsMonitor.__exit__ records each call's duration straight into
+                # service.function.duration (OTel ExponentialHistogram) — the single source of
+                # truth for FunctionCall. Wired in BOTH network and output_file mode: the file
+                # metric exporter emits canonical OTLP metrics JSON (incl. ExponentialHistogram),
+                # so the histogram is exported identically in either mode.
+                if otlp_emitter:
+                    meter = self._otlp_meter_provider.get_meter("serviceevents", "1.0")
+                    function_call_histogram = meter.create_histogram(
+                        "service.function.duration",
+                        unit="Microseconds",
+                        description="Function call duration",
+                    )
+                    # `Telemetry.Source` is the only signal-level base attribute
+                    # left on the per-call dimension set. service.name,
+                    # environment, deployment.environment.name, the SDK version,
+                    # deployment id, and VCS attributes all live on the OTel
+                    # Resource (set in _create_otlp_emitter), so they ride
+                    # along on every metric data point automatically without
+                    # bloating the cardinality budget.
+                    base_attrs = {
+                        "Telemetry.Source": "ServiceEvents",
+                    }
+                    self.monitor_state.set_metric_base_attrs(base_attrs)
+                    self.monitor_state.set_function_duration_histogram(function_call_histogram)
+                    logger.info("Wired OTel histogram into monitor state for direct recording")
+
+                # When packages_include is empty the hooks install but instrument nothing
+                # (there is no implicit default scope). That state is visible in the
+                # "AST hooks installed. Packages include: ..." log below; we intentionally
+                # do not warn, since function instrumentation is on by default and an empty
+                # allowlist is a normal, quiet no-op rather than a misconfiguration.
+                logger.info("Installing ServiceEvents AST transformation hooks")
+                install_ast_hooks(
+                    packages_include=set(self.config.packages_include),
+                    packages_exclude=self.config.packages_exclude,
+                )
+                logger.info(
+                    "AST hooks installed. Packages include: %s, Packages exclude: %s",
+                    self.config.packages_include,
+                    self.config.packages_exclude,
+                )
+            else:
+                logger.info("AST disabled: skipping AST hooks")
+
+            # DeploymentEventCollector: emits once at startup + every flush interval, regardless of mode.
+            if otlp_emitter:
+                deployment_event_collector = DeploymentEventCollector(
+                    flush_interval_ms=self.config.deployment_event_flush_interval,
+                    environment=self.config.environment,
+                    service_name=self.config.service_name,
+                    sdk_version=self.config.sdk_version,
+                    resource_attributes=self.config.resource_attributes,
+                    otlp_emitter=otlp_emitter,
+                )
+                self.collectors.append(deployment_event_collector)
+                deployment_event_collector.start()
+                logger.info(
+                    "Started DeploymentEventCollector (interval: %sms)",
+                    self.config.deployment_event_flush_interval,
+                )
+
+            # EndpointMetricCollector: always enabled (framework hooks provide data).
+            # suppress_endpoint_summary: when Application Signals is on, skip emitting
+            # EndpointSummary LogRecords (App Signals carries equivalent data). The
+            # collector still runs so latency histograms feed IncidentSnapshot triggers.
+            endpoint_collector = EndpointMetricCollector(
+                flush_interval_ms=self.config.endpoint_flush_interval,
+                environment=self.config.environment,
+                service_name=self.config.service_name,
+                sdk_version=self.config.sdk_version,
+                resource_attributes=self.config.resource_attributes,
+                otlp_emitter=otlp_emitter,
+                suppress_endpoint_summary=self.config.application_signals_enabled,
+            )
+            self.collectors.append(endpoint_collector)
+            endpoint_collector.start()
+            logger.info("Started EndpointMetricCollector (interval: %sms)", self.config.endpoint_flush_interval)
+
+            # IncidentSnapshotCollector: always runs (AST owns incidents).
+            incident_snapshot_collector = IncidentSnapshotCollector(
+                flush_interval_ms=self.config.incident_snapshot_flush_interval,
+                duration_threshold_ms=self.config.incident_snapshot_duration_threshold_ms,
+                max_per_period=self.config.incident_snapshot_max_per_minute,
+                environment=self.config.environment,
+                service_name=self.config.service_name,
+                sdk_version=self.config.sdk_version,
+                capture_request_body=self.config.incident_snapshot_capture_request_body,
+                max_same_error=self.config.incident_snapshot_max_same_error,
+                resource_attributes=self.config.resource_attributes,
+                otlp_emitter=otlp_emitter,
+            )
+
+            latency_patterns = self.config.get_latency_threshold_patterns()
+            if latency_patterns:
+                incident_snapshot_collector.set_latency_threshold_patterns(latency_patterns)
+                logger.info("Applied %d latency threshold patterns", len(latency_patterns))
+
+            self.collectors.append(incident_snapshot_collector)
+            incident_snapshot_collector.start()
+            logger.info(
+                "Started IncidentSnapshotCollector (interval: %sms)",
+                self.config.incident_snapshot_flush_interval,
+            )
+
+            # Phase 3: Initialize framework hooks (auto-detect via ImportError)
+            try:
+                # Optional framework dep — auto-detected via ImportError.
+                # pylint: disable=import-outside-toplevel
+                from amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation import (
+                    install_flask_hooks,
+                )
+
+                install_flask_hooks(
+                    endpoint_collector=endpoint_collector,
+                    incident_snapshot_collector=incident_snapshot_collector,
+                    config=self.config,
+                )
+                logger.info("Flask instrumentation hooks installed")
+            except ImportError:
+                logger.debug("Flask not installed, skipping Flask instrumentation")
+            except Exception as exc:  # pylint: disable=broad-exception-caught  # telemetry must not crash app
+                logger.error("Error installing Flask hooks: %s", exc, exc_info=True)
+
+            try:
+                # Optional framework dep — auto-detected via ImportError.
+                # pylint: disable=import-outside-toplevel
+                from amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation import (
+                    install_fastapi_hooks,
+                )
+
+                install_fastapi_hooks(
+                    endpoint_collector=endpoint_collector,
+                    incident_snapshot_collector=incident_snapshot_collector,
+                    config=self.config,
+                )
+                logger.info("FastAPI instrumentation hooks installed")
+            except ImportError:
+                logger.debug("FastAPI not installed, skipping FastAPI instrumentation")
+            except Exception as exc:  # pylint: disable=broad-exception-caught  # telemetry must not crash app
+                logger.error("Error installing FastAPI hooks: %s", exc, exc_info=True)
+
+            try:
+                # Optional framework dep — auto-detected via ImportError.
+                # pylint: disable=import-outside-toplevel
+                from amazon.opentelemetry.distro.serviceevents.instrumentation.django_instrumentation import (
+                    install_django_hooks,
+                )
+
+                install_django_hooks(
+                    endpoint_collector=endpoint_collector,
+                    incident_snapshot_collector=incident_snapshot_collector,
+                    config=self.config,
+                )
+                logger.info("Django instrumentation hooks installed")
+            except ImportError:
+                logger.debug("Django not installed, skipping Django instrumentation")
+            except Exception as exc:  # pylint: disable=broad-exception-caught  # telemetry must not crash app
+                logger.error("Error installing Django hooks: %s", exc, exc_info=True)
+
+            # Register fork handler for multi-process servers (e.g., gunicorn)
+            try:
+                os.register_at_fork(after_in_child=self._reinitialize_after_fork)
+            except AttributeError:
+                pass  # os.register_at_fork not available (Windows)
+
+            # Flush on interpreter exit. Collectors run on daemon threads, which are killed
+            # abruptly at exit without running their final-collection path, and the OTLP
+            # providers are never force-flushed — so the last interval's snapshots/metrics
+            # would be lost on a clean shutdown. shutdown() is idempotent (guards on
+            # _initialized), so a redundant explicit call is harmless. Registered once.
+            if not self._atexit_registered:
+                atexit.register(self.shutdown)
+                self._atexit_registered = True
+
+            self._initialized = True
+            logger.info("ServiceEvents instrumentation initialized successfully (service=%s)", self.config.service_name)
+
+        except Exception as exc:  # pylint: disable=broad-exception-caught  # telemetry must not crash app
+            logger.error("Failed to initialize ServiceEvents instrumentation: %s", exc, exc_info=True)
+            # Don't crash application - graceful degradation
+            self._initialized = False
+
+    # Tested provider/exporter wiring — kept whole rather than fragmented.
+    def _create_otlp_emitter(self):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+        """Create dedicated OTLP LoggerProvider + MeterProvider + ServiceEventsOtlpEmitter."""
+        # Defer OTel SDK / exporter imports so this module imports without those deps.
+        # pylint: disable=import-outside-toplevel
+        from amazon.opentelemetry.distro.serviceevents.exporter.cloudwatch_file_exporter import (
+            ServiceEventsCloudWatchLogFileExporter,
+            ServiceEventsCloudWatchMetricFileExporter,
+        )
+        from amazon.opentelemetry.distro.serviceevents.exporter.otlp_emitter import ServiceEventsOtlpEmitter
+        from opentelemetry.exporter.otlp.proto.http import Compression
+        from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+        from opentelemetry.sdk._logs import LoggerProvider
+        from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+        from opentelemetry.sdk.metrics import Counter, Histogram, MeterProvider
+        from opentelemetry.sdk.metrics.export import AggregationTemporality, PeriodicExportingMetricReader
+        from opentelemetry.sdk.resources import Resource
+
+        # Build Resource from application context.
+        # aws.local.service duplicates service.name for backend compatibility —
+        # the backend currently queries aws.local.service and will migrate to
+        # service.name in a future release, at which point this duplicate is removed.
+        #
+        # SDK version, deployment id, and VCS attributes are folded into the
+        # Resource so they flow with every signal (logs + metrics) without
+        # being repeated on every per-call attribute set. This keeps
+        # `service.function.duration` data points lean.
+        resource_attrs = {
+            "service.name": self.config.service_name,
+            "aws.local.service": self.config.service_name,
+        }
+        # Only set the deployment.environment.name resource attribute when environment is
+        # known — omit it entirely (no sentinel) when unset.
+        if self.config.environment:
+            resource_attrs["deployment.environment.name"] = self.config.environment
+        version = self.config.sdk_version
+        if version:
+            resource_attrs["aws.service_events.version"] = version
+        deployment_id = os.getenv("OTEL_AWS_SERVICE_EVENTS_DEPLOYMENT_ID", "")
+        if deployment_id:
+            resource_attrs["aws.service_events.deployment.id"] = deployment_id
+        git_commit_sha = os.getenv("OTEL_AWS_SERVICE_EVENTS_GIT_COMMIT_SHA", "")
+        if git_commit_sha:
+            resource_attrs["vcs.ref.head.revision"] = git_commit_sha
+        git_repo_url = os.getenv("OTEL_AWS_SERVICE_EVENTS_GIT_REPO_URL", "")
+        if git_repo_url:
+            resource_attrs["vcs.repository.url.full"] = git_repo_url
+        # Add platform attributes from OTel Resource detectors
+        if self.config.resource_attributes:
+            ra = self.config.resource_attributes
+            for attr_name, attr_key in [
+                ("cloud_provider", "cloud.provider"),
+                ("cloud_platform", "cloud.platform"),
+                ("cloud_region", "cloud.region"),
+                ("cloud_account_id", "cloud.account.id"),
+                ("cloud_availability_zone", "cloud.availability_zone"),
+                ("host_id", "host.id"),
+                ("host_type", "host.type"),
+                ("container_id", "container.id"),
+            ]:
+                val = getattr(ra, attr_name, None)
+                if val:
+                    resource_attrs[attr_key] = val
+        resource = Resource.create(resource_attrs)
+
+        # Dedicated LoggerProvider for ServiceEvents OTLP signals.
+        # When `output_file` is set, use the CloudWatch-faithful file exporter
+        # in place of the OTLP HTTP exporter — logs and metrics all land in the same file.
+        output_file = self.config.output_file
+        logs_endpoint = self.config.logs_endpoint
+        log_headers = {}
+        if self.config.log_group:
+            log_headers["x-aws-log-group"] = self.config.log_group
+        log_stream = self.config.log_stream or self.config.service_name
+        if log_stream:
+            log_headers["x-aws-log-stream"] = log_stream
+
+        if output_file:
+            log_exporter = ServiceEventsCloudWatchLogFileExporter(output_file)
+        else:
+            log_exporter = _build_log_otlp_exporter(logs_endpoint, log_headers, Compression.NoCompression)
+        self._otlp_logger_provider = LoggerProvider(resource=resource)
+        self._otlp_logger_provider.add_log_record_processor(BatchLogRecordProcessor(log_exporter))
+
+        # Dedicated MeterProvider for ServiceEvents metrics (count + service.function.duration).
+        # File mode: write OTLP metrics JSON to the same file as logs. Network mode: POST OTLP metrics.
+        # Both paths use Delta temporality so the file mirror matches the wire.
+        # metrics_endpoint is guaranteed non-empty by the endpoint policy enforced
+        # before ServiceEventsConfig reaches this code path.
+        metrics_endpoint = self.config.metrics_endpoint
+        if output_file:
+            metric_exporter = ServiceEventsCloudWatchMetricFileExporter(output_file)
+        else:
+            metric_exporter = OTLPMetricExporter(
+                endpoint=metrics_endpoint,
+                preferred_temporality={
+                    Counter: AggregationTemporality.DELTA,
+                    Histogram: AggregationTemporality.DELTA,
+                },
+            )
+        # Honor OTEL_METRIC_EXPORT_INTERVAL when set (defaults to 60s in the
+        # OTel SDK). Lets contract tests force a fast flush without code change,
+        # and operators tune flush cadence per environment.
+        reader = PeriodicExportingMetricReader(metric_exporter)
+
+        # Configure ExponentialBucketHistogramAggregation for function call duration metric
+        # pylint: disable=import-outside-toplevel
+        from opentelemetry.sdk.metrics.view import ExponentialBucketHistogramAggregation, View
+
+        function_duration_view = View(
+            instrument_name="service.function.duration",
+            aggregation=ExponentialBucketHistogramAggregation(),
+        )
+        self._otlp_meter_provider = MeterProvider(
+            resource=resource, metric_readers=[reader], views=[function_duration_view]
+        )
+
+        # Deployment context from env
+        deployment_id = os.getenv("OTEL_AWS_SERVICE_EVENTS_DEPLOYMENT_ID", "")
+        git_commit_sha = os.getenv("OTEL_AWS_SERVICE_EVENTS_GIT_COMMIT_SHA", "")
+        git_repo_url = os.getenv("OTEL_AWS_SERVICE_EVENTS_GIT_REPO_URL", "")
+
+        emitter = ServiceEventsOtlpEmitter(
+            logger_provider=self._otlp_logger_provider,
+            meter_provider=self._otlp_meter_provider,
+            deployment_id=deployment_id,
+            git_commit_sha=git_commit_sha,
+            git_repo_url=git_repo_url,
+        )
+        self._otlp_emitter = emitter
+
+        if output_file:
+            logger.info("ServiceEvents OTLP emitter initialized (output_file: %s)", output_file)
+        else:
+            logger.info(
+                "ServiceEvents OTLP emitter initialized (logs: %s, metrics: %s)",
+                logs_endpoint,
+                metrics_endpoint or "disabled",
+            )
+        return emitter
+
+    def _reinitialize_after_fork(self) -> None:
+        """
+        Re-initialize ServiceEvents collector threads after fork.
+
+        Called automatically in child processes (e.g., gunicorn workers) via
+        os.register_at_fork. Daemon threads do not survive fork(), so collectors
+        must be restarted in each worker for data to be collected and flushed.
+        """
+        try:
+            # Lazy import to avoid import-time coupling with python_monitor.
+            # pylint: disable=import-outside-toplevel
+            from amazon.opentelemetry.distro.serviceevents.python_monitor import reset_after_fork
+
+            reset_after_fork()
+
+            # Note: reset_after_fork() preserves the monitor-state singleton's
+            # identity (clearing only its mutable state), so:
+            #   - self.monitor_state stays valid — no need to re-fetch.
+            #   - The OTel histogram wiring set in initialize() is preserved,
+            #     so post-fork __exit__ calls record into the histogram with no
+            #     race against re-wiring.
+            #   - Collectors and in-flight monitor objects that cached
+            #     _ServiceEventsMonitorState.get_instance() still point at the
+            #     correct (now-cleared) singleton.
+
+            # Reset and restart each collector thread
+            for collector in self.collectors:
+                collector._reset_for_fork()
+                collector.start()
+
+            logger.info("ServiceEvents re-initialized after fork in worker process (pid=%d)", os.getpid())
+        except Exception as exc:  # pylint: disable=broad-exception-caught  # telemetry must not crash app
+            logger.error("Failed to re-initialize ServiceEvents after fork: %s", exc, exc_info=True)
+
+    def shutdown(self) -> None:
+        """
+        Stop all collectors and cleanup resources.
+
+        This should be called during application shutdown to ensure proper cleanup.
+        """
+        if not self._initialized:
+            return
+
+        # An explicit shutdown removes the atexit hook so it doesn't run a second time at
+        # interpreter exit (the second run would be a guarded no-op via _initialized, but
+        # unregistering also avoids emitting logs after the logging subsystem may have torn
+        # down its streams). Safe if the hook was never registered.
+        if self._atexit_registered:
+            try:
+                atexit.unregister(self.shutdown)
+            except Exception:  # pylint: disable=broad-exception-caught  # never fail teardown
+                pass
+            self._atexit_registered = False
+
+        try:
+            logger.info("Shutting down ServiceEvents instrumentation")
+
+            # Stop all collectors (this will also close file exporter if present)
+            for collector in self.collectors:
+                try:
+                    collector.stop()
+                    logger.debug("Stopped collector: %s", collector.__class__.__name__)
+                except Exception as exc:  # pylint: disable=broad-exception-caught  # telemetry must not crash app
+                    logger.error("Error stopping collector: %s", exc, exc_info=True)
+
+            # Shutdown OTLP emitter and providers
+            if self._otlp_emitter:
+                try:
+                    self._otlp_emitter.shutdown()
+                    logger.debug("Shut down OTLP emitter")
+                except Exception as exc:  # pylint: disable=broad-exception-caught  # telemetry must not crash app
+                    logger.error("Error shutting down OTLP emitter: %s", exc, exc_info=True)
+
+            self._initialized = False
+            logger.info("ServiceEvents instrumentation shut down successfully")
+
+        except Exception as exc:  # pylint: disable=broad-exception-caught  # telemetry must not crash app
+            logger.error("Error during ServiceEvents shutdown: %s", exc, exc_info=True)

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/serviceevents_instrumentation.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/serviceevents_instrumentation.py
@@ -39,9 +39,15 @@ def _build_log_otlp_exporter(logs_endpoint: str, headers: dict, compression):
 
     Mirrors the Java SDK's behavior in ``ServiceEventsInstrumentation.java:557``.
     Imports are deferred so this module stays importable without OTel SDK
-    and boto3 at import time.
+    and botocore at import time.
+
+    The SigV4 path requires ``botocore`` (an optional distro dependency). When
+    it is unavailable we fall back to a plain, unsigned ``OTLPLogExporter``
+    against the same endpoint rather than raising — telemetry must never crash
+    the host app, and a usable exporter keeps ``initialize()`` from tripping its
+    broad-except and silently disabling all of ServiceEvents.
     """
-    # Module-local imports to preserve the file's lazy-import posture (defer OTel SDK / boto3).
+    # Module-local imports to preserve the file's lazy-import posture (defer OTel SDK / botocore).
     # pylint: disable=import-outside-toplevel
     import re
 
@@ -52,10 +58,25 @@ def _build_log_otlp_exporter(logs_endpoint: str, headers: dict, compression):
     if not is_cw_endpoint:
         return OTLPLogExporter(endpoint=logs_endpoint, headers=headers, compression=compression)
 
-    # Direct-to-CloudWatch path: import AWS extras lazily (boto3 is only
-    # required when we actually take the SigV4 path).
+    # Direct-to-CloudWatch (SigV4) path. Use the shared botocore-session helper
+    # the rest of the distro relies on (see aws_opentelemetry_configurator
+    # ._create_aws_otlp_exporter). It returns a ``botocore.session.Session`` —
+    # the type OTLPAwsLogRecordExporter is annotated for — or ``None`` when
+    # botocore is not installed.
     # pylint: disable=import-outside-toplevel
-    import boto3
+    from amazon.opentelemetry.distro._utils import get_aws_session
+
+    session = get_aws_session()
+    if not session:
+        # botocore unavailable: cannot SigV4-sign. Degrade to a plain OTLP
+        # exporter against the same endpoint instead of returning None (the
+        # caller does not handle None) or raising into the host app.
+        logger.warning(
+            "ServiceEvents direct-to-CloudWatch SigV4 export requires botocore, which is not installed; "
+            "falling back to an unsigned OTLP log exporter for %s",
+            logs_endpoint,
+        )
+        return OTLPLogExporter(endpoint=logs_endpoint, headers=headers, compression=compression)
 
     from amazon.opentelemetry.distro.exporter.otlp.aws.logs.otlp_aws_log_record_exporter import OTLPAwsLogRecordExporter
 
@@ -66,7 +87,7 @@ def _build_log_otlp_exporter(logs_endpoint: str, headers: dict, compression):
     _ = compression  # suppress unused-kwarg lint on this branch
     return OTLPAwsLogRecordExporter(
         aws_region=region,
-        session=boto3.Session(),
+        session=session,
         endpoint=logs_endpoint,
         headers=headers,
     )

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/utils/__init__.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/utils/__init__.py
@@ -1,0 +1,11 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+ServiceEvents utility modules.
+"""
+
+from .instance_id import clear_instance_id_cache, get_instance_id
+from .seh_histogram import SEHHistogram
+
+__all__ = ["SEHHistogram", "get_instance_id", "clear_instance_id_cache"]

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/utils/instance_id.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/utils/instance_id.py
@@ -1,0 +1,62 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Instance ID utility for ServiceEvents telemetry.
+
+Provides a consistent host identifier that works across different deployment
+environments (on-premise, containers, VMs, cloud instances).
+"""
+
+import os
+import socket
+from typing import Optional
+
+# Cache the instance ID to avoid repeated lookups
+_cached_instance_id: Optional[str] = None
+
+
+def get_instance_id() -> str:
+    """
+    Get the host/instance identifier for telemetry.
+
+    Works across different environments:
+    - Containers: Returns container hostname (usually container ID or pod name)
+    - VMs/EC2: Returns the VM hostname
+    - On-premise: Returns the machine hostname
+
+    Priority:
+    1. INSTANCE_ID environment variable (common in cloud environments)
+    2. HOSTNAME environment variable (set in many container runtimes)
+    3. socket.gethostname() (fallback)
+
+    Returns:
+        String identifier for the current host/instance.
+    """
+    # Module-level cache for the resolved instance ID.
+    global _cached_instance_id  # pylint: disable=global-statement
+
+    if _cached_instance_id is not None:
+        return _cached_instance_id
+
+    # Try environment variables first (allows explicit override)
+    instance_id = os.getenv("INSTANCE_ID") or os.getenv("HOSTNAME")
+
+    if not instance_id:
+        # Fall back to socket hostname
+        try:
+            instance_id = socket.gethostname()
+        except Exception:  # pylint: disable=broad-exception-caught
+            # Telemetry must never crash the customer app; fall back safely.
+            instance_id = "unknown"
+
+    # Cache the result
+    _cached_instance_id = instance_id
+    return instance_id
+
+
+def clear_instance_id_cache():
+    """Clear the cached instance ID (mainly for testing)."""
+    # Module-level cache for the resolved instance ID.
+    global _cached_instance_id  # pylint: disable=global-statement
+    _cached_instance_id = None

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/utils/seh_histogram.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/utils/seh_histogram.py
@@ -1,0 +1,263 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+CloudWatch SEH (Sparse Exponential Histogram) implementation for Python.
+
+This module implements the SEH1 algorithm used by AWS CloudWatch for efficient
+distribution aggregation with ~10% relative error. Based on the Go implementation:
+https://github.com/aws/amazon-cloudwatch-agent/blob/main/metric/distribution/seh1/seh1_distribution.go
+
+The SEH algorithm uses exponentially-spaced buckets to compress large numbers of
+samples into a compact representation suitable for CloudWatch EMF (Embedded Metric Format).
+"""
+
+import math
+from typing import Dict, List, Optional, Tuple
+
+# Constants for SEH1 algorithm
+# Bucket width factor: log(1.1) gives ~10% relative error per bucket
+BUCKET_FACTOR = math.log(1.1)  # ~0.0953101798043
+
+# Special bucket number for exact zero values
+BUCKET_FOR_ZERO = -32768  # math.MinInt16 equivalent
+
+# Supported value range: ±2^360 (extremely large, practically unlimited)
+MIN_VALUE = -(2**360)
+MAX_VALUE = 2**360
+
+
+class SEHHistogram:
+    """
+    Sparse Exponential Histogram for distribution aggregation.
+
+    This class maintains a sparse map of exponentially-spaced buckets to efficiently
+    aggregate duration samples while preserving statistical properties.
+
+    Attributes:
+        max_buckets: Maximum number of distinct buckets allowed (CloudWatch EMF limit: 100)
+        buckets: Sparse map of bucket_number → count (only non-zero buckets stored)
+        minimum: Minimum value observed
+        maximum: Maximum value observed
+        sum: Sum of all values × weights
+        count: Total weighted sample count
+    """
+
+    def __init__(self, max_buckets: int = 100):
+        """
+        Initialize an empty SEH histogram.
+
+        Args:
+            max_buckets: Maximum number of distinct buckets to maintain.
+                        CloudWatch EMF supports up to 100 values per metric.
+        """
+        self.max_buckets = max_buckets
+        self.buckets: Dict[int, float] = {}
+        self.minimum: Optional[float] = None
+        self.maximum: Optional[float] = None
+        self.sum: float = 0.0
+        self.count: float = 0.0
+
+    def record(self, value: float, weight: float = 1.0) -> bool:
+        """
+        Record a value into the histogram with optional weight.
+
+        Args:
+            value: The value to record (e.g., duration in nanoseconds)
+            weight: Weight for this sample (default: 1.0)
+
+        Returns:
+            True if the value was recorded, False if rejected (validation failed)
+
+        Raises:
+            ValueError: If validation fails (NaN, Infinity, invalid range, or weight <= 0)
+        """
+        # Validate input
+        if not self._validate_input(value, weight):
+            return False
+
+        bucket_num = self._get_bucket(value)
+
+        # Bucket-cap handling: when a new distinct value would exceed max_buckets, fold its
+        # weight into the nearest existing bucket instead of dropping the sample. Dropping
+        # would desync this histogram's count/sum (and the buckets it emits) from the
+        # endpoint aggregation's own count/sum_duration, producing an EMF histogram where
+        # Count > sum(Counts) and Sum includes durations absent from every bucket. Folding
+        # keeps the invariant sum(bucket weights) == count at the cost of ~one extra bucket
+        # of relative error for the few overflow samples (only past 100 distinct buckets).
+        if bucket_num not in self.buckets and len(self.buckets) >= self.max_buckets:
+            bucket_num = min(self.buckets, key=lambda existing: abs(existing - bucket_num))
+
+        # Update statistics. min/max track the true observed value, not the folded bucket.
+        self.count += weight
+        self.sum += value * weight
+
+        if self.minimum is None or value < self.minimum:
+            self.minimum = value
+
+        if self.maximum is None or value > self.maximum:
+            self.maximum = value
+
+        # Update bucket count
+        if bucket_num in self.buckets:
+            self.buckets[bucket_num] += weight
+        else:
+            self.buckets[bucket_num] = weight
+
+        return True
+
+    def get_values_and_counts(self) -> Tuple[List[float], List[float]]:
+        """
+        Get the histogram as parallel arrays of values and counts.
+
+        Returns:
+            Tuple of (values, counts) where:
+            - values: List of representative values (bucket midpoints)
+            - counts: List of counts corresponding to each value
+            Both lists are sorted by bucket number (ascending).
+
+        Note:
+            This format is compatible with CloudWatch EMF histogram structure.
+        """
+        if not self.buckets:
+            return ([], [])
+
+        # Sort buckets by bucket number
+        sorted_buckets = sorted(self.buckets.items())
+
+        values = []
+        counts = []
+
+        for bucket_num, count in sorted_buckets:
+            # Recover representative value from bucket number
+            value = self._recover_value(bucket_num)
+            values.append(value)
+            counts.append(count)
+
+        return (values, counts)
+
+    @staticmethod
+    def _validate_input(value: float, weight: float) -> bool:
+        """
+        Validate input value and weight.
+
+        Args:
+            value: Value to validate
+            weight: Weight to validate
+
+        Returns:
+            True if valid, False otherwise
+
+        Raises:
+            ValueError: If validation fails with descriptive message
+        """
+        # Check for NaN
+        if math.isnan(value):
+            raise ValueError("Value cannot be NaN")
+
+        if math.isnan(weight):
+            raise ValueError("Weight cannot be NaN")
+
+        # Check for Infinity
+        if math.isinf(value):
+            raise ValueError("Value cannot be Infinity")
+
+        if math.isinf(weight):
+            raise ValueError("Weight cannot be Infinity")
+
+        # Check weight > 0
+        if weight <= 0:
+            raise ValueError(f"Weight must be positive, got {weight}")
+
+        # Check value range (with 0.1% tolerance like Go implementation)
+        # Note: In practice, duration values will be well within this range
+        tolerance = 1.001
+        if value < MIN_VALUE * tolerance:
+            raise ValueError(f"Value {value} is below minimum supported value")
+
+        if value > MAX_VALUE * tolerance:
+            raise ValueError(f"Value {value} exceeds maximum supported value")
+
+        return True
+
+    @staticmethod
+    def _get_bucket(value: float) -> int:
+        """
+        Calculate the bucket number for a given value.
+
+        The bucket calculation uses logarithmic spacing:
+        bucket_number = floor(log(value) / log(1.1))
+
+        Args:
+            value: The value to bucket
+
+        Returns:
+            Bucket number as int16 (-32768 to 32767)
+
+        Note:
+            Zero values map to a special bucket (BUCKET_FOR_ZERO = -32768)
+        """
+        if value == 0:
+            return BUCKET_FOR_ZERO
+
+        # For negative values, use absolute value for bucket calculation
+        # (preserving sign in the bucket space)
+        abs_value = abs(value)
+
+        # Calculate bucket: floor(log(abs_value) / BUCKET_FACTOR)
+        bucket_num = int(math.floor(math.log(abs_value) / BUCKET_FACTOR))
+
+        # Apply sign
+        if value < 0:
+            bucket_num = -bucket_num
+
+        return bucket_num
+
+    @staticmethod
+    def _recover_value(bucket_num: int) -> float:
+        """
+        Recover the representative value from a bucket number.
+
+        Uses the geometric midpoint of the exponential bucket range:
+        value = exp((bucket_num + 0.5) × log(1.1))
+
+        The 0.5 offset selects the center of the bucket's range.
+
+        Args:
+            bucket_num: Bucket number
+
+        Returns:
+            Representative value for this bucket
+        """
+        if bucket_num == BUCKET_FOR_ZERO:
+            return 0.0
+
+        # Calculate midpoint value: exp((bucket_num + 0.5) × BUCKET_FACTOR)
+        value = math.exp((bucket_num + 0.5) * BUCKET_FACTOR)
+
+        return value
+
+    def is_empty(self) -> bool:
+        """Check if the histogram is empty (no samples recorded)."""
+        return self.count == 0
+
+    def get_statistics(self) -> Dict[str, float]:
+        """
+        Get summary statistics for the histogram.
+
+        Returns:
+            Dictionary with keys: min, max, sum, count
+        """
+        return {
+            "min": self.minimum if self.minimum is not None else 0.0,
+            "max": self.maximum if self.maximum is not None else 0.0,
+            "sum": self.sum,
+            "count": self.count,
+        }
+
+    def __repr__(self) -> str:
+        """String representation for debugging."""
+        return (
+            f"SEHHistogram(count={self.count}, buckets={len(self.buckets)}, "
+            f"min={self.minimum}, max={self.maximum}, sum={self.sum})"
+        )

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/collectors/test_base_collector.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/collectors/test_base_collector.py
@@ -1,0 +1,124 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import threading
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from amazon.opentelemetry.distro.serviceevents.collectors.base_collector import BaseCollector
+
+
+class _CountingCollector(BaseCollector):
+    """Concrete BaseCollector that records each collect() call and can signal completion."""
+
+    def __init__(self, flush_interval_ms=10, name="CountingCollector", raise_on_collect=False):
+        super().__init__(flush_interval_ms=flush_interval_ms, name=name)
+        self.collect_count = 0
+        self.raise_on_collect = raise_on_collect
+        self.collected = threading.Event()
+
+    def collect(self):
+        self.collect_count += 1
+        self.collected.set()
+        if self.raise_on_collect:
+            raise ValueError("boom")
+
+
+class TestBaseCollector(TestCase):
+    """Cover BaseCollector start/stop/_run_loop/_reset_for_fork threading paths."""
+
+    def test_start_launches_loop_thread_and_stop_joins_cleanly(self):
+        """start() runs the loop thread; stop() sets state false and joins it."""
+        collector = _CountingCollector(flush_interval_ms=10)
+        try:
+            collector.start()
+            self.assertTrue(collector._running)
+            self.assertIsNotNone(collector._thread)
+            # Wait deterministically for at least one collection rather than sleeping.
+            self.assertTrue(collector.collected.wait(timeout=5.0))
+        finally:
+            collector.stop()
+
+        self.assertFalse(collector._running)
+        collector._thread.join(timeout=5.0)
+        self.assertFalse(collector._thread.is_alive())
+
+    def test_start_twice_logs_already_running_and_returns(self):
+        """A second start() hits the _running guard and does not spawn a new thread."""
+        collector = _CountingCollector(flush_interval_ms=10)
+        try:
+            collector.start()
+            self.assertTrue(collector.collected.wait(timeout=5.0))
+            first_thread = collector._thread
+
+            collector.start()
+
+            # Guard returned early: same thread object, still running.
+            self.assertIs(collector._thread, first_thread)
+            self.assertTrue(collector._running)
+        finally:
+            collector.stop()
+        collector._thread.join(timeout=5.0)
+
+    def test_stop_when_not_running_returns_early(self):
+        """stop() on a never-started collector returns without touching the (None) thread."""
+        collector = _CountingCollector(flush_interval_ms=10)
+
+        collector.stop()
+
+        self.assertFalse(collector._running)
+        self.assertIsNone(collector._thread)
+
+    def test_collect_exception_is_caught_by_run_loop(self):
+        """collect() raising is swallowed by _run_loop so telemetry never crashes the host."""
+        collector = _CountingCollector(flush_interval_ms=10, raise_on_collect=True)
+        try:
+            collector.start()
+            # First periodic collect() raises but the loop survives.
+            self.assertTrue(collector.collected.wait(timeout=5.0))
+            self.assertTrue(collector._thread.is_alive())
+        finally:
+            # stop() triggers the final collect() too; both raise and are caught.
+            collector.stop()
+
+        self.assertFalse(collector._running)
+        collector._thread.join(timeout=5.0)
+        self.assertFalse(collector._thread.is_alive())
+        self.assertGreaterEqual(collector.collect_count, 1)
+
+    def test_stop_warns_when_thread_does_not_stop_cleanly(self):
+        """stop() logs a warning when the worker thread is still alive after join timeout."""
+        collector = _CountingCollector(flush_interval_ms=10)
+        # Simulate a thread that refuses to die within the join timeout.
+        fake_thread = MagicMock()
+        fake_thread.is_alive.return_value = True
+        collector._thread = fake_thread
+        collector._running = True
+
+        with self.assertLogs(
+            "amazon.opentelemetry.distro.serviceevents.collectors.base_collector", level="WARNING"
+        ) as captured:
+            collector.stop()
+
+        fake_thread.join.assert_called_once_with(timeout=5.0)
+        self.assertTrue(any("did not stop cleanly" in line for line in captured.output))
+        self.assertFalse(collector._running)
+
+    def test_flush_interval_sec_derived_from_ms(self):
+        """flush_interval_sec is the millisecond value divided by 1000."""
+        collector = _CountingCollector(flush_interval_ms=2500)
+        self.assertEqual(collector.flush_interval_sec, 2.5)
+
+    def test_reset_for_fork_resets_thread_state(self):
+        """_reset_for_fork clears the dead thread and running flag and swaps the stop event."""
+        collector = _CountingCollector(flush_interval_ms=10)
+        old_event = collector._stop_event
+        collector._thread = MagicMock()
+        collector._running = True
+
+        collector._reset_for_fork()
+
+        self.assertIsNone(collector._thread)
+        self.assertFalse(collector._running)
+        self.assertIsNot(collector._stop_event, old_event)
+        self.assertFalse(collector._stop_event.is_set())

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/collectors/test_deployment_event_collector.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/collectors/test_deployment_event_collector.py
@@ -1,0 +1,84 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from amazon.opentelemetry.distro.serviceevents.collectors.deployment_event_collector import DeploymentEventCollector
+
+
+class TestDeploymentEventCollector(TestCase):
+    """Trigger labeling and fork re-arm for DeploymentEventCollector."""
+
+    def _build(self):
+        emitter = MagicMock()
+        collector = DeploymentEventCollector(
+            flush_interval_ms=86_400_000,
+            environment="testing",
+            service_name="test-svc",
+            otlp_emitter=emitter,
+        )
+        # The real loop sets _running=True before calling collect(); mirror that so the
+        # trigger labeling ("periodic" vs "shutdown") matches a live collector without
+        # spinning up the background daemon thread.
+        collector._running = True
+        return collector, emitter
+
+    def _triggers(self, emitter):
+        return [call.kwargs.get("trigger") for call in emitter.emit_deployment_event.call_args_list]
+
+    def test_first_collect_is_startup_then_periodic(self):
+        """First emit is 'startup'; subsequent emits while running are 'periodic'."""
+        collector, emitter = self._build()
+
+        collector.collect()
+        collector.collect()
+
+        self.assertEqual(self._triggers(emitter), ["startup", "periodic"])
+
+    def test_final_collect_after_stop_is_shutdown(self):
+        """After _running flips false (stop), the next collect is labeled 'shutdown'."""
+        collector, emitter = self._build()
+        collector.collect()  # startup
+        collector._running = False
+
+        collector.collect()
+
+        self.assertEqual(self._triggers(emitter)[-1], "shutdown")
+
+    def test_reset_for_fork_rearms_startup(self):
+        """Each forked worker re-emits its own 'startup' on first collect after fork."""
+        collector, emitter = self._build()
+        collector.collect()  # parent: startup, _first_collect now False
+        self.assertFalse(collector._first_collect)
+
+        collector._reset_for_fork()
+
+        self.assertTrue(collector._first_collect)
+        collector.collect()
+        self.assertEqual(self._triggers(emitter)[-1], "startup")
+
+    def test_collect_no_emitter_is_noop(self):
+        """With no emitter configured, collect() returns early without arming the startup flag."""
+        collector = DeploymentEventCollector(
+            flush_interval_ms=86_400_000,
+            environment="testing",
+            service_name="test-svc",
+            otlp_emitter=None,
+        )
+        collector._running = True
+
+        collector.collect()
+
+        # Early return happens before the startup-flag transition.
+        self.assertTrue(collector._first_collect)
+
+    def test_collect_swallows_emit_errors(self):
+        """An emitter failure is swallowed so telemetry never crashes the customer app."""
+        collector, emitter = self._build()
+        emitter.emit_deployment_event.side_effect = RuntimeError("boom")
+
+        # Should not raise despite the emitter blowing up.
+        collector.collect()
+
+        emitter.emit_deployment_event.assert_called_once()

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/collectors/test_endpoint_collector.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/collectors/test_endpoint_collector.py
@@ -1,0 +1,575 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import threading
+import time
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from amazon.opentelemetry.distro.serviceevents.collectors.endpoint_collector import EndpointMetricCollector
+from amazon.opentelemetry.distro.serviceevents.python_monitor import _ServiceEventsMonitorState
+
+
+class TestEndpointMetricCollector(TestCase):
+    """Test the EndpointMetricCollector class."""
+
+    def setUp(self):
+        """Reset monitor state before each test."""
+        _ServiceEventsMonitorState._instance = None
+
+    def test_init_with_explicit_params(self):
+        """Test collector initialization with explicit parameters."""
+        collector = EndpointMetricCollector(
+            flush_interval_ms=10000,
+            environment="testing",
+            service_name="test-service",
+            sdk_version="1.0.0",
+        )
+
+        self.assertEqual(collector.flush_interval_ms, 10000)
+        self.assertEqual(collector.environment, "testing")
+        self.assertEqual(collector.service_name, "test-service")
+        self.assertEqual(collector.sdk_version, "1.0.0")
+        self.assertEqual(collector.name, "EndpointMetricCollector")
+
+    @patch.dict("os.environ", {"OTEL_SERVICE_NAME": "api-svc"})
+    def test_init_with_defaults(self):
+        """Test collector initialization with default values."""
+        collector = EndpointMetricCollector(flush_interval_ms=5000, environment="production")
+
+        self.assertEqual(collector.environment, "production")
+        self.assertEqual(collector.service_name, "api-svc")
+        self.assertEqual(collector.sdk_version, "0.14.2")
+
+    def test_record_request_creates_aggregation_entry(self):
+        """Test that record_request creates an aggregation entry."""
+        collector = EndpointMetricCollector(flush_interval_ms=10000)
+
+        collector.record_request(
+            route="/api/users",
+            method="GET",
+            status_code=200,
+            duration_ns=50_000_000,  # 50ms
+        )
+
+        self.assertEqual(len(collector._aggregations), 1)
+        # Get the single entry
+        operation = list(collector._aggregations.keys())[0]
+        agg = collector._aggregations[operation]
+        # route and method are no longer stored in aggregation; operation is the key
+        self.assertEqual(agg["count"], 1)
+        self.assertEqual(agg["faults"], 0)
+        self.assertEqual(agg["errors"], 0)
+        self.assertIsNotNone(agg["seh_histogram"])
+        self.assertEqual(agg["incidents_exemplar"], [])
+
+    def test_record_request_increments_count(self):
+        """Test that multiple record_request calls increment the count."""
+        collector = EndpointMetricCollector(flush_interval_ms=10000)
+
+        for _ in range(5):
+            collector.record_request(
+                route="/api/users",
+                method="GET",
+                status_code=200,
+                duration_ns=50_000_000,
+            )
+
+        operation = list(collector._aggregations.keys())[0]
+        self.assertEqual(collector._aggregations[operation]["count"], 5)
+
+    def test_record_request_with_error_info(self):
+        """Test that error recording populates error_breakdown."""
+        collector = EndpointMetricCollector(flush_interval_ms=10000)
+
+        collector.record_request(
+            route="/api/users",
+            method="POST",
+            status_code=500,
+            duration_ns=100_000_000,
+            error_info={"error_type": "ValueError", "function_name": "func_123"},
+        )
+
+        operation = list(collector._aggregations.keys())[0]
+        agg = collector._aggregations[operation]
+        self.assertEqual(agg["count"], 1)
+        # Check error_breakdown
+        self.assertIn("500", agg["error_breakdown"])
+        error_key = "ValueError:func_123"
+        self.assertIn(error_key, agg["error_breakdown"]["500"])
+        self.assertEqual(agg["error_breakdown"]["500"][error_key]["count"], 1)
+
+    def test_collect_with_empty_data(self):
+        """Test that collect with no data doesn't crash."""
+        collector = EndpointMetricCollector(flush_interval_ms=10000)
+        # Should not raise any exception
+        collector.collect()
+
+    def test_collect_swaps_aggregations(self):
+        """Test that collect swaps aggregations - old data returned, internal state cleared."""
+        collector = EndpointMetricCollector(
+            flush_interval_ms=10000,
+            environment="testing",
+            service_name="test-svc",
+            otlp_emitter=MagicMock(),
+        )
+
+        collector.record_request(
+            route="/api/items",
+            method="GET",
+            status_code=200,
+            duration_ns=10_000_000,
+        )
+
+        # Verify there's data before collect
+        self.assertEqual(len(collector._aggregations), 1)
+
+        collector.collect()
+
+        # After collect, aggregations should be empty
+        self.assertEqual(len(collector._aggregations), 0)
+
+    def test_emit_endpoint_summary_event_fields(self):
+        """The EndpointMetricEvent handed to the emitter carries operation/route/method/count."""
+        emitter = MagicMock()
+        collector = EndpointMetricCollector(
+            flush_interval_ms=10000,
+            environment="testing",
+            service_name="test-svc",
+            otlp_emitter=emitter,
+        )
+
+        collector.record_request(
+            route="/health",
+            method="GET",
+            status_code=200,
+            duration_ns=5_000_000,
+        )
+
+        collector.collect()
+
+        emitter.emit_endpoint_summary.assert_called_once()
+        event = emitter.emit_endpoint_summary.call_args[0][0]
+        self.assertEqual(event.operation, "GET /health")
+        self.assertEqual(event.route, "/health")
+        self.assertEqual(event.method, "GET")
+        self.assertEqual(event.count, 1)
+        self.assertEqual(event.telemetry_type, "EndpointSummary")
+
+    def test_start_stop_lifecycle(self):
+        """Test starting and stopping the collector."""
+        collector = EndpointMetricCollector(flush_interval_ms=100)
+
+        collector.start()
+        self.assertTrue(collector._running)
+        self.assertIsNotNone(collector._thread)
+        self.assertTrue(collector._thread.is_alive())
+
+        time.sleep(0.05)
+
+        collector.stop()
+        self.assertFalse(collector._running)
+
+        time.sleep(0.2)
+        self.assertFalse(collector._thread.is_alive())
+
+    def test_concurrent_record_request(self):
+        """Test concurrent record_request from multiple threads."""
+        collector = EndpointMetricCollector(flush_interval_ms=10000)
+        errors = []
+
+        def record_requests(thread_id):
+            try:
+                for i in range(50):
+                    collector.record_request(
+                        route="/api/items",
+                        method="GET",
+                        status_code=200,
+                        duration_ns=10_000_000,
+                    )
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=record_requests, args=(i,)) for i in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertEqual(len(errors), 0, f"Errors during concurrent access: {errors}")
+        # All 200 requests should be counted
+        operation = list(collector._aggregations.keys())[0]
+        self.assertEqual(collector._aggregations[operation]["count"], 200)
+
+    def test_different_routes_create_separate_entries(self):
+        """Test that different route/method combos create separate aggregation entries."""
+        collector = EndpointMetricCollector(flush_interval_ms=10000)
+
+        collector.record_request(route="/api/users", method="GET", status_code=200, duration_ns=10_000_000)
+        collector.record_request(route="/api/users", method="POST", status_code=201, duration_ns=20_000_000)
+        collector.record_request(route="/api/items", method="GET", status_code=200, duration_ns=15_000_000)
+
+        self.assertEqual(len(collector._aggregations), 3)
+
+    def test_error_info_not_recorded_below_400(self):
+        """Test that error_info is not recorded for status codes below 400."""
+        collector = EndpointMetricCollector(flush_interval_ms=10000)
+
+        collector.record_request(
+            route="/api/users",
+            method="GET",
+            status_code=200,
+            duration_ns=10_000_000,
+            error_info={"error_type": "ValueError", "function_name": "func_123"},
+        )
+
+        operation = list(collector._aggregations.keys())[0]
+        agg = collector._aggregations[operation]
+        # error_breakdown should be empty since status < 400
+        self.assertEqual(len(agg["error_breakdown"]), 0)
+
+    def test_5xx_increments_faults(self):
+        """Test that 5xx status codes increment faults counter."""
+        collector = EndpointMetricCollector(flush_interval_ms=10000)
+
+        collector.record_request(route="/api/users", method="GET", status_code=500, duration_ns=10_000_000)
+        collector.record_request(route="/api/users", method="GET", status_code=503, duration_ns=10_000_000)
+        collector.record_request(route="/api/users", method="GET", status_code=200, duration_ns=10_000_000)
+
+        operation = list(collector._aggregations.keys())[0]
+        agg = collector._aggregations[operation]
+        self.assertEqual(agg["faults"], 2)
+        self.assertEqual(agg["errors"], 0)
+        self.assertEqual(agg["count"], 3)
+
+    def test_4xx_increments_errors(self):
+        """Test that 4xx status codes increment errors counter, not faults."""
+        collector = EndpointMetricCollector(flush_interval_ms=10000)
+
+        collector.record_request(route="/api/users", method="GET", status_code=400, duration_ns=10_000_000)
+        collector.record_request(route="/api/users", method="GET", status_code=404, duration_ns=10_000_000)
+        collector.record_request(route="/api/users", method="GET", status_code=429, duration_ns=10_000_000)
+
+        operation = list(collector._aggregations.keys())[0]
+        agg = collector._aggregations[operation]
+        self.assertEqual(agg["errors"], 3)
+        self.assertEqual(agg["faults"], 0)
+        self.assertEqual(agg["count"], 3)
+
+    def test_emitted_event_includes_fault_error_duration_fields(self):
+        """The emitted EndpointMetricEvent carries faults, errors, count, and a duration histogram."""
+        emitter = MagicMock()
+        collector = EndpointMetricCollector(
+            flush_interval_ms=10000,
+            environment="testing",
+            service_name="test-svc",
+            otlp_emitter=emitter,
+        )
+
+        collector.record_request(route="/api/users", method="GET", status_code=200, duration_ns=50_000_000)
+        collector.record_request(route="/api/users", method="GET", status_code=500, duration_ns=100_000_000)
+        collector.record_request(route="/api/users", method="GET", status_code=404, duration_ns=30_000_000)
+
+        collector.collect()
+
+        emitter.emit_endpoint_summary.assert_called_once()
+        event = emitter.emit_endpoint_summary.call_args[0][0]
+        self.assertEqual(event.faults, 1)
+        self.assertEqual(event.errors, 1)
+        self.assertEqual(event.count, 3)
+
+        # Duration is a populated DurationMetrics histogram.
+        self.assertIsNotNone(event.duration)
+        self.assertEqual(event.duration.count, 3)
+        self.assertTrue(event.duration.values)
+        self.assertTrue(event.duration.counts)
+
+    def test_format_converts_duration_to_microseconds(self):
+        """Test that duration values are converted from nanoseconds to microseconds."""
+        emitter = MagicMock()
+        collector = EndpointMetricCollector(
+            flush_interval_ms=10000,
+            environment="testing",
+            service_name="test-svc",
+            otlp_emitter=emitter,
+        )
+
+        # Record a single request: 50ms = 50_000_000 ns = 50_000 us
+        collector.record_request(route="/api/test", method="GET", status_code=200, duration_ns=50_000_000)
+
+        collector.collect()
+
+        event = emitter.emit_endpoint_summary.call_args[0][0]
+        # Sum should be 50_000 microseconds (50ms)
+        self.assertAlmostEqual(event.duration.sum, 50_000.0, places=1)
+
+    def test_record_incident_exemplar(self):
+        """Test that record_incident_exemplar stores exemplar in aggregation."""
+        collector = EndpointMetricCollector(flush_interval_ms=10000)
+
+        # First record a request to create the aggregation entry
+        collector.record_request(route="/api/users", method="GET", status_code=500, duration_ns=10_000_000)
+
+        operation = list(collector._aggregations.keys())[0]
+
+        # Now record an incident exemplar
+        exemplar = {
+            "snapshot_id": "snap_abc123",
+            "trigger_type": "exception",
+            "severity": "critical",
+            "operation": operation,
+            "timestamp": 1706745600000,
+        }
+        collector.record_incident_exemplar(operation, exemplar)
+
+        agg = collector._aggregations[operation]
+        self.assertEqual(len(agg["incidents_exemplar"]), 1)
+        self.assertEqual(agg["incidents_exemplar"][0]["snapshot_id"], "snap_abc123")
+
+    def test_record_incident_exemplar_no_aggregation(self):
+        """Test that record_incident_exemplar is safe when no aggregation exists."""
+        collector = EndpointMetricCollector(flush_interval_ms=10000)
+
+        # Record exemplar for non-existent endpoint — should not raise
+        collector.record_incident_exemplar(
+            "nonexistent-id",
+            {
+                "snapshot_id": "snap_xyz",
+                "trigger_type": "exception",
+                "severity": "high",
+                "timestamp": 1706745600000,
+            },
+        )
+
+        # No aggregation created
+        self.assertEqual(len(collector._aggregations), 0)
+
+    def test_incidents_exemplar_in_emitted_event(self):
+        """The emitted event includes incident_count and the recorded incident exemplars."""
+        emitter = MagicMock()
+        collector = EndpointMetricCollector(
+            flush_interval_ms=10000,
+            environment="testing",
+            service_name="test-svc",
+            otlp_emitter=emitter,
+        )
+
+        collector.record_request(route="/api/users", method="GET", status_code=500, duration_ns=10_000_000)
+        operation = list(collector._aggregations.keys())[0]
+
+        collector.record_incident_exemplar(
+            operation,
+            {
+                "snapshot_id": "snap_001",
+                "trigger_type": "exception",
+                "severity": "critical",
+                "operation": operation,
+                "timestamp": 1706745600000,
+            },
+        )
+        collector.record_incident_exemplar(
+            operation,
+            {
+                "snapshot_id": "snap_002",
+                "trigger_type": "exception",
+                "severity": "high",
+                "operation": operation,
+                "timestamp": 1706745601000,
+            },
+        )
+
+        collector.collect()
+
+        event = emitter.emit_endpoint_summary.call_args[0][0]
+        self.assertEqual(event.incident_count, 2)
+        self.assertEqual(len(event.incidents_exemplar), 2)
+        self.assertEqual(event.incidents_exemplar[0].snapshot_id, "snap_001")
+        self.assertEqual(event.incidents_exemplar[1].snapshot_id, "snap_002")
+
+    def test_no_incidents_defaults(self):
+        """Test that endpoints with no incidents have zero count and empty exemplar."""
+        emitter = MagicMock()
+        collector = EndpointMetricCollector(
+            flush_interval_ms=10000,
+            environment="testing",
+            service_name="test-svc",
+            otlp_emitter=emitter,
+        )
+
+        collector.record_request(route="/api/healthy", method="GET", status_code=200, duration_ns=5_000_000)
+
+        collector.collect()
+
+        event = emitter.emit_endpoint_summary.call_args[0][0]
+        self.assertEqual(event.incident_count, 0)
+        self.assertEqual(event.incidents_exemplar, [])
+
+    def test_error_metrics_emitted_per_error_type(self):
+        """collect() emits one EndpointErrorMetric per error type alongside the summary."""
+        emitter = MagicMock()
+        collector = EndpointMetricCollector(
+            flush_interval_ms=10000,
+            environment="testing",
+            service_name="test-svc",
+            otlp_emitter=emitter,
+        )
+
+        for _ in range(3):
+            collector.record_request(
+                route="/api/users",
+                method="POST",
+                status_code=500,
+                duration_ns=10_000_000,
+                error_info={"error_type": "RuntimeError", "function_name": "func_a"},
+            )
+        for _ in range(2):
+            collector.record_request(
+                route="/api/users",
+                method="POST",
+                status_code=400,
+                duration_ns=10_000_000,
+                error_info={"error_type": "ValueError", "function_name": "func_b"},
+            )
+
+        collector.collect()
+
+        # EndpointSummary emitted once.
+        emitter.emit_endpoint_summary.assert_called_once()
+
+        # Per-error-type metrics emitted: one EndpointErrorMetric per error type.
+        emitter.emit_endpoint_error_metrics.assert_called_once()
+        metrics = emitter.emit_endpoint_error_metrics.call_args[0][0]
+        by_exception = {m.exception: m for m in metrics}
+        self.assertEqual(set(by_exception), {"RuntimeError", "ValueError"})
+        self.assertEqual(by_exception["RuntimeError"].count, 3)
+        self.assertEqual(by_exception["ValueError"].count, 2)
+        for metric in metrics:
+            self.assertEqual(metric.telemetry_type, "EndpointErrorMetric")
+
+    def test_no_error_metrics_emitted_without_errors(self):
+        """No EndpointErrorMetric is emitted when there are no errors (summary only)."""
+        emitter = MagicMock()
+        collector = EndpointMetricCollector(
+            flush_interval_ms=10000,
+            environment="testing",
+            service_name="test-svc",
+            otlp_emitter=emitter,
+        )
+        collector.record_request(route="/api/healthy", method="GET", status_code=200, duration_ns=5_000_000)
+
+        collector.collect()
+
+        emitter.emit_endpoint_summary.assert_called_once()
+        emitter.emit_endpoint_error_metrics.assert_not_called()
+
+
+class TestEndpointCollectorAppSignalsSuppression(TestCase):
+    """EndpointSummary suppression when Application Signals is enabled.
+
+    App Signals carries equivalent per-endpoint duration + error metrics, so emitting
+    EndpointSummary in bundled mode duplicates data on the backend. The collector
+    still runs (latency histograms feed IncidentSnapshot triggers), but stops emitting
+    the aws.service_events.endpoint_summary LogRecord.
+
+    EndpointErrorMetric (per-exception-type breakdown) is ServiceEvents-specific and always
+    emits regardless — App Signals doesn't carry the same shape.
+    """
+
+    def setUp(self) -> None:
+        _ServiceEventsMonitorState._instance = None
+
+    def _build_collector_with_emitter(self, suppress: bool) -> tuple:
+        emitter = MagicMock()
+        collector = EndpointMetricCollector(
+            flush_interval_ms=10000,
+            environment="testing",
+            service_name="svc",
+            otlp_emitter=emitter,
+            suppress_endpoint_summary=suppress,
+        )
+        return collector, emitter
+
+    def test_suppress_true_skips_endpoint_summary_emit(self) -> None:
+        collector, emitter = self._build_collector_with_emitter(suppress=True)
+        collector.record_request(route="/api/users", method="GET", status_code=200, duration_ns=10_000_000)
+
+        collector.collect()
+
+        emitter.emit_endpoint_summary.assert_not_called()
+
+    def test_suppress_true_still_emits_error_metrics(self) -> None:
+        """EndpointErrorMetric carries per-exception-type breakdown App Signals doesn't have."""
+        collector, emitter = self._build_collector_with_emitter(suppress=True)
+        collector.record_request(
+            route="/api/users",
+            method="POST",
+            status_code=500,
+            duration_ns=10_000_000,
+            error_info={"error_type": "RuntimeError", "function_name": "handler"},
+        )
+
+        collector.collect()
+
+        emitter.emit_endpoint_summary.assert_not_called()
+        emitter.emit_endpoint_error_metrics.assert_called()
+
+    def test_suppress_false_emits_both(self) -> None:
+        """Default bundled-off path: both signals emit as they always have."""
+        collector, emitter = self._build_collector_with_emitter(suppress=False)
+        collector.record_request(
+            route="/api/users",
+            method="POST",
+            status_code=500,
+            duration_ns=10_000_000,
+            error_info={"error_type": "RuntimeError", "function_name": "handler"},
+        )
+
+        collector.collect()
+
+        emitter.emit_endpoint_summary.assert_called_once()
+        emitter.emit_endpoint_error_metrics.assert_called_once()
+
+    def test_suppress_true_does_not_clear_aggregations_via_shortcut(self) -> None:
+        """Suppression is emit-path only: internal aggregation swap still happens."""
+        collector, _emitter = self._build_collector_with_emitter(suppress=True)
+        collector.record_request(route="/api/users", method="GET", status_code=200, duration_ns=10_000_000)
+        self.assertEqual(len(collector._aggregations), 1)
+
+        collector.collect()
+
+        # Aggregations swapped out on collect() regardless of suppression.
+        self.assertEqual(len(collector._aggregations), 0)
+
+    def test_suppress_default_is_false(self) -> None:
+        """Keyword-only arg with default False preserves backward compatibility."""
+        collector = EndpointMetricCollector(flush_interval_ms=10000)
+        self.assertFalse(collector.suppress_endpoint_summary)
+
+
+class TestEndpointCollectorForkReset(TestCase):
+    """Fork-safety: child must not inherit the parent's accumulated aggregations."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+
+    def test_reset_for_fork_clears_aggregations(self):
+        """Inherited aggregations are dropped so the child doesn't re-emit parent metrics."""
+        collector = EndpointMetricCollector(flush_interval_ms=10000)
+        collector.record_request(route="/api/users", method="GET", status_code=200, duration_ns=1_000_000)
+        self.assertEqual(len(collector._aggregations), 1)
+
+        collector._reset_for_fork()
+
+        self.assertEqual(len(collector._aggregations), 0)
+
+    def test_reset_for_fork_recreates_lock_and_refreshes_pid(self):
+        """A fresh lock (parent thread may have held the old one) and the child's pid."""
+        collector = EndpointMetricCollector(flush_interval_ms=10000)
+        old_lock = collector._aggregations_lock
+
+        collector._reset_for_fork()
+
+        self.assertIsNot(collector._aggregations_lock, old_lock)
+        # New lock is unlocked and usable.
+        self.assertTrue(collector._aggregations_lock.acquire(blocking=False))
+        collector._aggregations_lock.release()

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/collectors/test_endpoint_collector.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/collectors/test_endpoint_collector.py
@@ -39,7 +39,9 @@ class TestEndpointMetricCollector(TestCase):
 
         self.assertEqual(collector.environment, "production")
         self.assertEqual(collector.service_name, "api-svc")
-        self.assertEqual(collector.sdk_version, "0.14.2")
+        # sdk_version defaults to "" (must be provided by the caller, which always passes
+        # ServiceEventsConfig.sdk_version = ADOT_VERSION); the old "0.14.2" default was stale.
+        self.assertEqual(collector.sdk_version, "")
 
     def test_record_request_creates_aggregation_entry(self):
         """Test that record_request creates an aggregation entry."""

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/collectors/test_incident_snapshot_collector.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/collectors/test_incident_snapshot_collector.py
@@ -1,0 +1,1813 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import hashlib
+import time
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from amazon.opentelemetry.distro.serviceevents.collectors.incident_snapshot_collector import IncidentSnapshotCollector
+from amazon.opentelemetry.distro.serviceevents.models import (
+    CallPathEntry,
+    ExceptionInfo,
+    IncidentSnapshot,
+    RequestContext,
+    ResourceAttributes,
+    TelemetryCorrelation,
+)
+from amazon.opentelemetry.distro.serviceevents.python_monitor import _ServiceEventsMonitorState
+
+
+class TestDetermineTriggerType(TestCase):
+    """Test the _determine_trigger_type method."""
+
+    def setUp(self):
+        """Reset monitor state before each test."""
+        _ServiceEventsMonitorState._instance = None
+
+    def test_exception_trigger(self):
+        """Test that exception returns 'exception' trigger type."""
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=100,
+        )
+
+        result = collector._determine_trigger_type(
+            status_code=500,
+            duration_ms=50.0,
+            exception=ValueError("test"),
+        )
+        self.assertEqual(result, "exception")
+
+    def test_error_status_trigger(self):
+        """Test that status >= 500 without exception returns 'exception'."""
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=100,
+        )
+
+        result = collector._determine_trigger_type(
+            status_code=500,
+            duration_ms=50.0,
+            exception=None,
+        )
+        self.assertEqual(result, "exception")
+
+    def test_latency_trigger(self):
+        """Test that slow request triggers 'latency'."""
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=100,
+            max_per_period=100,
+        )
+
+        result = collector._determine_trigger_type(
+            status_code=200,
+            duration_ms=150.0,
+            exception=None,
+        )
+        self.assertEqual(result, "latency")
+
+    def test_no_trigger(self):
+        """Test that normal request (200 OK, fast) returns None."""
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=100,
+        )
+
+        result = collector._determine_trigger_type(
+            status_code=200,
+            duration_ms=50.0,
+            exception=None,
+        )
+        self.assertIsNone(result)
+
+    def test_exception_with_error_status(self):
+        """Test that exception + status >= 500 returns 'exception'."""
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=100,
+        )
+
+        result = collector._determine_trigger_type(
+            status_code=500,
+            duration_ms=50.0,
+            exception=RuntimeError("server error"),
+        )
+        self.assertEqual(result, "exception")
+
+    def test_latency_with_per_operation_threshold(self):
+        """Test latency trigger with per-operation threshold (exact match)."""
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,  # default high
+            max_per_period=100,
+        )
+
+        # Set a low threshold for this specific operation
+        collector.set_latency_threshold("GET /api/users", 50.0)
+
+        result = collector._determine_trigger_type(
+            status_code=200,
+            duration_ms=75.0,
+            exception=None,
+            operation="GET /api/users",
+        )
+        self.assertEqual(result, "latency")
+
+
+class TestDetermineSeverity(TestCase):
+    """Test the _determine_severity method."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+
+    def _make_collector(self):
+        return IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=100,
+        )
+
+    def test_critical_500(self):
+        """Test that status 500 returns 'critical'."""
+        collector = self._make_collector()
+        self.assertEqual(collector._determine_severity(500, "exception"), "critical")
+
+    def test_critical_503(self):
+        """Test that status 503 returns 'critical'."""
+        collector = self._make_collector()
+        self.assertEqual(collector._determine_severity(503, "exception"), "critical")
+
+    def test_high_504(self):
+        """Test that status 504 returns 'high'."""
+        collector = self._make_collector()
+        self.assertEqual(collector._determine_severity(504, "exception"), "high")
+
+    def test_high_exception(self):
+        """Test that exception trigger returns 'high'."""
+        collector = self._make_collector()
+        self.assertEqual(collector._determine_severity(200, "exception"), "high")
+
+    def test_medium_latency(self):
+        """Test that latency trigger returns 'medium'."""
+        collector = self._make_collector()
+        self.assertEqual(collector._determine_severity(200, "latency"), "medium")
+
+    def test_low_default(self):
+        """Test default severity is 'low'."""
+        collector = self._make_collector()
+        self.assertEqual(collector._determine_severity(200, "some_other"), "low")
+
+
+class TestCheckRateLimit(TestCase):
+    """Test the _check_rate_limit method."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+
+    def test_allows_within_limit(self):
+        """Test that requests within limit are allowed."""
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=5,
+        )
+
+        for _ in range(5):
+            self.assertTrue(collector._check_rate_limit())
+
+    def test_denies_over_limit(self):
+        """Test that requests over limit are denied."""
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=3,
+        )
+
+        # Fill up the limit
+        for _ in range(3):
+            self.assertTrue(collector._check_rate_limit())
+
+        # Next should be denied
+        self.assertFalse(collector._check_rate_limit())
+
+    def test_old_entries_expire(self):
+        """Test that old entries expire and free up capacity."""
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=2,
+        )
+
+        # Fill up the limit
+        self.assertTrue(collector._check_rate_limit())
+        self.assertTrue(collector._check_rate_limit())
+        self.assertFalse(collector._check_rate_limit())
+
+        # Manually age out old entries by modifying timestamps
+        with collector._timestamps_lock:
+            old_time = time.time() - 7200  # well past the fixed 60s window
+            collector._snapshot_timestamps.clear()
+            collector._snapshot_timestamps.append(old_time)
+            collector._snapshot_timestamps.append(old_time)
+
+        # Now should be allowed (old entries expired)
+        self.assertTrue(collector._check_rate_limit())
+
+
+class TestGenerateErrorHash(TestCase):
+    """Test the _generate_error_hash method."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+
+    def test_with_exception(self):
+        """Test hash with exception type and message."""
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=100,
+        )
+
+        exc = ValueError("test error")
+        result = collector._generate_error_hash("/api/users", exc)
+
+        expected_input = "route:/api/users|exc:ValueError:test error"
+        expected = hashlib.md5(expected_input.encode("utf-8")).hexdigest()
+        self.assertEqual(result, expected)
+
+    def test_without_exception(self):
+        """Test hash without exception (slow request)."""
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=100,
+        )
+
+        result = collector._generate_error_hash("/api/users", None)
+
+        expected_input = "route:/api/users"
+        expected = hashlib.md5(expected_input.encode("utf-8")).hexdigest()
+        self.assertEqual(result, expected)
+
+    def test_different_routes_different_hashes(self):
+        """Test that different routes produce different hashes."""
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=100,
+        )
+
+        hash1 = collector._generate_error_hash("/api/users", None)
+        hash2 = collector._generate_error_hash("/api/items", None)
+        self.assertNotEqual(hash1, hash2)
+
+
+class TestCheckDeduplication(TestCase):
+    """Test the _check_deduplication method."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+
+    def test_first_occurrence_allowed(self):
+        """Test that first occurrence of an error hash is allowed."""
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=100,
+            max_same_error=2,
+        )
+
+        self.assertTrue(collector._check_deduplication("error_hash_1"))
+
+    def test_blocks_after_max_same_error(self):
+        """Test that error is blocked after max_same_error occurrences."""
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=100,
+            max_same_error=2,
+        )
+
+        self.assertTrue(collector._check_deduplication("error_hash_1"))
+        self.assertTrue(collector._check_deduplication("error_hash_1"))
+        # Third should be blocked (max_same_error=2)
+        self.assertFalse(collector._check_deduplication("error_hash_1"))
+
+    def test_batch_deduplication(self):
+        """Test batch-level deduplication (one per error type per batch)."""
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=100,
+            max_same_error=10,  # High limit so period dedup doesn't interfere
+        )
+
+        # Add to current batch hashes
+        with collector._error_hashes_lock:
+            collector._current_batch_hashes.add("batch_error_1")
+
+        # It's already in the batch, so process_potential_incident would skip it
+        # We test this directly on the set
+        self.assertIn("batch_error_1", collector._current_batch_hashes)
+
+    def test_different_hashes_independent(self):
+        """Test that different error hashes are tracked independently."""
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=100,
+            max_same_error=1,
+        )
+
+        self.assertTrue(collector._check_deduplication("hash_a"))
+        self.assertTrue(collector._check_deduplication("hash_b"))
+        # hash_a is at limit
+        self.assertFalse(collector._check_deduplication("hash_a"))
+        # hash_b is at limit
+        self.assertFalse(collector._check_deduplication("hash_b"))
+        # New hash is fine
+        self.assertTrue(collector._check_deduplication("hash_c"))
+
+
+class TestSetAndGetLatencyThreshold(TestCase):
+    """Test latency threshold setting and retrieval."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+
+    def test_set_exact_operation(self):
+        """Test setting latency threshold by exact operation."""
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=500,
+            max_per_period=100,
+        )
+
+        collector.set_latency_threshold("GET /api/users", 200.0)
+
+        result = collector.get_latency_threshold(operation="GET /api/users")
+        self.assertEqual(result, 200.0)
+
+    def test_set_by_route_method_combo(self):
+        """Test setting latency threshold by route/method combination."""
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=500,
+            max_per_period=100,
+        )
+
+        op = collector.set_latency_threshold_by_route("/api/users", "GET", 100.0)
+        self.assertIsNotNone(op)
+        self.assertEqual(op, "GET /api/users")
+
+        result = collector.get_latency_threshold(operation=op)
+        self.assertEqual(result, 100.0)
+
+    def test_pattern_matching(self):
+        """Test pattern-based threshold matching."""
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=500,
+            max_per_period=100,
+        )
+
+        collector.set_latency_threshold_patterns(
+            [
+                ("* /server_request", 50.0),
+                ("GET /api/*", 100.0),
+            ]
+        )
+
+        # Matches first pattern
+        result = collector.get_latency_threshold(route="/server_request", method="GET")
+        self.assertEqual(result, 50.0)
+
+        # Matches second pattern
+        result = collector.get_latency_threshold(route="/api/users", method="GET")
+        self.assertEqual(result, 100.0)
+
+    def test_fallback_to_default(self):
+        """Test that unknown endpoints fall back to default threshold."""
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=500,
+            max_per_period=100,
+        )
+
+        result = collector.get_latency_threshold(operation="nonexistent")
+        self.assertEqual(result, 500.0)
+
+    def test_get_all_latency_thresholds(self):
+        """Test retrieving all configured exact-match thresholds."""
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=500,
+            max_per_period=100,
+        )
+
+        collector.set_latency_threshold("GET /api/users", 100.0)
+        collector.set_latency_threshold("POST /api/orders", 200.0)
+
+        result = collector.get_all_latency_thresholds()
+        self.assertEqual(result, {"GET /api/users": 100.0, "POST /api/orders": 200.0})
+
+    def test_get_all_latency_threshold_patterns(self):
+        """Test retrieving all configured patterns."""
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=500,
+            max_per_period=100,
+        )
+
+        collector.set_latency_threshold_patterns(
+            [
+                ("* /health", 1000.0),
+                ("POST /api/*", 200.0),
+            ]
+        )
+
+        result = collector.get_all_latency_threshold_patterns()
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0], ("* /health", 1000.0))
+        self.assertEqual(result[1], ("POST /api/*", 200.0))
+
+
+class TestProcessPotentialIncident(TestCase):
+    """Test the process_potential_incident method."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+
+    @patch.object(IncidentSnapshotCollector, "_collect_incident_snapshot")
+    def test_creates_snapshot_for_exception(self, mock_collect):
+        """Test that process_potential_incident creates a snapshot for exceptions."""
+        mock_snapshot = MagicMock()
+        mock_collect.return_value = mock_snapshot
+
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=100,
+        )
+
+        exc = ValueError("test error")
+        collector.process_potential_incident(
+            route="/api/users",
+            method="GET",
+            status_code=500,
+            duration_ms=50.0,
+            exception=exc,
+            request_data={"headers": {}, "args": {}},
+        )
+
+        mock_collect.assert_called_once()
+        self.assertEqual(len(collector._pending_snapshots), 1)
+
+    @patch.object(IncidentSnapshotCollector, "_collect_incident_snapshot")
+    def test_failed_collection_rolls_back_reservation(self, mock_collect):
+        """If collection raises, the dedup/batch/rate-limit slots are released so a later
+        identical error can still produce a snapshot."""
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=5,
+        )
+
+        # First attempt: collection blows up → reservation must be rolled back.
+        mock_collect.side_effect = RuntimeError("boom")
+        result = collector.process_potential_incident(
+            route="/api/users",
+            method="GET",
+            status_code=500,
+            duration_ms=50.0,
+            exception=ValueError("same error"),
+            request_data={"headers": {}, "args": {}},
+        )
+        self.assertIsNone(result)
+        # Slots released: no lingering batch hash, dedup entry, or rate-limit timestamp.
+        self.assertEqual(collector._current_batch_hashes, set())
+        self.assertEqual(collector._error_hashes, {})
+        self.assertEqual(len(collector._snapshot_timestamps), 0)
+
+        # Second attempt with the SAME error now succeeds (was not suppressed by the
+        # failed first attempt's stale reservation).
+        mock_collect.side_effect = None
+        mock_collect.return_value = MagicMock()
+        result = collector.process_potential_incident(
+            route="/api/users",
+            method="GET",
+            status_code=500,
+            duration_ms=50.0,
+            exception=ValueError("same error"),
+            request_data={"headers": {}, "args": {}},
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(len(collector._pending_snapshots), 1)
+
+    def test_no_snapshot_for_normal_request(self):
+        """Test that no snapshot is created for normal requests."""
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=100,
+        )
+
+        collector.process_potential_incident(
+            route="/api/users",
+            method="GET",
+            status_code=200,
+            duration_ms=50.0,
+            exception=None,
+            request_data={"headers": {}, "args": {}},
+        )
+
+        self.assertEqual(len(collector._pending_snapshots), 0)
+
+    @patch.object(IncidentSnapshotCollector, "_collect_incident_snapshot")
+    def test_rate_limited_skip(self, mock_collect):
+        """Test that rate-limited incidents are skipped."""
+        mock_snapshot = MagicMock()
+        mock_collect.return_value = mock_snapshot
+
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=1,  # Only 1 allowed
+        )
+
+        # First should succeed
+        collector.process_potential_incident(
+            route="/api/users",
+            method="GET",
+            status_code=500,
+            duration_ms=50.0,
+            exception=ValueError("error1"),
+            request_data={"headers": {}, "args": {}},
+        )
+
+        # Second should be rate limited
+        collector.process_potential_incident(
+            route="/api/items",
+            method="POST",
+            status_code=500,
+            duration_ms=60.0,
+            exception=RuntimeError("error2"),
+            request_data={"headers": {}, "args": {}},
+        )
+
+        # Only 1 snapshot should have been created
+        self.assertEqual(mock_collect.call_count, 1)
+
+    @patch.object(IncidentSnapshotCollector, "_collect_incident_snapshot")
+    def test_dedup_blocked_requests_dont_consume_rate_limit(self, mock_collect):
+        """Dedup-blocked requests should NOT consume rate limit slots.
+
+        Regression test: Previously _check_rate_limit() ran before dedup checks,
+        so every error attempt consumed a rate limit slot even if dedup rejected it.
+        Under high error rates, this exhausted the rate limit with phantom slots.
+        """
+        mock_snapshot = MagicMock()
+        mock_collect.return_value = mock_snapshot
+
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=100,
+            max_same_error=2,
+        )
+
+        exc = ValueError("same error")
+        # Trigger same error 50 times — only 2 should pass dedup (max_same_error=2)
+        for _ in range(50):
+            collector.process_potential_incident(
+                route="/api/users",
+                method="GET",
+                status_code=500,
+                duration_ms=50.0,
+                exception=exc,
+                request_data={"headers": {}, "args": {}},
+            )
+            # Clear batch hashes between calls to allow period dedup to handle it
+            # (batch dedup would block all after the first within same collect cycle)
+            with collector._error_hashes_lock:
+                collector._current_batch_hashes.clear()
+
+        # Only 2 snapshots should have been created (max_same_error=2)
+        self.assertEqual(mock_collect.call_count, 2)
+        # Rate limit should show only 2 consumed, not 50
+        self.assertEqual(len(collector._snapshot_timestamps), 2)
+
+    @patch.object(IncidentSnapshotCollector, "_collect_incident_snapshot")
+    def test_rate_limit_reserves_capacity_for_different_errors(self, mock_collect):
+        """After dedup blocks one error type, rate limit capacity remains for other errors."""
+        mock_snapshot = MagicMock()
+        mock_collect.return_value = mock_snapshot
+
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=5,
+            max_same_error=1,
+        )
+
+        # Send same error 20 times — only 1 passes dedup
+        for _ in range(20):
+            collector.process_potential_incident(
+                route="/api/users",
+                method="GET",
+                status_code=500,
+                duration_ms=50.0,
+                exception=ValueError("error A"),
+                request_data={"headers": {}, "args": {}},
+            )
+            with collector._error_hashes_lock:
+                collector._current_batch_hashes.clear()
+
+        # 1 snapshot created, 1 rate limit slot used
+        self.assertEqual(mock_collect.call_count, 1)
+        self.assertEqual(len(collector._snapshot_timestamps), 1)
+
+        # Now send 4 different errors — all should succeed (4 remaining slots)
+        for i in range(4):
+            collector.process_potential_incident(
+                route=f"/api/endpoint_{i}",
+                method="GET",
+                status_code=500,
+                duration_ms=50.0,
+                exception=ValueError(f"error {i}"),
+                request_data={"headers": {}, "args": {}},
+            )
+            with collector._error_hashes_lock:
+                collector._current_batch_hashes.clear()
+
+        # Total: 1 + 4 = 5 snapshots, 5 rate limit slots
+        self.assertEqual(mock_collect.call_count, 5)
+        self.assertEqual(len(collector._snapshot_timestamps), 5)
+
+        # 6th different error should be rate-limited
+        result = collector.process_potential_incident(
+            route="/api/overflow",
+            method="GET",
+            status_code=500,
+            duration_ms=50.0,
+            exception=ValueError("error overflow"),
+            request_data={"headers": {}, "args": {}},
+        )
+        self.assertIsNone(result)
+        self.assertEqual(mock_collect.call_count, 5)  # No additional snapshot
+
+
+class TestBuildCallPath(TestCase):
+    """Test the _build_call_path method."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+
+    @patch("amazon.opentelemetry.distro.serviceevents.collectors.incident_snapshot_collector.get_function_info")
+    def test_from_dict_entries(self, mock_get_func_info):
+        """Test building call path from dict entries, including is_async lookup."""
+        # func_a is sync, func_b is async
+        mock_get_func_info.side_effect = lambda fid: ({"is_async": True} if fid == "func_b" else {"is_async": False})
+
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=100,
+        )
+
+        inv_data = {
+            "call_path": [
+                {"function_name": "func_a", "caller_function_name": None, "duration_ns": 1000},
+                {"function_name": "func_b", "caller_function_name": "func_a", "duration_ns": 500},
+            ]
+        }
+
+        result = collector._build_call_path(inv_data, error_function_name="func_b")
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].function_name, "func_a")
+        self.assertFalse(result[0].error)
+        self.assertFalse(result[0].is_async)
+        self.assertEqual(result[1].function_name, "func_b")
+        self.assertTrue(result[1].error)
+        self.assertTrue(result[1].is_async)
+
+    @patch("amazon.opentelemetry.distro.serviceevents.collectors.incident_snapshot_collector.get_function_info")
+    def test_from_tuple_entries(self, mock_get_func_info):
+        """Test building call path from tuple entries (caller, callee)."""
+        # func_a is async, func_b is unknown (returns None)
+        mock_get_func_info.side_effect = lambda fid: ({"is_async": True} if fid == "func_a" else None)
+
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=100,
+        )
+
+        inv_data = {
+            "call_path": [
+                (None, "func_a"),
+                ("func_a", "func_b"),
+            ]
+        }
+
+        result = collector._build_call_path(inv_data, error_function_name=None)
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].function_name, "func_a")
+        self.assertEqual(result[0].caller_function_name, None)
+        self.assertFalse(result[0].error)
+        self.assertTrue(result[0].is_async)
+        self.assertEqual(result[1].function_name, "func_b")
+        self.assertEqual(result[1].caller_function_name, "func_a")
+        self.assertFalse(result[1].is_async)  # Unknown function defaults to False
+
+    def test_empty_inv_data(self):
+        """Test building call path from None investigation data."""
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=100,
+        )
+
+        result = collector._build_call_path(None)
+        self.assertEqual(result, [])
+
+    def test_no_call_path_key(self):
+        """Test building call path when call_path key is missing."""
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=100,
+        )
+
+        result = collector._build_call_path({"other_key": "value"})
+        self.assertEqual(result, [])
+
+
+class TestCollect(TestCase):
+    """Test the collect method."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+
+    def test_collect_clears_batch_hashes(self):
+        """Test that collect clears batch-level hashes."""
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=100,
+        )
+
+        # Add some batch hashes
+        with collector._error_hashes_lock:
+            collector._current_batch_hashes.add("hash1")
+            collector._current_batch_hashes.add("hash2")
+
+        collector.collect()
+
+        self.assertEqual(len(collector._current_batch_hashes), 0)
+
+    def test_collect_exports_pending_snapshots(self):
+        """Test that collect exports pending snapshots and clears them."""
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=100,
+        )
+
+        mock_snapshot = MagicMock()
+        mock_snapshot.to_dict.return_value = {"snapshot_id": "test"}
+
+        with collector._pending_lock:
+            collector._pending_snapshots.append(mock_snapshot)
+
+        with patch("builtins.print"):
+            collector.collect()
+
+        self.assertEqual(len(collector._pending_snapshots), 0)
+
+
+class TestIncidentSnapshotToDict(TestCase):
+    """Test IncidentSnapshot.to_dict() sparse serialization of is_async."""
+
+    def _make_snapshot(self, call_path_entries):
+        """Helper to create an IncidentSnapshot with given call_path entries."""
+        return IncidentSnapshot(
+            snapshot_id="snap_test",
+            timestamp=1000,
+            severity="high",
+            trigger_type="exception",
+            service="test-service",
+            environment="test",
+            instance_id="host-1",
+            operation="POST /api/test",
+            sdk_version="0.14.2",
+            pid=1234,
+            duration_ms=100.0,
+            exception_info=[
+                ExceptionInfo(
+                    exception_type="ValueError",
+                    exception_message="test",
+                    stack_trace="traceback...",
+                    call_path=call_path_entries,
+                )
+            ],
+            request_context=RequestContext(type="http", timestamp=1000, status_code=500),
+            telemetry_correlation=TelemetryCorrelation(),
+        )
+
+    def test_is_async_stripped_when_false(self):
+        """Test that is_async is omitted from call_path entries when False."""
+        snapshot = self._make_snapshot(
+            [
+                CallPathEntry(function_name="f1", caller_function_name=None, duration_ns=1000, is_async=False),
+            ]
+        )
+
+        result = snapshot.to_dict()
+        entry = result["exception_info"][0]["call_path"][0]
+        self.assertNotIn("is_async", entry)
+
+    def test_is_async_present_when_true(self):
+        """Test that is_async is present in call_path entries when True."""
+        snapshot = self._make_snapshot(
+            [
+                CallPathEntry(function_name="f1", caller_function_name=None, duration_ns=1000, is_async=True),
+            ]
+        )
+
+        result = snapshot.to_dict()
+        entry = result["exception_info"][0]["call_path"][0]
+        self.assertIn("is_async", entry)
+        self.assertTrue(entry["is_async"])
+
+    def test_mixed_async_sync_entries(self):
+        """Test sparse pattern with mixed async and sync call_path entries."""
+        snapshot = self._make_snapshot(
+            [
+                CallPathEntry(function_name="f1", caller_function_name=None, duration_ns=1000, is_async=False),
+                CallPathEntry(function_name="f2", caller_function_name="f1", duration_ns=500, is_async=True),
+                CallPathEntry(function_name="f3", caller_function_name="f2", duration_ns=200, is_async=False),
+            ]
+        )
+
+        result = snapshot.to_dict()
+        entries = result["exception_info"][0]["call_path"]
+
+        self.assertNotIn("is_async", entries[0])  # sync — stripped
+        self.assertTrue(entries[1]["is_async"])  # async — present
+        self.assertNotIn("is_async", entries[2])  # sync — stripped
+
+    def test_is_partial_false_when_complete(self):
+        """Test that is_partial=false is always present in JSON (complete data)."""
+        snapshot = self._make_snapshot(
+            [
+                CallPathEntry(function_name="f1", caller_function_name=None, duration_ns=1000),
+            ]
+        )
+        result = snapshot.to_dict()
+        self.assertIn("is_partial", result)
+        self.assertFalse(result["is_partial"])
+
+    def test_is_partial_true_strips_only_zero_duration_ns(self):
+        """is_partial=true strips only the misleading zero durations from unsampled frames."""
+        snapshot = self._make_snapshot(
+            [
+                CallPathEntry(function_name="f1", caller_function_name=None, duration_ns=0),
+                CallPathEntry(function_name="f2", caller_function_name="f1", duration_ns=0),
+            ]
+        )
+        snapshot.is_partial = True
+        result = snapshot.to_dict()
+        self.assertIn("is_partial", result)
+        self.assertTrue(result["is_partial"])
+        # All-zero durations are stripped (nothing meaningful to keep).
+        for entry in result["exception_info"][0]["call_path"]:
+            self.assertNotIn("duration_ns", entry)
+
+    def test_is_partial_true_preserves_real_durations(self):
+        """A partial snapshot keeps genuine per-frame timings, dropping only the zeros."""
+        snapshot = self._make_snapshot(
+            [
+                CallPathEntry(function_name="f1", caller_function_name=None, duration_ns=5000),
+                CallPathEntry(function_name="f2", caller_function_name="f1", duration_ns=0),
+                CallPathEntry(function_name="f3", caller_function_name="f2", duration_ns=3000),
+            ]
+        )
+        snapshot.is_partial = True
+        result = snapshot.to_dict()
+        entries = result["exception_info"][0]["call_path"]
+        # Sampled frames keep their real durations...
+        self.assertEqual(entries[0]["duration_ns"], 5000)
+        self.assertEqual(entries[2]["duration_ns"], 3000)
+        # ...and only the unsampled zero is dropped.
+        self.assertNotIn("duration_ns", entries[1])
+
+    def test_non_partial_keeps_duration_ns(self):
+        """Test that is_partial=false retains duration_ns in call_path entries."""
+        snapshot = self._make_snapshot(
+            [
+                CallPathEntry(function_name="f1", caller_function_name=None, duration_ns=5000),
+                CallPathEntry(function_name="f2", caller_function_name="f1", duration_ns=3000),
+            ]
+        )
+        result = snapshot.to_dict()
+        self.assertFalse(result["is_partial"])
+        # duration_ns should be present
+        entries = result["exception_info"][0]["call_path"]
+        self.assertEqual(entries[0]["duration_ns"], 5000)
+        self.assertEqual(entries[1]["duration_ns"], 3000)
+
+
+class TestIncidentCollectorForkReset(TestCase):
+    """Fork-safety: child must not inherit pending snapshots or stale dedup/rate-limit state."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+
+    def _build(self):
+        return IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=100,
+        )
+
+    def test_reset_for_fork_clears_pending_and_dedup_state(self):
+        """Pending snapshots and dedup/rate-limit bookkeeping are cleared in the child."""
+        collector = self._build()
+        # Simulate parent-accumulated state.
+        collector._pending_snapshots.append(MagicMock())
+        collector._error_hashes["abc"] = [time.time()]
+        collector._current_batch_hashes.add("abc")
+        collector._snapshot_timestamps.append(time.time())
+
+        collector._reset_for_fork()
+
+        self.assertEqual(collector._pending_snapshots, [])
+        self.assertEqual(collector._error_hashes, {})
+        self.assertEqual(collector._current_batch_hashes, set())
+        self.assertEqual(len(collector._snapshot_timestamps), 0)
+
+    def test_reset_for_fork_recreates_locks_and_refreshes_pid(self):
+        """All collector locks are fresh (parent threads may have held them) post-fork."""
+        collector = self._build()
+        old_locks = (
+            collector._pending_lock,
+            collector._timestamps_lock,
+            collector._error_hashes_lock,
+            collector._latency_thresholds_lock,
+            collector._latency_patterns_lock,
+        )
+
+        collector._reset_for_fork()
+
+        new_locks = (
+            collector._pending_lock,
+            collector._timestamps_lock,
+            collector._error_hashes_lock,
+            collector._latency_thresholds_lock,
+            collector._latency_patterns_lock,
+        )
+        for old, new in zip(old_locks, new_locks):
+            self.assertIsNot(new, old)
+            self.assertTrue(new.acquire(blocking=False))
+            new.release()
+
+    def test_reset_for_fork_preserves_latency_thresholds(self):
+        """Latency thresholds are config, not per-request state — preserved across fork."""
+        collector = self._build()
+        collector.set_latency_threshold("GET /api/slow", 250.0)
+        collector.set_latency_threshold_patterns([("GET /api/*", 500.0)])
+
+        collector._reset_for_fork()
+
+        self.assertEqual(collector.get_latency_threshold(operation="GET /api/slow"), 250.0)
+        self.assertEqual(collector.get_latency_threshold(route="/api/other", method="GET"), 500.0)
+
+
+class TestConstructorHostId(TestCase):
+    """Constructor enhances instance_id from resource attributes."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+
+    def test_host_id_overrides_instance_id(self):
+        """host.id from resource attributes is preferred as the instance_id."""
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=100,
+            resource_attributes=ResourceAttributes(host_id="i-0abc123def456"),
+        )
+        self.assertEqual(collector.instance_id, "i-0abc123def456")
+
+
+class TestUpdateIncidentConfig(TestCase):
+    """Test the update_incident_config live-setter."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+
+    def _make_collector(self, max_per_period=5):
+        return IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=max_per_period,
+        )
+
+    def test_updates_flags_without_recreating_deque(self):
+        """Updating only flags leaves the timestamps deque object unchanged."""
+        collector = self._make_collector(max_per_period=5)
+        original_deque = collector._snapshot_timestamps
+
+        collector.update_incident_config(capture_request_body=True, max_per_period=5, max_same_error=3)
+
+        self.assertTrue(collector.capture_request_body)
+        self.assertEqual(collector._max_same_error, 3)
+        # max_per_period unchanged -> same deque instance
+        self.assertIs(collector._snapshot_timestamps, original_deque)
+
+    def test_changing_max_per_period_recreates_deque_preserving_entries(self):
+        """Changing max_per_period rebuilds the deque with the new maxlen, keeping entries."""
+        collector = self._make_collector(max_per_period=2)
+        with collector._timestamps_lock:
+            collector._snapshot_timestamps.append(111.0)
+            collector._snapshot_timestamps.append(222.0)
+        original_deque = collector._snapshot_timestamps
+
+        collector.update_incident_config(capture_request_body=False, max_per_period=10, max_same_error=1)
+
+        self.assertEqual(collector.max_per_period, 10)
+        self.assertIsNot(collector._snapshot_timestamps, original_deque)
+        self.assertEqual(collector._snapshot_timestamps.maxlen, 20)
+        self.assertEqual(list(collector._snapshot_timestamps), [111.0, 222.0])
+
+
+class TestProcessPotentialIncidentBranches(TestCase):
+    """Branch coverage for process_potential_incident dedup/stack-trace paths."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+
+    def _make_collector(self, **kwargs):
+        return IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=100,
+            **kwargs,
+        )
+
+    @patch.object(IncidentSnapshotCollector, "_collect_incident_snapshot")
+    def test_fallback_stack_trace_when_no_active_traceback(self, mock_collect):
+        """When sys.exc_info has no traceback, the stack trace is formatted from the exception object."""
+        mock_collect.return_value = MagicMock()
+        collector = self._make_collector()
+
+        # An exception built outside an active handler has no exc_tb via sys.exc_info().
+        exc = ValueError("orphan error")
+        result = collector.process_potential_incident(
+            route="/api/users",
+            method="GET",
+            status_code=500,
+            duration_ms=50.0,
+            exception=exc,
+            request_data={"headers": {}, "args": {}},
+        )
+
+        self.assertIsNotNone(result)
+        mock_collect.assert_called_once()
+        # The fallback path passes a captured_stack_trace string built from the exception object.
+        self.assertIsNotNone(mock_collect.call_args.kwargs["captured_stack_trace"])
+
+    @patch.object(IncidentSnapshotCollector, "_collect_incident_snapshot")
+    def test_active_traceback_is_captured(self, mock_collect):
+        """Inside an active handler, the live traceback is formatted via sys.exc_info()."""
+        mock_collect.return_value = MagicMock()
+        collector = self._make_collector()
+
+        try:
+            raise ValueError("live error")
+        except ValueError as exc:
+            result = collector.process_potential_incident(
+                route="/api/users",
+                method="GET",
+                status_code=500,
+                duration_ms=50.0,
+                exception=exc,
+                request_data={"headers": {}, "args": {}},
+            )
+
+        self.assertIsNotNone(result)
+        stack_trace = mock_collect.call_args.kwargs["captured_stack_trace"]
+        self.assertIn("ValueError", stack_trace)
+        self.assertIn("Traceback", stack_trace)
+
+    @patch.object(IncidentSnapshotCollector, "_collect_incident_snapshot")
+    def test_batch_deduplicated_returns_none(self, mock_collect):
+        """An error hash already in the current batch is batch-deduplicated and skipped."""
+        mock_collect.return_value = MagicMock()
+        collector = self._make_collector()
+
+        error_hash = collector._generate_error_hash("/api/users", ValueError("dup"))
+        with collector._error_hashes_lock:
+            collector._current_batch_hashes.add(error_hash)
+
+        result = collector.process_potential_incident(
+            route="/api/users",
+            method="GET",
+            status_code=500,
+            duration_ms=50.0,
+            exception=ValueError("dup"),
+            request_data={"headers": {}, "args": {}},
+        )
+
+        self.assertIsNone(result)
+        mock_collect.assert_not_called()
+
+
+class TestRollbackReservationErrorPath(TestCase):
+    """The rollback helper must never raise, even on internal errors."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+
+    def test_rollback_swallows_exceptions(self):
+        """_rollback_reservation logs and swallows any exception raised internally."""
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=100,
+        )
+
+        # Force an internal failure by making the batch-hash set raise on discard.
+        broken = MagicMock()
+        broken.discard.side_effect = RuntimeError("boom")
+        collector._current_batch_hashes = broken
+
+        # Should not raise.
+        collector._rollback_reservation("some_hash")
+
+
+class TestCheckDeduplicationCleanup(TestCase):
+    """Cleanup of fully-expired hash entries during dedup."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+
+    def test_expired_hash_entry_is_deleted(self):
+        """A hash whose timestamps are all older than the window is removed during cleanup."""
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=100,
+            max_same_error=5,
+        )
+
+        # Seed a stale hash whose only timestamp predates the 60s window.
+        with collector._error_hashes_lock:
+            collector._error_hashes["stale_hash"] = [time.time() - 7200]
+
+        # A different hash triggers the cleanup loop, which deletes the stale entry.
+        self.assertTrue(collector._check_deduplication("fresh_hash"))
+        self.assertNotIn("stale_hash", collector._error_hashes)
+
+
+class TestCollectExports(TestCase):
+    """Collect path that emits to the OTLP emitter."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+
+    def test_no_pending_snapshots_returns_early(self):
+        """collect() returns early when there are no pending snapshots."""
+        emitter = MagicMock()
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=100,
+            otlp_emitter=emitter,
+        )
+
+        collector.collect()
+
+        emitter.emit_incident_snapshot.assert_not_called()
+
+    def test_no_emitter_drops_snapshots(self):
+        """collect() with snapshots but no emitter clears pending without emitting."""
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=100,
+            otlp_emitter=None,
+        )
+        with collector._pending_lock:
+            collector._pending_snapshots.append(MagicMock())
+
+        collector.collect()
+
+        self.assertEqual(len(collector._pending_snapshots), 0)
+
+    def test_emits_each_pending_snapshot(self):
+        """collect() emits every pending snapshot via the OTLP emitter and clears them."""
+        emitter = MagicMock()
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=100,
+            otlp_emitter=emitter,
+        )
+
+        snap1 = MagicMock()
+        snap1.to_dict.return_value = {"snapshot_id": "s1"}
+        snap2 = MagicMock()
+        snap2.to_dict.return_value = {"snapshot_id": "s2"}
+        with collector._pending_lock:
+            collector._pending_snapshots.extend([snap1, snap2])
+
+        collector.collect()
+
+        self.assertEqual(emitter.emit_incident_snapshot.call_count, 2)
+        emitter.emit_incident_snapshot.assert_any_call({"snapshot_id": "s1"})
+        emitter.emit_incident_snapshot.assert_any_call({"snapshot_id": "s2"})
+        self.assertEqual(len(collector._pending_snapshots), 0)
+
+
+class TestCollectIncidentSnapshot(TestCase):
+    """Test the _collect_incident_snapshot assembly method."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+
+    def _make_collector(self, **kwargs):
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=100,
+            service_name="svc",
+            environment="prod",
+            **kwargs,
+        )
+        # Deterministic investigation data — no real monitor singleton involved.
+        collector._monitor_state = MagicMock()
+        collector._monitor_state.get_investigation_data.return_value = None
+        return collector
+
+    def test_exception_snapshot_basic_fields(self):
+        """Assembles a snapshot for an exception incident with core metadata populated."""
+        collector = self._make_collector(capture_request_body=False)
+
+        snapshot = collector._collect_incident_snapshot(
+            route="/api/users",
+            method="GET",
+            status_code=500,
+            duration_ms=42.0,
+            exception=ValueError("boom"),
+            request_data={"headers": {}, "args": {}},
+            trigger_type="exception",
+            captured_stack_trace="TRACE",
+        )
+
+        self.assertTrue(snapshot.snapshot_id.startswith("snap_"))
+        self.assertEqual(snapshot.severity, "critical")
+        self.assertEqual(snapshot.trigger_type, "exception")
+        self.assertEqual(snapshot.operation, "GET /api/users")
+        self.assertEqual(snapshot.service, "svc")
+        self.assertEqual(snapshot.environment, "prod")
+        self.assertEqual(snapshot.duration_ms, 42.0)
+        self.assertEqual(snapshot.exception_info[0].stack_trace, "TRACE")
+        # capture_request_body=False -> payload fields are gated off.
+        self.assertEqual(snapshot.request_context.custom_context, {})
+        self.assertIsNone(snapshot.request_context.query_params)
+        self.assertIsNone(snapshot.request_context.request_headers)
+
+    def test_partial_flag_when_call_path_durations_zero(self):
+        """is_partial is True when any call_path entry has a zero duration."""
+        collector = self._make_collector()
+        collector._monitor_state.get_investigation_data.return_value = {
+            "call_path": [(None, "func_a")],
+        }
+
+        with patch(
+            "amazon.opentelemetry.distro.serviceevents.collectors." "incident_snapshot_collector.get_function_info",
+            return_value={"is_async": False},
+        ):
+            snapshot = collector._collect_incident_snapshot(
+                route="/slow",
+                method="GET",
+                status_code=200,
+                duration_ms=999.0,
+                exception=None,
+                request_data={"headers": {}, "args": {}},
+                trigger_type="latency",
+            )
+
+        self.assertTrue(snapshot.is_partial)
+        self.assertEqual(snapshot.severity, "medium")
+
+    def test_capture_request_body_with_cached_body(self):
+        """When capture is on and no Flask request, the FastAPI cached_body is used."""
+        collector = self._make_collector(capture_request_body=True)
+
+        snapshot = collector._collect_incident_snapshot(
+            route="/api/users",
+            method="POST",
+            status_code=500,
+            duration_ms=10.0,
+            exception=ValueError("x"),
+            request_data={
+                "headers": {"Content-Type": "application/json"},
+                "args": {"user_id": "42"},
+                "view_args": {"id": "7"},
+                "cached_body": "raw-payload",
+            },
+            trigger_type="exception",
+        )
+
+        self.assertEqual(snapshot.request_context.request_body, "raw-payload")
+        self.assertEqual(snapshot.request_context.custom_context, {"user_id": "42"})
+        self.assertEqual(snapshot.request_context.query_params, {"user_id": "42"})
+        self.assertEqual(snapshot.request_context.path_params, {"id": "7"})
+        self.assertEqual(snapshot.request_context.request_headers, {"Content-Type": "application/json"})
+
+    def test_capture_request_body_with_flask_request(self):
+        """When capture is on and a Flask request is present, body comes from the lazy importer."""
+        collector = self._make_collector(capture_request_body=True)
+        flask_request = MagicMock()
+
+        with patch(
+            "amazon.opentelemetry.distro.serviceevents.instrumentation." "flask_instrumentation._get_request_body",
+            return_value="flask-body",
+        ) as mock_get_body:
+            snapshot = collector._collect_incident_snapshot(
+                route="/api/users",
+                method="POST",
+                status_code=500,
+                duration_ms=10.0,
+                exception=ValueError("x"),
+                request_data={"flask_request": flask_request, "args": {}},
+                trigger_type="exception",
+            )
+
+        mock_get_body.assert_called_once_with(flask_request)
+        self.assertEqual(snapshot.request_context.request_body, "flask-body")
+
+
+class TestCollectExceptionInfo(TestCase):
+    """Test the _collect_exception_info branches."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+
+    def _make_collector(self):
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=100,
+        )
+        collector._monitor_state = MagicMock()
+        return collector
+
+    def test_no_exception_no_inv_data_returns_empty(self):
+        """No explicit exception and no investigation data yields an empty list."""
+        collector = self._make_collector()
+        collector._monitor_state.get_investigation_data.return_value = None
+
+        self.assertEqual(collector._collect_exception_info(None), [])
+
+    def test_latency_returns_call_path_without_exception(self):
+        """A latency incident with call_path but no captured exception returns a call-path-only entry."""
+        collector = self._make_collector()
+        collector._monitor_state.get_investigation_data.return_value = {
+            "call_path": [(None, "func_a")],
+        }
+
+        with patch(
+            "amazon.opentelemetry.distro.serviceevents.collectors." "incident_snapshot_collector.get_function_info",
+            return_value={"is_async": False},
+        ):
+            result = collector._collect_exception_info(None)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].exception_type, "")
+        self.assertEqual(result[0].exception_message, "")
+        self.assertEqual(len(result[0].call_path), 1)
+
+    def test_exc_data_none_with_call_path(self):
+        """inv_data has an 'exception' key set to None -> treated as latency call-path-only."""
+        collector = self._make_collector()
+        collector._monitor_state.get_investigation_data.return_value = {
+            "exception": None,
+            "call_path": [(None, "func_a")],
+        }
+
+        with patch(
+            "amazon.opentelemetry.distro.serviceevents.collectors." "incident_snapshot_collector.get_function_info",
+            return_value=None,
+        ):
+            result = collector._collect_exception_info(None)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].exception_type, "")
+        self.assertEqual(len(result[0].call_path), 1)
+
+    def test_exc_data_none_without_call_path_returns_empty(self):
+        """inv_data 'exception' is None and there is no call_path -> empty list."""
+        collector = self._make_collector()
+        collector._monitor_state.get_investigation_data.return_value = {"exception": None}
+
+        self.assertEqual(collector._collect_exception_info(None), [])
+
+    def test_no_exception_no_call_path_returns_empty(self):
+        """No explicit exception, inv_data present but lacking exception/call_path -> empty list."""
+        collector = self._make_collector()
+        collector._monitor_state.get_investigation_data.return_value = {"other": "value"}
+
+        self.assertEqual(collector._collect_exception_info(None), [])
+
+    def test_monitor_captured_exception_with_traceback_info(self):
+        """A monitor-captured exception with traceback_info formats a full stack trace."""
+        collector = self._make_collector()
+        try:
+            raise ValueError("captured")
+        except ValueError as exc:
+            tb_info = (type(exc), exc, exc.__traceback__)
+        collector._monitor_state.get_investigation_data.return_value = {
+            "exception": {
+                "function_name": "func_a",
+                "name": "ValueError",
+                "message": "captured",
+                "traceback_info": tb_info,
+            },
+            "call_path": [{"function_name": "func_a", "caller_function_name": None, "duration_ns": 5}],
+        }
+
+        with patch(
+            "amazon.opentelemetry.distro.serviceevents.collectors." "incident_snapshot_collector.get_function_info",
+            return_value={"is_async": False},
+        ):
+            result = collector._collect_exception_info(None)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].exception_type, "ValueError")
+        self.assertEqual(result[0].exception_message, "captured")
+        self.assertIn("ValueError", result[0].stack_trace)
+        self.assertTrue(result[0].call_path[0].error)
+
+    def test_monitor_captured_exception_traceback_info_format_fails(self):
+        """When formatting traceback_info raises, fall back to name+message string."""
+        collector = self._make_collector()
+        collector._monitor_state.get_investigation_data.return_value = {
+            "exception": {
+                "function_name": "func_a",
+                "name": "BadError",
+                "message": "oops",
+                # Invalid traceback_info triggers the except branch in format_exception.
+                "traceback_info": ("not", "a", "valid", "tuple"),
+            },
+            "call_path": [],
+        }
+
+        result = collector._collect_exception_info(None)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].stack_trace, "BadError: oops")
+
+    def test_monitor_captured_exception_with_traceback_strings(self):
+        """A captured exception with a 'traceback' string list joins them as the stack trace."""
+        collector = self._make_collector()
+        collector._monitor_state.get_investigation_data.return_value = {
+            "exception": {
+                "name": "KeyError",
+                "message": "missing",
+                "traceback": ["line1\n", "line2\n"],
+            },
+            "call_path": [],
+        }
+
+        result = collector._collect_exception_info(None)
+
+        self.assertEqual(result[0].exception_type, "KeyError")
+        self.assertEqual(result[0].stack_trace, "line1\nline2\n")
+
+    def test_explicit_exception_uses_captured_stack_trace(self):
+        """An explicit exception uses the pre-captured stack trace and marks the error frame."""
+        collector = self._make_collector()
+        collector._monitor_state.get_investigation_data.return_value = {
+            "exception": {"function_name": "func_b"},
+            "call_path": [{"function_name": "func_b", "caller_function_name": None, "duration_ns": 9}],
+        }
+
+        with patch(
+            "amazon.opentelemetry.distro.serviceevents.collectors." "incident_snapshot_collector.get_function_info",
+            return_value={"is_async": False},
+        ):
+            result = collector._collect_exception_info(ValueError("explicit"), captured_stack_trace="MY TRACE")
+
+        self.assertEqual(result[0].exception_type, "ValueError")
+        self.assertEqual(result[0].exception_message, "explicit")
+        self.assertEqual(result[0].stack_trace, "MY TRACE")
+        self.assertTrue(result[0].call_path[0].error)
+
+    def test_explicit_exception_falls_back_to_str(self):
+        """Without a captured stack trace, an explicit exception falls back to str(exception)."""
+        collector = self._make_collector()
+        collector._monitor_state.get_investigation_data.return_value = None
+
+        result = collector._collect_exception_info(ValueError("plain"))
+
+        self.assertEqual(result[0].stack_trace, "plain")
+        self.assertEqual(result[0].call_path, [])
+
+
+class TestExtractCustomContext(TestCase):
+    """Test the _extract_custom_context static helper."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+
+    def test_extracts_user_id(self):
+        """user_id present in args is stringified into custom context."""
+        result = IncidentSnapshotCollector._extract_custom_context({"args": {"user_id": 42}})
+        self.assertEqual(result, {"user_id": "42"})
+
+    def test_empty_when_no_user_id(self):
+        """No user_id in args yields an empty custom context."""
+        result = IncidentSnapshotCollector._extract_custom_context({"args": {"other": "x"}})
+        self.assertEqual(result, {})
+
+
+class TestFormatIds(TestCase):
+    """Test the _format_trace_id and _format_span_id static helpers."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+
+    def test_format_trace_id_none(self):
+        """A None trace id formats to None."""
+        self.assertIsNone(IncidentSnapshotCollector._format_trace_id(None))
+
+    def test_format_trace_id_int(self):
+        """An int trace id formats to 0x-prefixed 32-char hex."""
+        self.assertEqual(IncidentSnapshotCollector._format_trace_id(1), "0x" + "0" * 31 + "1")
+
+    def test_format_trace_id_str_passthrough(self):
+        """A string trace id is passed through as-is."""
+        self.assertEqual(IncidentSnapshotCollector._format_trace_id("0xabc"), "0xabc")
+
+    def test_format_span_id_none(self):
+        """A None span id formats to None."""
+        self.assertIsNone(IncidentSnapshotCollector._format_span_id(None))
+
+    def test_format_span_id_int(self):
+        """An int span id formats to 0x-prefixed 16-char hex."""
+        self.assertEqual(IncidentSnapshotCollector._format_span_id(255), "0x" + "0" * 14 + "ff")
+
+    def test_format_span_id_str_passthrough(self):
+        """A string span id is passed through as-is."""
+        self.assertEqual(IncidentSnapshotCollector._format_span_id("span-1"), "span-1")
+
+
+class TestValidTraceparentId(TestCase):
+    """Test the _valid_traceparent_id validator."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+
+    def test_empty_returns_none(self):
+        """Empty input is rejected."""
+        self.assertIsNone(IncidentSnapshotCollector._valid_traceparent_id("", 32))
+
+    def test_wrong_length_returns_none(self):
+        """Input of the wrong length is rejected."""
+        self.assertIsNone(IncidentSnapshotCollector._valid_traceparent_id("abcd", 32))
+
+    def test_non_hex_returns_none(self):
+        """Input containing non-hex characters is rejected."""
+        self.assertIsNone(IncidentSnapshotCollector._valid_traceparent_id("z" * 16, 16))
+
+    def test_all_zero_sentinel_returns_none(self):
+        """The all-zero sentinel id is rejected per the W3C spec."""
+        self.assertIsNone(IncidentSnapshotCollector._valid_traceparent_id("0" * 16, 16))
+
+    def test_valid_id_lowercased(self):
+        """A valid mixed-case hex id is accepted and lowercased."""
+        self.assertEqual(IncidentSnapshotCollector._valid_traceparent_id("ABCD" * 4, 16), "abcd" * 4)
+
+
+class TestExtractTraceId(TestCase):
+    """Test the _extract_trace_id method across its lookup tiers."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+
+    def _make_collector(self):
+        return IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=100,
+        )
+
+    def test_pre_captured_trace_id(self):
+        """A pre-captured int trace_id is formatted and returned first."""
+        collector = self._make_collector()
+        result = collector._extract_trace_id({"trace_id": 255})
+        self.assertEqual(result, "0x" + "0" * 30 + "ff")
+
+    def test_from_current_otel_span(self):
+        """A valid current OTel span supplies the trace id when no pre-captured value exists."""
+        collector = self._make_collector()
+        span = MagicMock()
+        span_context = MagicMock()
+        span_context.is_valid = True
+        span_context.trace_id = 1
+        span.get_span_context.return_value = span_context
+
+        with patch(
+            "amazon.opentelemetry.distro.serviceevents.collectors."
+            "incident_snapshot_collector.trace.get_current_span",
+            return_value=span,
+        ):
+            result = collector._extract_trace_id({})
+
+        self.assertEqual(result, "0x" + "0" * 31 + "1")
+
+    def test_otel_span_exception_falls_through(self):
+        """If reading the current span raises, extraction falls through to headers."""
+        collector = self._make_collector()
+        with patch(
+            "amazon.opentelemetry.distro.serviceevents.collectors."
+            "incident_snapshot_collector.trace.get_current_span",
+            side_effect=RuntimeError("no span"),
+        ):
+            result = collector._extract_trace_id(
+                {"headers": {"traceparent": "00-" + "a" * 32 + "-" + "b" * 16 + "-01"}}
+            )
+
+        self.assertEqual(result, "0x" + "a" * 32)
+
+    def test_from_traceparent_header(self):
+        """A valid traceparent header supplies the trace id."""
+        collector = self._make_collector()
+        span = MagicMock()
+        span.get_span_context.return_value.is_valid = False
+        with patch(
+            "amazon.opentelemetry.distro.serviceevents.collectors."
+            "incident_snapshot_collector.trace.get_current_span",
+            return_value=span,
+        ):
+            result = collector._extract_trace_id(
+                {"headers": {"traceparent": "00-" + "c" * 32 + "-" + "d" * 16 + "-01"}}
+            )
+        self.assertEqual(result, "0x" + "c" * 32)
+
+    def test_invalid_traceparent_falls_to_xray(self):
+        """An invalid traceparent trace-id falls through to the X-Ray header."""
+        collector = self._make_collector()
+        span = MagicMock()
+        span.get_span_context.return_value.is_valid = False
+        with patch(
+            "amazon.opentelemetry.distro.serviceevents.collectors."
+            "incident_snapshot_collector.trace.get_current_span",
+            return_value=span,
+        ):
+            result = collector._extract_trace_id(
+                {
+                    "headers": {
+                        "traceparent": "00-" + "0" * 32 + "-" + "b" * 16 + "-01",
+                        "X-Amzn-Trace-Id": "Root=1-abc",
+                    }
+                }
+            )
+        self.assertEqual(result, "Root=1-abc")
+
+    def test_datadog_header(self):
+        """The Datadog trace-id header is used as a final fallback."""
+        collector = self._make_collector()
+        span = MagicMock()
+        span.get_span_context.return_value.is_valid = False
+        with patch(
+            "amazon.opentelemetry.distro.serviceevents.collectors."
+            "incident_snapshot_collector.trace.get_current_span",
+            return_value=span,
+        ):
+            result = collector._extract_trace_id({"headers": {"x-datadog-trace-id": "12345"}})
+        self.assertEqual(result, "12345")
+
+    def test_no_trace_id_returns_none(self):
+        """When no source supplies a trace id, None is returned."""
+        collector = self._make_collector()
+        span = MagicMock()
+        span.get_span_context.return_value.is_valid = False
+        with patch(
+            "amazon.opentelemetry.distro.serviceevents.collectors."
+            "incident_snapshot_collector.trace.get_current_span",
+            return_value=span,
+        ):
+            result = collector._extract_trace_id({"headers": {}})
+        self.assertIsNone(result)
+
+
+class TestExtractSpanId(TestCase):
+    """Test the _extract_span_id method across its lookup tiers."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+
+    def _make_collector(self):
+        return IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=100,
+        )
+
+    def test_pre_captured_span_id(self):
+        """A pre-captured int span_id is formatted and returned first."""
+        collector = self._make_collector()
+        result = collector._extract_span_id({"span_id": 255})
+        self.assertEqual(result, "0x" + "0" * 14 + "ff")
+
+    def test_from_current_otel_span(self):
+        """A valid current OTel span supplies the span id when no pre-captured value exists."""
+        collector = self._make_collector()
+        span = MagicMock()
+        span_context = MagicMock()
+        span_context.is_valid = True
+        span_context.span_id = 1
+        span.get_span_context.return_value = span_context
+
+        with patch(
+            "amazon.opentelemetry.distro.serviceevents.collectors."
+            "incident_snapshot_collector.trace.get_current_span",
+            return_value=span,
+        ):
+            result = collector._extract_span_id({})
+
+        self.assertEqual(result, "0x" + "0" * 15 + "1")
+
+    def test_otel_span_exception_falls_through(self):
+        """If reading the current span raises, extraction falls through to headers."""
+        collector = self._make_collector()
+        with patch(
+            "amazon.opentelemetry.distro.serviceevents.collectors."
+            "incident_snapshot_collector.trace.get_current_span",
+            side_effect=RuntimeError("no span"),
+        ):
+            result = collector._extract_span_id({"headers": {"traceparent": "00-" + "a" * 32 + "-" + "b" * 16 + "-01"}})
+
+        self.assertEqual(result, "0x" + "b" * 16)
+
+    def test_invalid_traceparent_span_returns_none(self):
+        """An invalid traceparent span-id yields None (no further fallback)."""
+        collector = self._make_collector()
+        span = MagicMock()
+        span.get_span_context.return_value.is_valid = False
+        with patch(
+            "amazon.opentelemetry.distro.serviceevents.collectors."
+            "incident_snapshot_collector.trace.get_current_span",
+            return_value=span,
+        ):
+            result = collector._extract_span_id({"headers": {"traceparent": "00-" + "a" * 32 + "-" + "0" * 16 + "-01"}})
+        self.assertIsNone(result)
+
+    def test_no_span_id_returns_none(self):
+        """When no source supplies a span id, None is returned."""
+        collector = self._make_collector()
+        span = MagicMock()
+        span.get_span_context.return_value.is_valid = False
+        with patch(
+            "amazon.opentelemetry.distro.serviceevents.collectors."
+            "incident_snapshot_collector.trace.get_current_span",
+            return_value=span,
+        ):
+            result = collector._extract_span_id({"headers": {}})
+        self.assertIsNone(result)
+
+
+class TestGenerateSessionAndRequestId(TestCase):
+    """Test the _generate_session_id and _generate_request_id helpers."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+
+    def test_session_id_with_user_id(self):
+        """A session id is built from the user_id when present in args."""
+        result = IncidentSnapshotCollector._generate_session_id({"args": {"user_id": "u1"}})
+        self.assertIsNotNone(result)
+        self.assertTrue(result.startswith("session_u1_"))
+
+    def test_session_id_without_user_id(self):
+        """No user_id yields no session id."""
+        result = IncidentSnapshotCollector._generate_session_id({"args": {}})
+        self.assertIsNone(result)
+
+    def test_request_id_format(self):
+        """A request id is a uuid prefixed with 'req_'."""
+        result = IncidentSnapshotCollector._generate_request_id()
+        self.assertTrue(result.startswith("req_"))

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/collectors/test_incident_snapshot_collector.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/collectors/test_incident_snapshot_collector.py
@@ -1460,6 +1460,32 @@ class TestCollectExceptionInfo(TestCase):
         self.assertIn("ValueError", result[0].stack_trace)
         self.assertTrue(result[0].call_path[0].error)
 
+    def test_monitor_captured_exception_with_preformatted_traceback_string(self):
+        """The monitor now stores traceback_info as a pre-formatted string; use it as-is."""
+        collector = self._make_collector()
+        preformatted = "Traceback (most recent call last):\n  ...\nValueError: captured\n"
+        collector._monitor_state.get_investigation_data.return_value = {
+            "exception": {
+                "function_name": "func_a",
+                "name": "ValueError",
+                "message": "captured",
+                "traceback_info": preformatted,
+            },
+            "call_path": [{"function_name": "func_a", "caller_function_name": None, "duration_ns": 5}],
+        }
+
+        with patch(
+            "amazon.opentelemetry.distro.serviceevents.collectors." "incident_snapshot_collector.get_function_info",
+            return_value={"is_async": False},
+        ):
+            result = collector._collect_exception_info(None)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].exception_type, "ValueError")
+        # The pre-formatted string is used verbatim, not re-formatted.
+        self.assertEqual(result[0].stack_trace, preformatted)
+        self.assertTrue(result[0].call_path[0].error)
+
     def test_monitor_captured_exception_traceback_info_format_fails(self):
         """When formatting traceback_info raises, fall back to name+message string."""
         collector = self._make_collector()

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/exporter/test_cloudwatch_file_exporter.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/exporter/test_cloudwatch_file_exporter.py
@@ -1,0 +1,692 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import glob
+import json
+import os
+import tempfile
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from amazon.opentelemetry.distro.serviceevents.exporter import cloudwatch_file_exporter
+from amazon.opentelemetry.distro.serviceevents.exporter.cloudwatch_file_exporter import (
+    ServiceEventsCloudWatchLogFileExporter,
+    ServiceEventsCloudWatchMetricFileExporter,
+    _acquire_writer,
+    _release_writer,
+    _reset_file_writers,
+    _Utf8RotatingFileHandler,
+    serialize_log_record,
+)
+from opentelemetry.sdk._logs import ReadableLogRecord
+from opentelemetry.sdk._logs._internal import LogRecord
+from opentelemetry.sdk._logs.export import LogRecordExportResult
+from opentelemetry.sdk.metrics.export import MetricExportResult
+from opentelemetry.sdk.resources import Resource
+
+
+def _make_readable(
+    event_name="aws.service_events.function_call",
+    attributes=None,
+    body=None,
+    timestamp=1744137998974205000,
+    trace_id=None,
+    span_id=None,
+    trace_flags=None,
+):
+    record = LogRecord(
+        timestamp=timestamp,
+        observed_timestamp=timestamp,
+        trace_id=trace_id,
+        span_id=span_id,
+        trace_flags=trace_flags,
+        severity_text=None,
+        severity_number=None,
+        body=body if body is not None else {"exceptions": {"RuntimeError": 3}},
+        attributes=(
+            attributes
+            if attributes is not None
+            else {
+                "event.name": "aws.service_events.function_call",
+                "aws.service_events.function_name": "process_order",
+            }
+        ),
+        event_name=event_name,
+    )
+    resource = Resource.create(
+        {
+            "service.name": "shoppingcart",
+            "deployment.environment": "prod",
+            "telemetry.sdk.language": "python",
+        }
+    )
+    return ReadableLogRecord(log_record=record, resource=resource)
+
+
+class TestSerializeLogRecord(TestCase):
+    def test_flat_shape(self):
+        out = serialize_log_record(_make_readable())
+        self.assertEqual(out["eventName"], "aws.service_events.function_call")
+        self.assertEqual(out["timeUnixNano"], 1744137998974205000)
+        self.assertEqual(out["attributes"]["aws.service_events.function_name"], "process_order")
+        self.assertEqual(out["body"], {"exceptions": {"RuntimeError": 3}})
+        self.assertEqual(out["resource"]["service.name"], "shoppingcart")
+        self.assertEqual(out["resource"]["deployment.environment"], "prod")
+        self.assertNotIn("traceId", out)
+        self.assertNotIn("spanId", out)
+
+    def test_trace_context_included_when_set(self):
+        out = serialize_log_record(
+            _make_readable(
+                trace_id=0xAABBCCDDEEFF00112233445566778899,
+                span_id=0x1122334455667788,
+                trace_flags=1,
+            )
+        )
+        self.assertEqual(out["traceId"], "aabbccddeeff00112233445566778899")
+        self.assertEqual(out["spanId"], "1122334455667788")
+        self.assertEqual(out["flags"], 1)
+
+    def test_empty_body_becomes_empty_dict(self):
+        # Explicit empty dict → serializer preserves as {}
+        out = serialize_log_record(_make_readable(body={}))
+        self.assertEqual(out["body"], {})
+
+    def test_list_body_is_unwrapped_recursively(self):
+        # _unwrap_body recurses through lists/tuples preserving primitives.
+        out = serialize_log_record(_make_readable(body=[1, "a", {"k": 2}]))
+        self.assertEqual(out["body"], [1, "a", {"k": 2}])
+
+    def test_unserializable_body_falls_back_to_str(self):
+        # A value that is not a primitive/dict/list is coerced via str().
+        sentinel = object()
+        out = serialize_log_record(_make_readable(body={"obj": sentinel}))
+        self.assertEqual(out["body"]["obj"], str(sentinel))
+
+
+class TestLogExporter(TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.path = os.path.join(self.tmpdir.name, "serviceevents.ndjson")
+
+    def tearDown(self):
+        _reset_file_writers()
+        self.tmpdir.cleanup()
+
+    def _lines(self):
+        if not os.path.exists(self.path):
+            return []
+        with open(self.path) as f:
+            return [json.loads(line) for line in f if line.strip()]
+
+    def test_writes_one_ndjson_line_per_record(self):
+        exporter = ServiceEventsCloudWatchLogFileExporter(self.path)
+        try:
+            result = exporter.export(
+                [
+                    _make_readable(event_name="aws.service_events.function_call"),
+                    _make_readable(event_name="aws.service_events.endpoint_summary"),
+                ]
+            )
+        finally:
+            exporter.shutdown()
+        self.assertEqual(result, LogRecordExportResult.SUCCESS)
+        lines = self._lines()
+        self.assertEqual(len(lines), 2)
+        self.assertEqual(lines[0]["eventName"], "aws.service_events.function_call")
+        self.assertEqual(lines[1]["eventName"], "aws.service_events.endpoint_summary")
+
+    def test_appends_across_exports(self):
+        exporter = ServiceEventsCloudWatchLogFileExporter(self.path)
+        try:
+            exporter.export([_make_readable()])
+            exporter.export([_make_readable()])
+        finally:
+            exporter.shutdown()
+        self.assertEqual(len(self._lines()), 2)
+
+    def test_empty_batch_no_error(self):
+        exporter = ServiceEventsCloudWatchLogFileExporter(self.path)
+        try:
+            result = exporter.export([])
+        finally:
+            exporter.shutdown()
+        self.assertEqual(result, LogRecordExportResult.SUCCESS)
+        self.assertEqual(self._lines(), [])
+
+    def test_rejects_after_shutdown(self):
+        exporter = ServiceEventsCloudWatchLogFileExporter(self.path)
+        exporter.shutdown()
+        result = exporter.export([_make_readable()])
+        self.assertEqual(result, LogRecordExportResult.FAILURE)
+
+    def test_force_flush_returns_true_on_success(self):
+        # force_flush flushes the underlying handler and reports success.
+        exporter = ServiceEventsCloudWatchLogFileExporter(self.path)
+        try:
+            exporter.export([_make_readable()])
+            self.assertTrue(exporter.force_flush())
+        finally:
+            exporter.shutdown()
+
+    def test_force_flush_returns_false_when_handler_raises(self):
+        # An I/O error inside flush() is swallowed; force_flush returns False.
+        exporter = ServiceEventsCloudWatchLogFileExporter(self.path)
+        try:
+            exporter.export([_make_readable()])
+            with patch.object(exporter._writer.handler, "flush", side_effect=OSError("disk full")):
+                self.assertFalse(exporter.force_flush())
+        finally:
+            exporter.shutdown()
+
+    def test_export_failure_is_swallowed(self):
+        # A write failure inside export() is caught and reported as FAILURE,
+        # never propagated into the customer application.
+        exporter = ServiceEventsCloudWatchLogFileExporter(self.path)
+        try:
+            with patch.object(exporter._writer.handler, "emit", side_effect=OSError("disk full")):
+                result = exporter.export([_make_readable()])
+            self.assertEqual(result, LogRecordExportResult.FAILURE)
+        finally:
+            exporter.shutdown()
+
+    def test_double_shutdown_is_idempotent(self):
+        # Second shutdown() hits the early-return guard and does not raise.
+        exporter = ServiceEventsCloudWatchLogFileExporter(self.path)
+        exporter.shutdown()
+        exporter.shutdown()  # idempotent no-op
+
+
+class TestMetricExporter(TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.path = os.path.join(self.tmpdir.name, "serviceevents.ndjson")
+
+    def tearDown(self):
+        _reset_file_writers()
+        self.tmpdir.cleanup()
+
+    def _lines(self):
+        if not os.path.exists(self.path):
+            return []
+        with open(self.path) as f:
+            return [json.loads(line) for line in f if line.strip()]
+
+    def _make_metrics_data(self):
+        # Build a real MetricsData with one Sum metric (count) and one data point.
+        from opentelemetry.sdk.metrics.export import (
+            AggregationTemporality,
+            Metric,
+            MetricsData,
+            NumberDataPoint,
+            ResourceMetrics,
+            ScopeMetrics,
+            Sum,
+        )
+        from opentelemetry.sdk.util.instrumentation import InstrumentationScope
+
+        dp = NumberDataPoint(
+            attributes={
+                "Telemetry.Source": "ServiceEvents",
+                "service_name": "shoppingcart",
+                "operation": "POST /api/checkout",
+                "exception": "RuntimeError",
+            },
+            start_time_unix_nano=1744137900_000_000_000,
+            time_unix_nano=1744137960_000_000_000,
+            value=5,
+        )
+        sum_data = Sum(
+            data_points=[dp],
+            aggregation_temporality=AggregationTemporality.DELTA,
+            is_monotonic=True,
+        )
+        metric = Metric(name="count", description="", unit="Count", data=sum_data)
+        scope = InstrumentationScope(name="serviceevents", version="1.0")
+        sm = ScopeMetrics(scope=scope, metrics=[metric], schema_url="")
+        rm = ResourceMetrics(
+            resource=Resource.create({"service.name": "shoppingcart"}),
+            scope_metrics=[sm],
+            schema_url="",
+        )
+        return MetricsData(resource_metrics=[rm])
+
+    def _make_histogram_metrics_data(self):
+        # Build a real MetricsData with one ExponentialHistogram (service.function.duration).
+        from opentelemetry.sdk.metrics.export import (
+            AggregationTemporality,
+            Buckets,
+            ExponentialHistogram,
+            ExponentialHistogramDataPoint,
+            Metric,
+            MetricsData,
+            ResourceMetrics,
+            ScopeMetrics,
+        )
+        from opentelemetry.sdk.util.instrumentation import InstrumentationScope
+
+        dp = ExponentialHistogramDataPoint(
+            attributes={"Telemetry.Source": "ServiceEvents", "function.name": "app.handle", "status": "success"},
+            start_time_unix_nano=1744137900_000_000_000,
+            time_unix_nano=1744137960_000_000_000,
+            count=3,
+            sum=16166.0,
+            scale=4,
+            zero_count=0,
+            positive=Buckets(offset=47, bucket_counts=[1, 2]),
+            negative=Buckets(offset=0, bucket_counts=[]),
+            flags=0,
+            min=1500.0,
+            max=3875.0,
+        )
+        histogram = ExponentialHistogram(
+            data_points=[dp],
+            aggregation_temporality=AggregationTemporality.DELTA,
+        )
+        metric = Metric(
+            name="service.function.duration",
+            description="Function call duration",
+            unit="Microseconds",
+            data=histogram,
+        )
+        scope = InstrumentationScope(name="serviceevents", version="1.0")
+        sm = ScopeMetrics(scope=scope, metrics=[metric], schema_url="")
+        rm = ResourceMetrics(
+            resource=Resource.create({"service.name": "shoppingcart"}),
+            scope_metrics=[sm],
+            schema_url="",
+        )
+        return MetricsData(resource_metrics=[rm])
+
+    def test_writes_otlp_json_per_batch(self):
+        exporter = ServiceEventsCloudWatchMetricFileExporter(self.path)
+        try:
+            result = exporter.export(self._make_metrics_data())
+        finally:
+            exporter.shutdown()
+        self.assertEqual(result, MetricExportResult.SUCCESS)
+        lines = self._lines()
+        # One line per export batch (an ExportMetricsServiceRequest), not per data point.
+        self.assertEqual(len(lines), 1)
+        req = lines[0]
+        rm = req["resourceMetrics"][0]
+        self.assertEqual(rm["scopeMetrics"][0]["scope"]["name"], "serviceevents")
+        metric = rm["scopeMetrics"][0]["metrics"][0]
+        self.assertEqual(metric["name"], "count")
+        self.assertEqual(metric["unit"], "Count")
+        sum_dp = metric["sum"]["dataPoints"][0]
+        self.assertEqual(sum_dp["asInt"], "5")
+        # No EMF envelope; metric name stays lowercase (no count->Count capitalization).
+        self.assertNotIn("_aws", req)
+
+    def test_writes_exponential_histogram_as_otlp_json(self):
+        exporter = ServiceEventsCloudWatchMetricFileExporter(self.path)
+        try:
+            result = exporter.export(self._make_histogram_metrics_data())
+        finally:
+            exporter.shutdown()
+        self.assertEqual(result, MetricExportResult.SUCCESS)
+        lines = self._lines()
+        self.assertEqual(len(lines), 1)
+        metric = lines[0]["resourceMetrics"][0]["scopeMetrics"][0]["metrics"][0]
+        self.assertEqual(metric["name"], "service.function.duration")
+        self.assertEqual(metric["unit"], "Microseconds")
+        # The histogram serializes natively as exponentialHistogram (not dropped, not EMF).
+        self.assertIn("exponentialHistogram", metric)
+        hist_dp = metric["exponentialHistogram"]["dataPoints"][0]
+        self.assertEqual(hist_dp["count"], "3")
+        self.assertEqual(hist_dp["scale"], 4)
+
+    def test_empty_batch_no_error(self):
+        from opentelemetry.sdk.metrics.export import MetricsData
+
+        exporter = ServiceEventsCloudWatchMetricFileExporter(self.path)
+        try:
+            result = exporter.export(MetricsData(resource_metrics=[]))
+        finally:
+            exporter.shutdown()
+        self.assertEqual(result, MetricExportResult.SUCCESS)
+        self.assertEqual(self._lines(), [])
+
+    def test_temporality_is_delta_through_real_reader(self):
+        # Drive a real counter through a MeterProvider + PeriodicExportingMetricReader
+        # using this exporter, so the exporter's CONFIGURED temporality is exercised
+        # (not a hand-built MetricsData). The reader reads `_preferred_temporality`
+        # off the exporter; an empty dict would default to CUMULATIVE and diverge
+        # from the OTLP network exporter, which configures DELTA. Regression guard.
+        from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+
+        exporter = ServiceEventsCloudWatchMetricFileExporter(self.path)
+        reader = PeriodicExportingMetricReader(exporter, export_interval_millis=3_600_000)
+        provider = MeterProvider(metric_readers=[reader])
+        try:
+            counter = provider.get_meter("serviceevents", "1.0").create_counter("count", unit="Count")
+            counter.add(5, {"Telemetry.Source": "ServiceEvents", "operation": "POST /x"})
+            # Force a collection+export cycle through the reader (not a direct export()).
+            reader.collect()
+        finally:
+            provider.shutdown()
+        lines = self._lines()
+        self.assertTrue(lines, "reader.collect() should have produced one OTLP-JSON line")
+        metric = lines[0]["resourceMetrics"][0]["scopeMetrics"][0]["metrics"][0]
+        self.assertEqual(
+            metric["sum"]["aggregationTemporality"],
+            "AGGREGATION_TEMPORALITY_DELTA",
+            "file exporter must export Delta to match the OTLP network exporter",
+        )
+
+    def test_force_flush_returns_true_on_success(self):
+        # force_flush flushes the underlying handler and reports success.
+        exporter = ServiceEventsCloudWatchMetricFileExporter(self.path)
+        try:
+            exporter.export(self._make_metrics_data())
+            self.assertTrue(exporter.force_flush())
+        finally:
+            exporter.shutdown()
+
+    def test_force_flush_returns_false_when_handler_raises(self):
+        # An I/O error inside flush() is swallowed; force_flush returns False.
+        exporter = ServiceEventsCloudWatchMetricFileExporter(self.path)
+        try:
+            exporter.export(self._make_metrics_data())
+            with patch.object(exporter._writer.handler, "flush", side_effect=OSError("disk full")):
+                self.assertFalse(exporter.force_flush())
+        finally:
+            exporter.shutdown()
+
+    def test_export_failure_is_swallowed(self):
+        # A write failure inside export() is caught and reported as FAILURE,
+        # never propagated into the customer application.
+        exporter = ServiceEventsCloudWatchMetricFileExporter(self.path)
+        try:
+            with patch.object(exporter._writer.handler, "emit", side_effect=OSError("disk full")):
+                result = exporter.export(self._make_metrics_data())
+            self.assertEqual(result, MetricExportResult.FAILURE)
+        finally:
+            exporter.shutdown()
+
+    def test_double_shutdown_is_idempotent(self):
+        # Second shutdown() hits the early-return guard and does not raise.
+        exporter = ServiceEventsCloudWatchMetricFileExporter(self.path)
+        exporter.shutdown()
+        exporter.shutdown()  # idempotent no-op
+
+    def test_log_and_metric_exporters_share_one_file(self):
+        log_exp = ServiceEventsCloudWatchLogFileExporter(self.path)
+        metric_exp = ServiceEventsCloudWatchMetricFileExporter(self.path)
+        try:
+            log_exp.export([_make_readable()])
+            metric_exp.export(self._make_metrics_data())
+        finally:
+            log_exp.shutdown()
+            metric_exp.shutdown()
+        lines = self._lines()
+        self.assertEqual(len(lines), 2)
+        # Logs keep the flat CloudWatch-Insights shape (eventName); metrics are OTLP JSON.
+        self.assertTrue(any(line.get("eventName") == "aws.service_events.function_call" for line in lines))
+        self.assertTrue(any(line.get("resourceMetrics") for line in lines))
+
+
+class TestRotation(TestCase):
+    """Verify size-based rotation enforces the declared 50MB / 5-backup policy.
+
+    Tests use a tiny MAX_BYTES (1 KiB) so a handful of records cross the
+    threshold; the rotation mechanism is the same at any threshold.
+    """
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.path = os.path.join(self.tmpdir.name, "serviceevents.ndjson")
+
+    def tearDown(self):
+        _reset_file_writers()
+        self.tmpdir.cleanup()
+
+    def _backup_paths(self):
+        return sorted(glob.glob(self.path + ".*"))
+
+    def _exporter_with_threshold(self, max_bytes: int):
+        # Patch module constant so the exporter's _acquire_writer picks up the
+        # smaller threshold via its default arg.
+        patcher = patch.object(cloudwatch_file_exporter, "MAX_BYTES", max_bytes)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        return ServiceEventsCloudWatchLogFileExporter(self.path)
+
+    def test_below_threshold_no_rollover(self):
+        # 10 KiB threshold; 5 records × ~418 bytes ≈ 2 KiB — well below.
+        exporter = self._exporter_with_threshold(max_bytes=10 * 1024)
+        try:
+            exporter.export([_make_readable() for _ in range(5)])
+        finally:
+            exporter.shutdown()
+        self.assertTrue(os.path.exists(self.path))
+        self.assertEqual(self._backup_paths(), [])
+
+    def test_at_threshold_single_rollover(self):
+        # 1 KiB threshold; 4 records × ~418 bytes ≈ 1.6 KiB — crosses once.
+        exporter = self._exporter_with_threshold(max_bytes=1024)
+        try:
+            exporter.export([_make_readable() for _ in range(4)])
+        finally:
+            exporter.shutdown()
+        self.assertTrue(os.path.exists(self.path))
+        backups = self._backup_paths()
+        self.assertGreaterEqual(len(backups), 1, "expected at least one rollover")
+        self.assertIn(self.path + ".1", backups)
+
+    def test_backup_cap_drops_oldest(self):
+        # 512-byte threshold + many records → far more than 5 rotations.
+        # Backup cap must hold at 5 regardless.
+        exporter = self._exporter_with_threshold(max_bytes=512)
+        try:
+            for _ in range(10):
+                exporter.export([_make_readable() for _ in range(20)])
+        finally:
+            exporter.shutdown()
+        backups = self._backup_paths()
+        # Cap at 5 backups: <file>.1 .. <file>.5, no <file>.6.
+        self.assertLessEqual(len(backups), 5, f"expected ≤5 backups, got {backups}")
+        self.assertFalse(os.path.exists(self.path + ".6"), "<file>.6 should never exist with backupCount=5")
+
+    def test_utf8_byte_count_drives_rollover(self):
+        # 200-byte threshold; each record body holds 100 4-byte CJK code points.
+        # If shouldRollover used len(msg) (code points), 100 chars + a small JSON
+        # envelope wouldn't trip the threshold even though the on-disk bytes are
+        # ~400+. The override must count UTF-8 bytes so rotation fires.
+        exporter = self._exporter_with_threshold(max_bytes=200)
+        cjk_body = {"msg": "上" * 100}  # each char is 3 UTF-8 bytes
+        try:
+            for _ in range(3):
+                exporter.export([_make_readable(body=cjk_body)])
+        finally:
+            exporter.shutdown()
+        backups = self._backup_paths()
+        self.assertGreaterEqual(len(backups), 1, "UTF-8 byte counting must trigger rollover for multi-byte content")
+
+
+class TestExporterErrorHandling(TestCase):
+    """Constructing an exporter on an unopenable path MUST NOT raise — telemetry
+    code is forbidden from crashing the customer application."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        _reset_file_writers()
+        self.tmpdir.cleanup()
+
+    def _bogus_path(self) -> str:
+        # Create a regular file then try to write *under* it — mkdir on a
+        # path whose parent is a file fails with NotADirectoryError.
+        plain_file = os.path.join(self.tmpdir.name, "regular-file")
+        with open(plain_file, "wb") as f:
+            f.write(b"\0")
+        return os.path.join(plain_file, "nested", "svc.ndjson")
+
+    def test_log_exporter_unopenable_path_does_not_raise(self):
+        exporter = ServiceEventsCloudWatchLogFileExporter(self._bogus_path())
+        try:
+            result = exporter.export([_make_readable()])
+            self.assertEqual(result, LogRecordExportResult.FAILURE)
+            self.assertFalse(exporter.force_flush())
+        finally:
+            # shutdown must be a safe no-op when no writer was acquired.
+            exporter.shutdown()
+
+    def test_metric_exporter_unopenable_path_does_not_raise(self):
+        exporter = ServiceEventsCloudWatchMetricFileExporter(self._bogus_path())
+        try:
+            metrics = MagicMock()
+            metrics.resource_metrics = []
+            result = exporter.export(metrics)
+            self.assertEqual(result, MetricExportResult.FAILURE)
+            self.assertFalse(exporter.force_flush())
+        finally:
+            exporter.shutdown()
+
+    def test_log_exporter_invalid_path_type_does_not_raise(self):
+        # os.path.abspath raises TypeError on non-string input. Constructor MUST
+        # NOT propagate this — exporter is constructed at SDK init, before the
+        # customer app has any chance to recover.
+        try:
+            exporter = ServiceEventsCloudWatchLogFileExporter(None)  # type: ignore[arg-type]
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            self.fail(f"constructor must not raise on invalid path type: {exc!r}")
+        try:
+            self.assertEqual(exporter.export([_make_readable()]), LogRecordExportResult.FAILURE)
+        finally:
+            exporter.shutdown()
+
+    def test_metric_exporter_invalid_path_type_does_not_raise(self):
+        try:
+            exporter = ServiceEventsCloudWatchMetricFileExporter(None)  # type: ignore[arg-type]
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            self.fail(f"constructor must not raise on invalid path type: {exc!r}")
+        try:
+            metrics = MagicMock()
+            metrics.resource_metrics = []
+            self.assertEqual(exporter.export(metrics), MetricExportResult.FAILURE)
+        finally:
+            exporter.shutdown()
+
+
+class TestWriterSingleton(TestCase):
+    """Cover the shared-writer registry's release/reset edge cases."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.path = os.path.join(self.tmpdir.name, "serviceevents.ndjson")
+
+    def tearDown(self):
+        _reset_file_writers()
+        self.tmpdir.cleanup()
+
+    def test_release_unknown_path_is_noop(self):
+        # Releasing a path that was never acquired hits the entry-is-None guard
+        # and returns without raising.
+        _release_writer(os.path.join(self.tmpdir.name, "never-acquired.ndjson"))
+
+    def test_release_swallows_handler_close_error(self):
+        # A failure while closing the handler on final release is swallowed.
+        abs_path = os.path.abspath(self.path)
+        entry = _acquire_writer(abs_path)
+        self.assertIsNotNone(entry)
+        with patch.object(entry.handler, "close", side_effect=OSError("close failed")):
+            _release_writer(abs_path)  # must not raise
+
+    def test_reset_swallows_handler_close_error(self):
+        # _reset_file_writers swallows per-handler close errors and still clears.
+        abs_path = os.path.abspath(self.path)
+        entry = _acquire_writer(abs_path)
+        self.assertIsNotNone(entry)
+        with patch.object(entry.handler, "close", side_effect=OSError("close failed")):
+            _reset_file_writers()  # must not raise
+        # Registry is cleared even though close() raised.
+        self.assertEqual(cloudwatch_file_exporter._writers, {})
+
+
+class TestUtf8RotatingFileHandler(TestCase):
+    """Exercise the shouldRollover guards in the UTF-8 byte-counting handler."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.path = os.path.join(self.tmpdir.name, "serviceevents.ndjson")
+
+    def tearDown(self):
+        _reset_file_writers()
+        self.tmpdir.cleanup()
+
+    def _record(self, msg="hello\n"):
+        import logging
+
+        return logging.LogRecord(
+            name="serviceevents",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg=msg,
+            args=(),
+            exc_info=None,
+        )
+
+    def _handler(self, max_bytes):
+        import logging
+
+        handler = _Utf8RotatingFileHandler(
+            self.path, mode="a", maxBytes=max_bytes, backupCount=1, encoding="utf-8", delay=True
+        )
+        handler.terminator = ""
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        self.addCleanup(handler.close)
+        return handler
+
+    def test_opens_stream_when_none(self):
+        # delay=True leaves the stream unopened; shouldRollover must open it
+        # (and report False on the resulting empty file).
+        handler = self._handler(max_bytes=1024)
+        self.assertIsNone(handler.stream)
+        self.assertFalse(handler.shouldRollover(self._record()))
+        self.assertIsNotNone(handler.stream)
+
+    def test_disabled_when_max_bytes_non_positive(self):
+        # maxBytes <= 0 disables rotation entirely.
+        handler = self._handler(max_bytes=0)
+        self.assertFalse(handler.shouldRollover(self._record()))
+
+    def test_no_rollover_for_non_regular_base_file(self):
+        # If the base path is not a regular file, the guard returns False even
+        # past the byte threshold.
+        handler = self._handler(max_bytes=1)
+        handler.stream = handler._open()
+        with patch.object(os.path, "isfile", return_value=False):
+            self.assertFalse(handler.shouldRollover(self._record()))
+
+    def test_no_rollover_when_seek_raises_oserror(self):
+        # A seek/tell OSError is treated as "cannot determine size" → no rollover.
+        handler = self._handler(max_bytes=1)
+        handler.stream = handler._open()
+        with patch.object(handler.stream, "seek", side_effect=OSError("seek failed")):
+            self.assertFalse(handler.shouldRollover(self._record()))
+
+    def test_rollover_uses_codepoint_len_on_encode_failure(self):
+        # If encoding the formatted message fails, fall back to len(msg) for the
+        # size check rather than crashing the rotation path.
+        handler = self._handler(max_bytes=4)
+        handler.stream = handler._open()
+        handler.stream.write("seed")  # non-empty so the empty-file guard passes
+        handler.stream.flush()
+
+        class _BadStr(str):
+            def encode(self, *args, **kwargs):
+                raise UnicodeError("boom")
+
+            def __add__(self, other):
+                # format(record) + terminator → still a _BadStr so .encode() raises.
+                return _BadStr(str(self) + str(other))
+
+        with patch.object(handler, "format", return_value=_BadStr("abcdef")):
+            record = self._record()
+            # Fallback len("abcdef")==6 + current size (4) >= 4 → rollover.
+            self.assertTrue(handler.shouldRollover(record))

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/exporter/test_otlp_attribute_vs_body_types.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/exporter/test_otlp_attribute_vs_body_types.py
@@ -1,0 +1,397 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests validating OTLP LogRecord type constraints for Attributes vs Body.
+
+These tests prove WHY the hybrid approach (flat attributes + structured body)
+is necessary for the ServiceEvents OTLP log data model:
+
+Key findings:
+- Span/Resource attributes: only accept primitives (bool, str, bytes, int, float)
+  and homogeneous sequences. Dicts are REJECTED by SDK validation.
+- LogRecord attributes (Python): technically accept dicts via AnyValue protobuf,
+  BUT Java's AttributeKey<T> has no mapKey — so dicts in attributes break
+  cross-SDK parity.
+- Body (AnyValue): accepts primitives + Mapping (dict) + Sequence with full
+  nesting. This is where structured data belongs for cross-SDK compatibility.
+- Mixed-type sequences: stored as None (data lost) — avoid in attributes.
+"""
+
+import unittest
+
+from opentelemetry._events import Event
+from opentelemetry._logs import SeverityNumber
+from opentelemetry.sdk._events import EventLoggerProvider
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs.export import InMemoryLogExporter, SimpleLogRecordProcessor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.trace import TraceFlags
+
+
+class TestOtlpAttributeTypeConstraints(unittest.TestCase):
+    """Test OTLP LogRecord type behavior for attributes and body."""
+
+    def setUp(self):
+        self.exporter = InMemoryLogExporter()
+        self.provider = LoggerProvider(resource=Resource.create({"service.name": "test-service"}))
+        self.provider.add_log_record_processor(SimpleLogRecordProcessor(self.exporter))
+        self.event_logger_provider = EventLoggerProvider(logger_provider=self.provider)
+        self.event_logger = self.event_logger_provider.get_event_logger("test.scope")
+
+    def tearDown(self):
+        self.provider.shutdown()
+
+    def _emit_and_get(self, body, attributes):
+        """Emit an event and return the exported log record."""
+        self.exporter.clear()
+        event = Event(
+            name="test.event",
+            body=body,
+            attributes=attributes,
+            severity_number=SeverityNumber.INFO,
+        )
+        self.event_logger.emit(event)
+        records = self.exporter.get_finished_logs()
+        self.assertEqual(len(records), 1)
+        return records[0]
+
+    # ── Attribute type tests ──────────────────────────────────────────
+
+    def test_attributes_accept_string(self):
+        """String values work in attributes."""
+        record = self._emit_and_get(body="test", attributes={"key": "value"})
+        self.assertEqual(record.log_record.attributes["key"], "value")
+
+    def test_attributes_accept_int(self):
+        """Int values work in attributes."""
+        record = self._emit_and_get(body="test", attributes={"key": 42})
+        self.assertEqual(record.log_record.attributes["key"], 42)
+
+    def test_attributes_accept_float(self):
+        """Float values work in attributes."""
+        record = self._emit_and_get(body="test", attributes={"key": 3.14})
+        self.assertAlmostEqual(record.log_record.attributes["key"], 3.14)
+
+    def test_attributes_accept_bool(self):
+        """Bool values work in attributes."""
+        record = self._emit_and_get(body="test", attributes={"key": True})
+        self.assertEqual(record.log_record.attributes["key"], True)
+
+    def test_attributes_accept_string_sequence(self):
+        """Homogeneous string sequences work in attributes."""
+        record = self._emit_and_get(body="test", attributes={"key": ["a", "b", "c"]})
+        self.assertEqual(record.log_record.attributes["key"], ("a", "b", "c"))
+
+    def test_attributes_accept_int_sequence(self):
+        """Homogeneous int sequences work in attributes."""
+        record = self._emit_and_get(body="test", attributes={"key": [1, 2, 3]})
+        self.assertEqual(record.log_record.attributes["key"], (1, 2, 3))
+
+    def test_attributes_dict_passes_through_in_python_log_records(self):
+        """Python LogRecord attributes accept dicts (unlike Span attributes).
+
+        This is because LogRecord uses AnyValue in protobuf, which supports maps.
+        However, Java's AttributeKey<T> has no mapKey — so for cross-SDK parity,
+        we must NOT rely on this behavior. Use Body for nested structures instead.
+        """
+        record = self._emit_and_get(
+            body="test",
+            attributes={
+                "flat_key": "survives",
+                "nested_key": {"inner": "value"},  # passes through in Python
+            },
+        )
+        self.assertEqual(record.log_record.attributes["flat_key"], "survives")
+        # Python SDK accepts dicts in LogRecord attributes (unlike Span attributes)
+        self.assertIn("nested_key", record.log_record.attributes)
+
+    def test_attributes_nested_dict_passes_through_in_python_log_records(self):
+        """Python LogRecord attributes accept nested dicts (unlike Span attributes).
+
+        Java SDK cannot do this — AttributeKey has no map type.
+        For cross-SDK parity, nested structures belong in Body.
+        """
+        record = self._emit_and_get(
+            body="test",
+            attributes={
+                "keep": "yes",
+                "duration": {"Values": [1.0, 2.0], "Max": 5.0},
+            },
+        )
+        self.assertEqual(record.log_record.attributes["keep"], "yes")
+        # Python passes dicts through, but Java cannot
+        self.assertIn("duration", record.log_record.attributes)
+
+    def test_attributes_list_of_dicts_passes_through_in_python_log_records(self):
+        """Python LogRecord attributes accept lists of dicts.
+
+        Java SDK cannot represent this — no mapKey or nested array types.
+        For cross-SDK parity, lists of dicts belong in Body.
+        """
+        record = self._emit_and_get(
+            body="test",
+            attributes={
+                "keep": "yes",
+                "errors": [{"type": "RuntimeError", "count": 3}],
+            },
+        )
+        self.assertEqual(record.log_record.attributes["keep"], "yes")
+        # Python passes through, converted to tuple
+        self.assertIn("errors", record.log_record.attributes)
+
+    def test_attributes_mixed_type_sequence_stored_as_none(self):
+        """Mixed-type sequences are stored as None in attributes (value lost).
+
+        The SDK detects mixed types and sets the value to None.
+        This proves mixed-type sequences are not safely representable in attributes.
+        """
+        record = self._emit_and_get(
+            body="test",
+            attributes={
+                "keep": "yes",
+                "mixed": [1, "two", 3.0],  # mixed types → stored as None
+            },
+        )
+        self.assertEqual(record.log_record.attributes["keep"], "yes")
+        # Key exists but value is None — data is lost
+        self.assertIn("mixed", record.log_record.attributes)
+        self.assertIsNone(record.log_record.attributes["mixed"])
+
+    # ── Body type tests ───────────────────────────────────────────────
+
+    def test_body_accepts_string(self):
+        """String body works."""
+        record = self._emit_and_get(body="hello", attributes={})
+        self.assertEqual(record.log_record.body, "hello")
+
+    def test_body_accepts_dict(self):
+        """Dict body works — this is what attributes CANNOT do."""
+        body = {"endpoint_id": "abc-123", "count": 42}
+        record = self._emit_and_get(body=body, attributes={})
+        self.assertEqual(record.log_record.body["endpoint_id"], "abc-123")
+        self.assertEqual(record.log_record.body["count"], 42)
+
+    def test_body_accepts_nested_dict(self):
+        """Nested dicts work in body — full structure preserved."""
+        body = {
+            "duration": {
+                "Values": [1234.5, 2345.6],
+                "Counts": [10, 5],
+                "Max": 5000.0,
+                "Min": 100.0,
+                "Count": 15,
+                "Sum": 25000.0,
+            }
+        }
+        record = self._emit_and_get(body=body, attributes={})
+        self.assertEqual(record.log_record.body["duration"]["Max"], 5000.0)
+        self.assertEqual(record.log_record.body["duration"]["Values"], [1234.5, 2345.6])
+
+    def test_body_accepts_list_of_dicts(self):
+        """Lists of dicts work in body — error_breakdown structure preserved."""
+        body = {
+            "error_breakdown": [
+                {
+                    "failure_type": "500",
+                    "count": 3,
+                    "errors": [{"error_type": "RuntimeError", "function_id": "abc"}],
+                }
+            ]
+        }
+        record = self._emit_and_get(body=body, attributes={})
+        breakdown = record.log_record.body["error_breakdown"]
+        self.assertEqual(len(breakdown), 1)
+        self.assertEqual(breakdown[0]["failure_type"], "500")
+        self.assertEqual(breakdown[0]["errors"][0]["error_type"], "RuntimeError")
+
+    def test_body_accepts_deeply_nested_incident_snapshot(self):
+        """Full IncidentSnapshot body with 3+ levels of nesting works."""
+        body = {
+            "snapshot_id": "snap_abc123",
+            "severity": "critical",
+            "exception_info": [
+                {
+                    "exception_type": "RuntimeError",
+                    "exception_message": "fail",
+                    "stack_trace": "Traceback...",
+                    "call_path": [
+                        {
+                            "function_id": "func-1",
+                            "caller_function_id": "func-2",
+                            "duration_ns": 1958,
+                            "error": False,
+                        },
+                        {
+                            "function_id": "func-2",
+                            "caller_function_id": None,
+                            "duration_ns": 189666,
+                            "error": True,
+                        },
+                    ],
+                }
+            ],
+            "request_context": {
+                "type": "http",
+                "status_code": 500,
+                "request_body": {"user_id": "test-123", "password": "***REDACTED***"},
+                "query_params": {"debug": "true"},
+            },
+        }
+        record = self._emit_and_get(body=body, attributes={})
+
+        # 3 levels deep: body → exception_info[0] → call_path[1] → error
+        self.assertTrue(record.log_record.body["exception_info"][0]["call_path"][1]["error"])
+
+        # 3 levels deep: body → request_context → request_body → user_id
+        self.assertEqual(
+            record.log_record.body["request_context"]["request_body"]["user_id"],
+            "test-123",
+        )
+
+    # ── Hybrid approach tests ─────────────────────────────────────────
+
+    def test_hybrid_endpoint_summary(self):
+        """EndpointSummary: flat query fields in attributes, structured data in body."""
+        attributes = {
+            "serviceevents.signal_type": "EndpointSummary",
+            "service.name": "my-api",
+            "deployment.environment": "prod",
+            "http.request.method": "POST",
+            "url.route": "/api/users",
+            "serviceevents.endpoint_id": "2775225a-cb8e-5c0a",
+            "serviceevents.request.count": 9,
+            "serviceevents.request.faults": 9,
+            "serviceevents.request.errors": 0,
+        }
+        body = {
+            "endpoint_id": "2775225a-cb8e-5c0a",
+            "method": "POST",
+            "route": "/api/users",
+            "operation": "POST /api/users",
+            "count": 9,
+            "faults": 9,
+            "errors": 0,
+            "duration": {"Values": [9433.38], "Counts": [6], "Max": 19335.5, "Min": 9127.6, "Count": 9, "Sum": 97462.6},
+            "error_breakdown": [
+                {"failure_type": "500", "count": 7, "errors": [{"error_type": "RuntimeError", "function_id": "964a"}]}
+            ],
+        }
+
+        record = self._emit_and_get(body=body, attributes=attributes)
+
+        # Attributes: all flat, all queryable
+        self.assertEqual(record.log_record.attributes["serviceevents.signal_type"], "EndpointSummary")
+        self.assertEqual(record.log_record.attributes["http.request.method"], "POST")
+        self.assertEqual(record.log_record.attributes["serviceevents.request.faults"], 9)
+
+        # Body: nested structures preserved
+        self.assertEqual(record.log_record.body["duration"]["Max"], 19335.5)
+        self.assertEqual(record.log_record.body["error_breakdown"][0]["errors"][0]["error_type"], "RuntimeError")
+
+    def test_hybrid_incident_snapshot_with_trace_context(self):
+        """IncidentSnapshot: severity mapping + trace context + nested body."""
+        attributes = {
+            "serviceevents.signal_type": "IncidentSnapshot",
+            "serviceevents.severity": "critical",
+            "serviceevents.trigger_type": "exception",
+            "http.response.status_code": 500,
+        }
+        body = {
+            "snapshot_id": "snap_c361cdc6",
+            "severity": "critical",
+            "exception_info": [
+                {
+                    "exception_type": "RuntimeError",
+                    "stack_trace": "Traceback...\nRuntimeError: fail",
+                    "call_path": [{"function_id": "f1", "duration_ns": 1958, "error": True}],
+                }
+            ],
+            "telemetry_correlation": {
+                "trace_id": "0x699e34c662d55e013e833341a5d9f079",
+                "span_id": "0x85b7839f6afbae05",
+            },
+        }
+
+        # Parse trace context (as the emitter would)
+        trace_id = int("699e34c662d55e013e833341a5d9f079", 16)
+        span_id = int("85b7839f6afbae05", 16)
+
+        event = Event(
+            name="serviceevents.incident",
+            body=body,
+            attributes=attributes,
+            severity_number=SeverityNumber.FATAL,  # critical → FATAL
+            trace_id=trace_id,
+            span_id=span_id,
+            trace_flags=TraceFlags.SAMPLED,
+        )
+        self.exporter.clear()
+        self.event_logger.emit(event)
+        records = self.exporter.get_finished_logs()
+        self.assertEqual(len(records), 1)
+        record = records[0].log_record
+
+        # Severity mapped correctly
+        self.assertEqual(record.severity_number, SeverityNumber.FATAL)
+
+        # Trace context propagated
+        self.assertEqual(record.trace_id, trace_id)
+        self.assertEqual(record.span_id, span_id)
+        self.assertEqual(record.trace_flags, TraceFlags.SAMPLED)
+
+        # Attributes: flat and queryable
+        self.assertEqual(record.attributes["serviceevents.severity"], "critical")
+        self.assertEqual(record.attributes["http.response.status_code"], 500)
+
+        # Body: deeply nested structure preserved
+        self.assertEqual(record.body["exception_info"][0]["call_path"][0]["function_id"], "f1")
+        self.assertTrue(record.body["exception_info"][0]["call_path"][0]["error"])
+
+
+class TestAttributeTypeValidation(unittest.TestCase):
+    """Direct validation of OTel SDK type constants."""
+
+    def test_valid_attr_types_are_primitives_only(self):
+        """_VALID_ATTR_VALUE_TYPES contains only primitives — no dict, no list."""
+        import opentelemetry.attributes as attrs
+
+        valid = attrs._VALID_ATTR_VALUE_TYPES
+        self.assertIn(bool, valid)
+        self.assertIn(str, valid)
+        self.assertIn(int, valid)
+        self.assertIn(float, valid)
+        self.assertIn(bytes, valid)
+        self.assertNotIn(dict, valid)
+        self.assertNotIn(list, valid)
+
+    def test_valid_anyvalue_types_include_mapping(self):
+        """_VALID_ANY_VALUE_TYPES includes Mapping (dict) — Body can hold dicts."""
+        import typing
+
+        import opentelemetry.attributes as attrs
+
+        valid = attrs._VALID_ANY_VALUE_TYPES
+        self.assertIn(typing.Mapping, valid)
+        self.assertIn(typing.Sequence, valid)
+        self.assertIn(str, valid)
+        self.assertIn(int, valid)
+
+    def test_attr_types_are_strict_subset_of_anyvalue_types(self):
+        """Attribute types are a strict subset of AnyValue types.
+        This proves Body supports more types than Attributes."""
+        import opentelemetry.attributes as attrs
+
+        attr_types = set(attrs._VALID_ATTR_VALUE_TYPES)
+        any_types = set(attrs._VALID_ANY_VALUE_TYPES)
+
+        # Every attr type is also an anyvalue type
+        for t in attr_types:
+            self.assertIn(t, any_types, f"{t} is in attr types but not anyvalue types")
+
+        # AnyValue has MORE types than attributes
+        self.assertGreater(len(any_types), len(attr_types))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/exporter/test_otlp_contract.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/exporter/test_otlp_contract.py
@@ -1,0 +1,726 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Contract tests for ServiceEvents OTLP signal conformance.
+
+Verifies each signal type matches its expected OTLP shape:
+- Correct event.name attribute
+- Required attributes present
+- Body structure (nested fields, types)
+- Instrumentation scope aws.serviceevents/1.0
+- Trace context (IncidentSnapshot only)
+- Counter metric dimensions (EndpointErrorMetrics)
+
+These tests use in-memory exporters — no Docker or network needed.
+Mirrors the Java contract tests in ServiceEventsSpringMvcTest.
+"""
+
+import time
+
+import pytest
+
+from amazon.opentelemetry.distro.serviceevents.exporter.otlp_emitter import ServiceEventsOtlpEmitter
+from amazon.opentelemetry.distro.serviceevents.models import DeploymentEventTelemetry
+from amazon.opentelemetry.distro.serviceevents.models.deployment_telemetry import DeploymentContext
+from amazon.opentelemetry.distro.serviceevents.models.endpoint_telemetry import (
+    EndpointErrorMetric,
+    EndpointMetricEvent,
+    ErrorBreakdownEntry,
+    ErrorDetail,
+    IncidentExemplar,
+)
+from amazon.opentelemetry.distro.serviceevents.models.function_telemetry import DurationMetrics
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs.export import InMemoryLogExporter, SimpleLogRecordProcessor
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+from opentelemetry.sdk.resources import Resource
+
+
+@pytest.fixture
+def otlp_env():
+    """Create emitter + in-memory exporters for contract testing."""
+    resource = Resource.create(
+        {
+            "service.name": "contract-test-svc",
+            "deployment.environment.name": "contract-test",
+            "telemetry.sdk.language": "python",
+        }
+    )
+    log_exporter = InMemoryLogExporter()
+    lp = LoggerProvider(resource=resource)
+    lp.add_log_record_processor(SimpleLogRecordProcessor(log_exporter))
+    metric_reader = InMemoryMetricReader()
+    from opentelemetry.sdk.metrics.view import ExponentialBucketHistogramAggregation, View
+
+    function_duration_view = View(
+        instrument_name="service.function.duration",
+        aggregation=ExponentialBucketHistogramAggregation(),
+    )
+    mp = MeterProvider(resource=resource, metric_readers=[metric_reader], views=[function_duration_view])
+    emitter = ServiceEventsOtlpEmitter(lp, mp, "deploy-contract", "sha-contract", "https://github.com/contract")
+    yield emitter, log_exporter, metric_reader
+    lp.shutdown()
+    mp.shutdown()
+
+
+def _get_log(log_exporter, index=0):
+    logs = log_exporter.get_finished_logs()
+    assert len(logs) > index, f"Expected at least {index + 1} logs, got {len(logs)}"
+    return logs[index]
+
+
+def _attrs(log_exporter, index=0):
+    return dict(_get_log(log_exporter, index).log_record.attributes)
+
+
+def _body(log_exporter, index=0):
+    return _get_log(log_exporter, index).log_record.body
+
+
+def _scope(log_exporter, index=0):
+    return _get_log(log_exporter, index).instrumentation_scope
+
+
+# ==========================================================================
+# DeploymentEvent contract
+# ==========================================================================
+
+
+class TestDeploymentEventContract:
+    def test_event_name(self, otlp_env):
+        emitter, logs, _ = otlp_env
+        emitter.emit_deployment_event(DeploymentEventTelemetry.create(service_name="svc", environment="prod"))
+        assert _attrs(logs)["event.name"] == "aws.service_events.deployment_event"
+
+    def test_instrumentation_scope(self, otlp_env):
+        emitter, logs, _ = otlp_env
+        emitter.emit_deployment_event(DeploymentEventTelemetry.create())
+        scope = _scope(logs)
+        assert scope.name == "serviceevents"
+        assert scope.version == "1.0"
+
+    def test_no_body(self, otlp_env):
+        emitter, logs, _ = otlp_env
+        emitter.emit_deployment_event(DeploymentEventTelemetry.create())
+        body = _body(logs)
+        assert body == "" or body is None, "DeploymentEvent must have no body"
+
+    def test_deployment_id_attribute(self, otlp_env):
+        emitter, logs, _ = otlp_env
+        event = DeploymentEventTelemetry.create()
+        # A real context — a bare create() with no env yields the "unknown" sentinel,
+        # which the emitter intentionally omits.
+        event.deployment_context = DeploymentContext(git_commit_sha="sha-contract", deployment_id="deploy-contract")
+        emitter.emit_deployment_event(event)
+        attrs = _attrs(logs)
+        # From DeploymentContext or emitter config
+        assert "aws.service_events.deployment.id" in attrs or "vcs.ref.head.revision" in attrs
+
+    def test_no_trace_context(self, otlp_env):
+        emitter, logs, _ = otlp_env
+        emitter.emit_deployment_event(DeploymentEventTelemetry.create())
+        log = _get_log(logs)
+        assert log.log_record.trace_id == 0
+        assert log.log_record.span_id == 0
+
+
+# ==========================================================================
+# EndpointSummary contract
+# ==========================================================================
+
+
+class TestEndpointSummaryContract:
+    @pytest.fixture
+    def endpoint_event(self):
+        return EndpointMetricEvent(
+            environment="test",
+            service_name="svc",
+            sdk_version="0.14",
+            instance_id="host",
+            operation="POST /api/users",
+            method="POST",
+            route="/api/users",
+            pid=1234,
+            timestamp="2026-01-01T00:00:00Z",
+            count=100,
+            faults=5,
+            errors=10,
+            incident_count=2,
+            duration=DurationMetrics(
+                values=[10.0, 50.0, 200.0], counts=[50, 30, 20], max=500.0, min=1.0, count=100, sum=5000.0
+            ),
+            error_breakdown=[
+                ErrorBreakdownEntry(
+                    errors=[ErrorDetail(error_type="ValueError", function_name="mod.func")], count=5, failure_type="500"
+                ),
+            ],
+            incidents_exemplar=[
+                IncidentExemplar(
+                    snapshot_id="snap_001",
+                    trigger_type="exception",
+                    severity="critical",
+                    timestamp=int(time.time() * 1000),
+                ),
+            ],
+        )
+
+    def test_event_name(self, otlp_env, endpoint_event):
+        emitter, logs, _ = otlp_env
+        emitter.emit_endpoint_summary(endpoint_event)
+        assert _attrs(logs)["event.name"] == "aws.service_events.endpoint_summary"
+
+    def test_instrumentation_scope(self, otlp_env, endpoint_event):
+        emitter, logs, _ = otlp_env
+        emitter.emit_endpoint_summary(endpoint_event)
+        assert _scope(logs).name == "serviceevents"
+        assert _scope(logs).version == "1.0"
+
+    def test_http_method_attribute(self, otlp_env, endpoint_event):
+        emitter, logs, _ = otlp_env
+        emitter.emit_endpoint_summary(endpoint_event)
+        assert _attrs(logs)["http.request.method"] == "POST"
+
+    def test_url_route_attribute(self, otlp_env, endpoint_event):
+        emitter, logs, _ = otlp_env
+        emitter.emit_endpoint_summary(endpoint_event)
+        assert _attrs(logs)["url.route"] == "/api/users"
+
+    def test_operation_attribute(self, otlp_env, endpoint_event):
+        emitter, logs, _ = otlp_env
+        emitter.emit_endpoint_summary(endpoint_event)
+        assert _attrs(logs)["aws.service_events.operation"] == "POST /api/users"
+
+    def test_request_count_attribute(self, otlp_env, endpoint_event):
+        emitter, logs, _ = otlp_env
+        emitter.emit_endpoint_summary(endpoint_event)
+        assert _attrs(logs)["aws.service_events.request.count"] == 100
+
+    def test_faults_attribute(self, otlp_env, endpoint_event):
+        emitter, logs, _ = otlp_env
+        emitter.emit_endpoint_summary(endpoint_event)
+        assert _attrs(logs)["aws.service_events.request.faults"] == 5
+
+    def test_errors_attribute(self, otlp_env, endpoint_event):
+        emitter, logs, _ = otlp_env
+        emitter.emit_endpoint_summary(endpoint_event)
+        assert _attrs(logs)["aws.service_events.request.errors"] == 10
+
+    def test_incident_count_attribute(self, otlp_env, endpoint_event):
+        emitter, logs, _ = otlp_env
+        emitter.emit_endpoint_summary(endpoint_event)
+        assert _attrs(logs)["aws.service_events.incident.count"] == 2
+
+    def test_vcs_attributes(self, otlp_env, endpoint_event):
+        emitter, logs, _ = otlp_env
+        emitter.emit_endpoint_summary(endpoint_event)
+        attrs = _attrs(logs)
+        assert attrs["vcs.ref.head.revision"] == "sha-contract"
+        assert attrs["vcs.repository.url.full"] == "https://github.com/contract"
+        assert attrs["aws.service_events.deployment.id"] == "deploy-contract"
+
+    def test_body_duration_structure(self, otlp_env, endpoint_event):
+        emitter, logs, _ = otlp_env
+        emitter.emit_endpoint_summary(endpoint_event)
+        body = _body(logs)
+        assert isinstance(body, dict)
+        dur = body["duration"]
+        assert dur["Values"] == [10.0, 50.0, 200.0]
+        assert dur["Counts"] == [50, 30, 20]
+        assert dur["Max"] == 500.0
+        assert dur["Min"] == 1.0
+        assert dur["Count"] == 100
+        assert dur["Sum"] == 5000.0
+
+    def test_body_exception_breakdown(self, otlp_env, endpoint_event):
+        emitter, logs, _ = otlp_env
+        emitter.emit_endpoint_summary(endpoint_event)
+        body = _body(logs)
+        eb = body["exception_breakdown"]
+        assert len(eb) == 1
+        assert eb[0]["count"] == 5
+        assert eb[0]["failure_type"] == "500"
+        assert eb[0]["exceptions"][0]["exception_type"] == "ValueError"
+
+    def test_body_incidents_exemplar(self, otlp_env, endpoint_event):
+        emitter, logs, _ = otlp_env
+        emitter.emit_endpoint_summary(endpoint_event)
+        body = _body(logs)
+        ex = body["incidents_exemplar"]
+        assert len(ex) == 1
+        assert ex[0]["snapshot_id"] == "snap_001"
+        assert ex[0]["trigger_type"] == "exception"
+
+    def test_no_trace_context(self, otlp_env, endpoint_event):
+        emitter, logs, _ = otlp_env
+        emitter.emit_endpoint_summary(endpoint_event)
+        log = _get_log(logs)
+        assert log.log_record.trace_id == 0
+
+
+# ==========================================================================
+# FunctionCall contract (Histogram - direct recording)
+# ==========================================================================
+#
+# PythonServiceEventsMonitor.__exit__ records into the duration Histogram only
+# when the call is sampled. Latency stays clean and the SEH/EMF fallback path
+# remains the source of truth for total/error counts when sampling is below
+# 100%.
+#
+#   - service.function.duration (Histogram)  - sampled calls only (latency)
+
+
+def _get_function_call_metric(metric_reader):
+    """Extract the service.function.duration metric from InMemoryMetricReader."""
+    metrics_data = metric_reader.get_metrics_data()
+    if metrics_data is None:
+        return None, None
+    for resource_metrics in metrics_data.resource_metrics:
+        for scope_metrics in resource_metrics.scope_metrics:
+            for metric in scope_metrics.metrics:
+                if metric.name == "service.function.duration":
+                    return metric, scope_metrics.scope
+    return None, None
+
+
+def _build_call_attrs(
+    function_name,
+    caller=None,
+    function_at_line=None,
+    is_async=False,
+    exception_type=None,
+):
+    """Build the per-call attribute dict for service.function.duration.
+
+    Mirrors record_function_call_metrics in python_monitor_impl. Service
+    identity (service.name, environment, vcs.*, deployment id) lives on the
+    OTel Resource — not on this dict — so consumers correlate via Resource +
+    per-call attrs together.
+
+    `exception_type` is only used to flip ``status`` to ``"error"``; the class
+    name itself is not exposed as a histogram dimension to keep cardinality
+    bounded (it lives on the IncidentSnapshot log signal instead).
+    """
+    attrs = {
+        "Telemetry.Source": "ServiceEvents",
+        "function.name": function_name,
+    }
+    if caller:
+        attrs["aws.service_events.caller"] = caller
+    if function_at_line is not None:
+        attrs["aws.service_events.function_at_line"] = function_at_line
+    if is_async:
+        attrs["aws.service_events.async"] = True
+    if exception_type:
+        attrs["status"] = "error"
+    else:
+        attrs["status"] = "success"
+    return attrs
+
+
+def _record_function_call(
+    histogram,
+    duration_us,
+    *,
+    is_sampled=True,
+    **call_kwargs,
+):
+    """Simulate PythonServiceEventsMonitor.__exit__ recording into the histogram.
+
+    Mirrors record_function_call_metrics in python_monitor_impl: the histogram
+    fires only when the call is sampled.
+    """
+    if histogram is None or not is_sampled:
+        return
+    attrs = _build_call_attrs(**call_kwargs)
+    histogram.record(duration_us, attrs)
+
+
+class TestFunctionCallContract:
+    @pytest.fixture
+    def function_metrics(self, otlp_env):
+        """Create the duration Histogram on the meter, mirroring production
+        wiring in serviceevents_instrumentation.py.
+        """
+        emitter, _, _ = otlp_env
+        emitter._ensure_initialized()
+        meter = emitter._meter_provider.get_meter("serviceevents", "1.0")
+        histogram = meter.create_histogram(
+            "service.function.duration",
+            unit="Microseconds",
+            description="Function call duration",
+        )
+        return histogram
+
+    @pytest.fixture
+    def fc_params(self):
+        """Common parameters for function call recording."""
+        return {
+            "function_name": "mymod.MyClass.process",
+            "function_at_line": 42,
+            "caller": "mymod.handler",
+            "is_async": False,
+        }
+
+    @staticmethod
+    def _expected_success_attrs(fc_params):
+        return {
+            "Telemetry.Source": "ServiceEvents",
+            "function.name": fc_params["function_name"],
+            "aws.service_events.caller": fc_params["caller"],
+            "aws.service_events.function_at_line": fc_params["function_at_line"],
+            "status": "success",
+        }
+
+    def test_sampled_call_records_to_histogram(self, otlp_env, function_metrics, fc_params):
+        """Sampled calls land on the histogram with the full expected attribute
+        set (instrument metadata, scope, count, sum, attributes verified together).
+
+        Covers success and error paths so both branches of the status dimension
+        are validated in one go. Exception class names are intentionally not
+        recorded as a histogram dimension to keep cardinality bounded — they
+        flow through the IncidentSnapshot log signal instead.
+        """
+        _, _, metric_reader = otlp_env
+        histogram = function_metrics
+
+        # 3 successful calls + 1 errored call, all sampled.
+        for _ in range(3):
+            _record_function_call(histogram, 25.0, **fc_params)
+        _record_function_call(histogram, 25.0, exception_type="TypeError", **fc_params)
+
+        # Histogram: instrument metadata + scope.
+        hist_metric, hist_scope = _get_function_call_metric(metric_reader)
+        assert hist_metric is not None, "service.function.duration must be exported"
+        assert hist_metric.name == "service.function.duration"
+        assert hist_metric.unit == "Microseconds"
+        assert hist_scope.name == "serviceevents"
+        assert hist_scope.version == "1.0"
+
+        def _find(metric, *, status):
+            for dp in metric.data.data_points:
+                if dict(dp.attributes).get("status") == status:
+                    return dp
+            raise AssertionError(f"No data point with status={status}")
+
+        # Success: count=3 sum=75 (3 * 25us).
+        hist_success = _find(hist_metric, status="success")
+        expected_success = self._expected_success_attrs(fc_params)
+        assert dict(hist_success.attributes) == expected_success
+        assert hist_success.count == 3
+        assert hist_success.sum == 75.0
+
+        # Error: count=1 sum=25. Same attribute set as success aside from `status`;
+        # exception class name lives on the IncidentSnapshot signal, not here.
+        hist_err = _find(hist_metric, status="error")
+        expected_error = {**expected_success, "status": "error"}
+        assert dict(hist_err.attributes) == expected_error
+        assert "exception.type" not in dict(hist_err.attributes)
+        assert hist_err.count == 1
+        assert hist_err.sum == 25.0
+
+    def test_non_sampled_call_skips_histogram(self, otlp_env, function_metrics, fc_params):
+        """Non-sampled calls must NOT emit zero-duration histogram entries.
+
+        Guards the original duration-pollution bug.
+        """
+        _, _, metric_reader = otlp_env
+        histogram = function_metrics
+
+        # 5 successful + 2 errored, all non-sampled.
+        for _ in range(5):
+            _record_function_call(histogram, 0.0, is_sampled=False, **fc_params)
+        for _ in range(2):
+            _record_function_call(histogram, 0.0, is_sampled=False, exception_type="ValueError", **fc_params)
+
+        # Histogram must have ZERO data points for this function.
+        hist_metric, _ = _get_function_call_metric(metric_reader)
+        if hist_metric is not None:
+            matching = [
+                dp
+                for dp in hist_metric.data.data_points
+                if dict(dp.attributes).get("function.name") == fc_params["function_name"]
+            ]
+            assert len(matching) == 0, "Histogram must not record non-sampled calls (would pollute sum/percentiles)"
+
+    def test_mixed_sampling_histogram_count_equals_sampled_subset(self, otlp_env, function_metrics, fc_params):
+        """Histogram count tracks the sampled subset, not total invocations."""
+        _, _, metric_reader = otlp_env
+        histogram = function_metrics
+
+        for _ in range(3):
+            _record_function_call(histogram, 25.0, is_sampled=True, **fc_params)
+        for _ in range(5):
+            _record_function_call(histogram, 0.0, is_sampled=False, **fc_params)
+
+        hist_metric, _ = _get_function_call_metric(metric_reader)
+        assert hist_metric is not None
+        assert sum(dp.count for dp in hist_metric.data.data_points) == 3
+
+
+class TestIncidentSnapshotContract:
+    @pytest.fixture
+    def snapshot(self):
+        return {
+            "snapshot_id": "snap_contract_001",
+            "trigger_type": "exception",
+            "operation": "POST /api/checkout",
+            "duration_ms": 350.5,
+            "is_partial": False,
+            "method": "POST",
+            "route": "/api/checkout",
+            "exception_info": [
+                {
+                    "exception_type": "PaymentError",
+                    "exception_message": "Card declined",
+                    "stack_trace": "Traceback...",
+                    "call_path": [
+                        {
+                            "function_name": "checkout",
+                            "caller_function_name": "handler",
+                            "duration_ns": 350000000,
+                            "error": True,
+                        },
+                    ],
+                }
+            ],
+            "request_context": {
+                "type": "http",
+                "timestamp": int(time.time() * 1000),
+                "status_code": 500,
+                "custom_context": {"user_id": "u123"},
+            },
+            "telemetry_correlation": {
+                "trace_id": "abcdef0123456789abcdef0123456789",
+                "span_id": "0123456789abcdef",
+            },
+        }
+
+    def test_event_name(self, otlp_env, snapshot):
+        emitter, logs, _ = otlp_env
+        emitter.emit_incident_snapshot(snapshot)
+        assert _attrs(logs)["event.name"] == "aws.service_events.incident_snapshot"
+
+    def test_snapshot_id_attribute(self, otlp_env, snapshot):
+        emitter, logs, _ = otlp_env
+        emitter.emit_incident_snapshot(snapshot)
+        assert _attrs(logs)["aws.service_events.snapshot_id"] == "snap_contract_001"
+
+    def test_trigger_type_attribute(self, otlp_env, snapshot):
+        emitter, logs, _ = otlp_env
+        emitter.emit_incident_snapshot(snapshot)
+        assert _attrs(logs)["aws.service_events.trigger_type"] == "exception"
+
+    def test_operation_attribute(self, otlp_env, snapshot):
+        emitter, logs, _ = otlp_env
+        emitter.emit_incident_snapshot(snapshot)
+        assert _attrs(logs)["aws.service_events.operation"] == "POST /api/checkout"
+
+    def test_duration_ms_attribute(self, otlp_env, snapshot):
+        emitter, logs, _ = otlp_env
+        emitter.emit_incident_snapshot(snapshot)
+        assert _attrs(logs)["aws.service_events.duration_ms"] == 350.5
+
+    def test_http_method_attribute(self, otlp_env, snapshot):
+        emitter, logs, _ = otlp_env
+        emitter.emit_incident_snapshot(snapshot)
+        assert _attrs(logs)["http.request.method"] == "POST"
+
+    def test_url_route_attribute(self, otlp_env, snapshot):
+        emitter, logs, _ = otlp_env
+        emitter.emit_incident_snapshot(snapshot)
+        assert _attrs(logs)["url.route"] == "/api/checkout"
+
+    def test_status_code_attribute(self, otlp_env, snapshot):
+        emitter, logs, _ = otlp_env
+        emitter.emit_incident_snapshot(snapshot)
+        assert _attrs(logs)["http.response.status_code"] == 500
+
+    def test_request_type_attribute(self, otlp_env, snapshot):
+        emitter, logs, _ = otlp_env
+        emitter.emit_incident_snapshot(snapshot)
+        assert _attrs(logs)["aws.service_events.request.type"] == "http"
+
+    def test_body_exception_info(self, otlp_env, snapshot):
+        emitter, logs, _ = otlp_env
+        emitter.emit_incident_snapshot(snapshot)
+        body = _body(logs)
+        assert "exception_info" in body
+        assert body["exception_info"][0]["exception_type"] == "PaymentError"
+        assert body["exception_info"][0]["exception_message"] == "Card declined"
+
+    def test_body_request_context(self, otlp_env, snapshot):
+        emitter, logs, _ = otlp_env
+        emitter.emit_incident_snapshot(snapshot)
+        body = _body(logs)
+        assert "request_context" in body
+        assert body["request_context"]["status_code"] == 500
+
+    def test_trace_context_present(self, otlp_env, snapshot):
+        emitter, logs, _ = otlp_env
+        emitter.emit_incident_snapshot(snapshot)
+        log = _get_log(logs)
+        assert log.log_record.trace_id != 0
+        assert log.log_record.span_id != 0
+        assert log.log_record.trace_flags == 1  # SAMPLED
+
+    def test_trace_id_value(self, otlp_env, snapshot):
+        emitter, logs, _ = otlp_env
+        emitter.emit_incident_snapshot(snapshot)
+        log = _get_log(logs)
+        expected = int("abcdef0123456789abcdef0123456789", 16)
+        assert log.log_record.trace_id == expected
+
+    def test_no_trace_context_when_missing(self, otlp_env, snapshot):
+        emitter, logs, _ = otlp_env
+        snapshot["telemetry_correlation"] = {}
+        emitter.emit_incident_snapshot(snapshot)
+        log = _get_log(logs)
+        assert log.log_record.trace_id == 0
+        assert log.log_record.span_id == 0
+        assert log.log_record.trace_flags == 0
+
+
+# ==========================================================================
+# EndpointErrorMetrics contract
+# ==========================================================================
+
+
+class TestEndpointErrorMetricsContract:
+    def test_counter_name_and_unit(self, otlp_env):
+        emitter, _, metrics = otlp_env
+        emitter.emit_endpoint_error_metrics(
+            [
+                EndpointErrorMetric(
+                    environment="t",
+                    service_name="s",
+                    operation="GET /a",
+                    instance_id="h",
+                    pid=1,
+                    exception="Err",
+                    count=1,
+                ),
+            ]
+        )
+        data = metrics.get_metrics_data()
+        found = False
+        for rm in data.resource_metrics:
+            for sm in rm.scope_metrics:
+                for m in sm.metrics:
+                    if m.name == "count":
+                        found = True
+                        assert m.unit == "Count"
+        assert found
+
+    def test_dimensions_match_spec(self, otlp_env):
+        """Counter data points must have service_name, environment, operation, exception."""
+        emitter, _, metrics = otlp_env
+        emitter.emit_endpoint_error_metrics(
+            [
+                EndpointErrorMetric(
+                    environment="prod",
+                    service_name="my-svc",
+                    operation="POST /pay",
+                    instance_id="h",
+                    pid=1,
+                    exception="PaymentError",
+                    count=7,
+                ),
+            ]
+        )
+        data = metrics.get_metrics_data()
+        for rm in data.resource_metrics:
+            for sm in rm.scope_metrics:
+                for m in sm.metrics:
+                    if m.name == "count":
+                        points = list(m.data.data_points)
+                        assert len(points) == 1
+                        attrs = dict(points[0].attributes)
+                        assert attrs["service_name"] == "my-svc"
+                        assert attrs["environment"] == "prod"
+                        assert attrs["operation"] == "POST /pay"
+                        assert attrs["exception"] == "PaymentError"
+                        assert points[0].value == 7
+
+    def test_multiple_error_types(self, otlp_env):
+        emitter, _, metrics = otlp_env
+        emitter.emit_endpoint_error_metrics(
+            [
+                EndpointErrorMetric(
+                    environment="t",
+                    service_name="s",
+                    operation="GET /a",
+                    instance_id="h",
+                    pid=1,
+                    exception="TypeError",
+                    count=3,
+                ),
+                EndpointErrorMetric(
+                    environment="t",
+                    service_name="s",
+                    operation="GET /a",
+                    instance_id="h",
+                    pid=1,
+                    exception="ValueError",
+                    count=5,
+                ),
+            ]
+        )
+        data = metrics.get_metrics_data()
+        total = 0
+        for rm in data.resource_metrics:
+            for sm in rm.scope_metrics:
+                for m in sm.metrics:
+                    if m.name == "count":
+                        total += len(list(m.data.data_points))
+        assert total == 2
+
+    def test_instrumentation_scope(self, otlp_env):
+        emitter, _, metrics = otlp_env
+        emitter.emit_endpoint_error_metrics(
+            [
+                EndpointErrorMetric(
+                    environment="t",
+                    service_name="s",
+                    operation="GET /a",
+                    instance_id="h",
+                    pid=1,
+                    exception="Err",
+                    count=1,
+                ),
+            ]
+        )
+        data = metrics.get_metrics_data()
+        for rm in data.resource_metrics:
+            for sm in rm.scope_metrics:
+                if sm.metrics and any(m.name == "count" for m in sm.metrics):
+                    assert sm.scope.name == "serviceevents"
+                    assert sm.scope.version == "1.0"
+
+    def test_zero_count_skipped(self, otlp_env):
+        """Zero-count metrics should not add counter value (emitter skips add)."""
+        emitter, _, metrics = otlp_env
+        emitter.emit_endpoint_error_metrics(
+            [
+                EndpointErrorMetric(
+                    environment="t",
+                    service_name="s",
+                    operation="GET /a",
+                    instance_id="h",
+                    pid=1,
+                    exception="Err",
+                    count=0,
+                ),
+            ]
+        )
+        data = metrics.get_metrics_data()
+        if data is None:
+            return  # No metrics at all — pass
+        total_value = 0
+        for rm in data.resource_metrics:
+            for sm in rm.scope_metrics:
+                for m in sm.metrics:
+                    for dp in m.data.data_points:
+                        total_value += dp.value
+        assert total_value == 0, "Zero-count metrics should not add any counter value"

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/exporter/test_otlp_emitter.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/exporter/test_otlp_emitter.py
@@ -1,0 +1,628 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ServiceEventsOtlpEmitter."""
+
+import time
+from unittest.mock import MagicMock
+
+from amazon.opentelemetry.distro.serviceevents.exporter.otlp_emitter import ServiceEventsOtlpEmitter
+from amazon.opentelemetry.distro.serviceevents.models import DeploymentEventTelemetry
+from amazon.opentelemetry.distro.serviceevents.models.deployment_telemetry import DeploymentContext
+from amazon.opentelemetry.distro.serviceevents.models.endpoint_telemetry import (
+    EndpointErrorMetric,
+    EndpointMetricEvent,
+    ErrorBreakdownEntry,
+    ErrorDetail,
+    IncidentExemplar,
+)
+from amazon.opentelemetry.distro.serviceevents.models.function_telemetry import DurationMetrics
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs.export import InMemoryLogExporter, SimpleLogRecordProcessor
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+from opentelemetry.sdk.resources import Resource
+
+
+def _make_emitter():
+    """Create emitter with in-memory exporters for testing."""
+    resource = Resource.create({"service.name": "test-svc"})
+    log_exporter = InMemoryLogExporter()
+    lp = LoggerProvider(resource=resource)
+    lp.add_log_record_processor(SimpleLogRecordProcessor(log_exporter))
+    metric_reader = InMemoryMetricReader()
+    mp = MeterProvider(resource=resource, metric_readers=[metric_reader])
+    emitter = ServiceEventsOtlpEmitter(lp, mp, "deploy-1", "sha-abc", "https://github.com/test")
+    return emitter, log_exporter, metric_reader, lp, mp
+
+
+class TestDeploymentEvent:
+    def test_event_name(self):
+        emitter, log_exporter, _, lp, mp = _make_emitter()
+        event = DeploymentEventTelemetry.create(service_name="test", environment="prod")
+        emitter.emit_deployment_event(event)
+        logs = log_exporter.get_finished_logs()
+        assert len(logs) == 1
+        attrs = dict(logs[0].log_record.attributes)
+        assert attrs["event.name"] == "aws.service_events.deployment_event"
+
+    def test_no_body(self):
+        emitter, log_exporter, _, lp, mp = _make_emitter()
+        event = DeploymentEventTelemetry.create(service_name="test", environment="prod")
+        emitter.emit_deployment_event(event)
+        body = log_exporter.get_finished_logs()[0].log_record.body
+        assert body == "" or body is None
+
+    def test_deployment_context_attributes(self):
+        emitter, log_exporter, _, lp, mp = _make_emitter()
+        event = DeploymentEventTelemetry.create(service_name="test", environment="prod")
+        # Populate a real context so the attributes are genuinely present (a bare
+        # create() with no env yields the "unknown" sentinel, which is now omitted).
+        event.deployment_context = DeploymentContext(git_commit_sha="abc123", deployment_id="99")
+        emitter.emit_deployment_event(event)
+        attrs = dict(log_exporter.get_finished_logs()[0].log_record.attributes)
+        # DeploymentContext attributes should be present
+        assert "aws.service_events.deployment.id" in attrs or "vcs.ref.head.revision" in attrs
+
+    def test_instrumentation_scope(self):
+        emitter, log_exporter, _, lp, mp = _make_emitter()
+        event = DeploymentEventTelemetry.create(service_name="test", environment="prod")
+        emitter.emit_deployment_event(event)
+        log = log_exporter.get_finished_logs()[0]
+        assert log.instrumentation_scope.name == "serviceevents"
+        assert log.instrumentation_scope.version == "1.0"
+
+    def test_unset_context_fields_omitted(self):
+        """DeploymentContext fields left unset (empty) must NOT be emitted.
+
+        Unset fields default to empty, so each guarded attribute is omitted rather
+        than shipping a placeholder onto the wire.
+        """
+        emitter, log_exporter, _, lp, mp = _make_emitter()
+        event = DeploymentEventTelemetry.create(service_name="test", environment="prod")
+        event.deployment_context = DeploymentContext()  # all fields empty (unset)
+        emitter.emit_deployment_event(event)
+        attrs = dict(log_exporter.get_finished_logs()[0].log_record.attributes)
+        for key in (
+            "vcs.ref.head.revision",
+            "vcs.repository.url.full",
+            "aws.service_events.deployment.id",
+            "aws.service_events.deployment.url",
+            "aws.service_events.deployment.timestamp",
+        ):
+            assert key not in attrs, f"{key} should be omitted when its context value is unset"
+        # No placeholder sentinel should leak onto the wire either.
+        assert "unknown" not in attrs.values()
+        # The trigger attribute is still emitted normally.
+        assert attrs["aws.service_events.deployment.trigger"] == "periodic"
+
+    def test_real_context_fields_emitted(self):
+        """Populated DeploymentContext values are emitted as attributes."""
+        emitter, log_exporter, _, lp, mp = _make_emitter()
+        event = DeploymentEventTelemetry.create(service_name="test", environment="prod")
+        event.deployment_context = DeploymentContext(
+            git_repo_url="https://github.com/org/repo",
+            git_commit_sha="abc123",
+            deployment_url="https://github.com/org/repo/actions/runs/99",
+            deployment_timestamp="2026-02-04T00:00:00Z",
+            deployment_id="99",
+        )
+        emitter.emit_deployment_event(event)
+        attrs = dict(log_exporter.get_finished_logs()[0].log_record.attributes)
+        assert attrs["vcs.ref.head.revision"] == "abc123"
+        assert attrs["vcs.repository.url.full"] == "https://github.com/org/repo"
+        assert attrs["aws.service_events.deployment.id"] == "99"
+        assert attrs["aws.service_events.deployment.url"] == "https://github.com/org/repo/actions/runs/99"
+        assert attrs["aws.service_events.deployment.timestamp"] == "2026-02-04T00:00:00Z"
+
+
+class TestEndpointSummary:
+    def _make_event(self):
+        return EndpointMetricEvent(
+            environment="test",
+            service_name="test-svc",
+            sdk_version="0.14",
+            instance_id="localhost",
+            operation="GET /success",
+            method="GET",
+            route="/success",
+            pid=1234,
+            timestamp="2026-01-01T00:00:00Z",
+            count=10,
+            faults=2,
+            errors=1,
+            incident_count=0,
+            duration=DurationMetrics(values=[100.0, 200.0], counts=[5, 5], max=250.0, min=50.0, count=10, sum=1500.0),
+        )
+
+    def test_event_name(self):
+        emitter, log_exporter, _, lp, mp = _make_emitter()
+        emitter.emit_endpoint_summary(self._make_event())
+        attrs = dict(log_exporter.get_finished_logs()[0].log_record.attributes)
+        assert attrs["event.name"] == "aws.service_events.endpoint_summary"
+
+    def test_attributes(self):
+        emitter, log_exporter, _, lp, mp = _make_emitter()
+        emitter.emit_endpoint_summary(self._make_event())
+        attrs = dict(log_exporter.get_finished_logs()[0].log_record.attributes)
+        assert attrs["http.request.method"] == "GET"
+        assert attrs["url.route"] == "/success"
+        assert attrs["aws.service_events.operation"] == "GET /success"
+        assert attrs["aws.service_events.request.count"] == 10
+        assert attrs["aws.service_events.request.faults"] == 2
+        assert attrs["aws.service_events.request.errors"] == 1
+
+    def test_body_has_duration(self):
+        emitter, log_exporter, _, lp, mp = _make_emitter()
+        emitter.emit_endpoint_summary(self._make_event())
+        body = log_exporter.get_finished_logs()[0].log_record.body
+        assert isinstance(body, dict)
+        assert "duration" in body
+        dur = body["duration"]
+        assert dur["Values"] == [100.0, 200.0]
+        assert dur["Counts"] == [5, 5]
+        assert dur["Max"] == 250.0
+        assert dur["Count"] == 10
+
+    def test_body_has_exception_breakdown(self):
+        emitter, log_exporter, _, lp, mp = _make_emitter()
+        emitter.emit_endpoint_summary(self._make_event())
+        body = log_exporter.get_finished_logs()[0].log_record.body
+        assert "exception_breakdown" in body
+        assert isinstance(body["exception_breakdown"], list)
+
+    def test_body_has_incidents_exemplar(self):
+        emitter, log_exporter, _, lp, mp = _make_emitter()
+        emitter.emit_endpoint_summary(self._make_event())
+        body = log_exporter.get_finished_logs()[0].log_record.body
+        assert "incidents_exemplar" in body
+
+    def test_vcs_attributes(self):
+        emitter, log_exporter, _, lp, mp = _make_emitter()
+        emitter.emit_endpoint_summary(self._make_event())
+        attrs = dict(log_exporter.get_finished_logs()[0].log_record.attributes)
+        assert attrs["vcs.ref.head.revision"] == "sha-abc"
+        assert attrs["vcs.repository.url.full"] == "https://github.com/test"
+        assert attrs["aws.service_events.deployment.id"] == "deploy-1"
+
+
+class TestIncidentSnapshot:
+    def _make_snapshot(self):
+        return {
+            "snapshot_id": "snap_001",
+            "trigger_type": "exception",
+            "operation": "GET /error",
+            "duration_ms": 150.0,
+            "is_partial": False,
+            "method": "GET",
+            "route": "/error",
+            "exception_info": [{"exception_type": "RuntimeError", "exception_message": "fail"}],
+            "request_context": {
+                "type": "http",
+                "timestamp": int(time.time() * 1000),
+                "status_code": 500,
+            },
+            "telemetry_correlation": {
+                "trace_id": "0af7651916cd43dd8448eb211c80319c",
+                "span_id": "b7ad6b7169203331",
+            },
+        }
+
+    def test_event_name(self):
+        emitter, log_exporter, _, lp, mp = _make_emitter()
+        emitter.emit_incident_snapshot(self._make_snapshot())
+        attrs = dict(log_exporter.get_finished_logs()[0].log_record.attributes)
+        assert attrs["event.name"] == "aws.service_events.incident_snapshot"
+
+    def test_attributes(self):
+        emitter, log_exporter, _, lp, mp = _make_emitter()
+        emitter.emit_incident_snapshot(self._make_snapshot())
+        attrs = dict(log_exporter.get_finished_logs()[0].log_record.attributes)
+        assert attrs["aws.service_events.snapshot_id"] == "snap_001"
+        assert attrs["aws.service_events.trigger_type"] == "exception"
+        assert attrs["aws.service_events.operation"] == "GET /error"
+        assert attrs["http.request.method"] == "GET"
+        assert attrs["url.route"] == "/error"
+        assert attrs["http.response.status_code"] == 500
+
+    def test_body_has_exception_info(self):
+        emitter, log_exporter, _, lp, mp = _make_emitter()
+        emitter.emit_incident_snapshot(self._make_snapshot())
+        body = log_exporter.get_finished_logs()[0].log_record.body
+        assert isinstance(body, dict)
+        assert "exception_info" in body
+        assert body["exception_info"][0]["exception_type"] == "RuntimeError"
+
+    def test_body_has_request_context(self):
+        emitter, log_exporter, _, lp, mp = _make_emitter()
+        emitter.emit_incident_snapshot(self._make_snapshot())
+        body = log_exporter.get_finished_logs()[0].log_record.body
+        assert "request_context" in body
+        assert body["request_context"]["status_code"] == 500
+
+    def test_trace_context(self):
+        emitter, log_exporter, _, lp, mp = _make_emitter()
+        emitter.emit_incident_snapshot(self._make_snapshot())
+        log = log_exporter.get_finished_logs()[0]
+        assert log.log_record.trace_id != 0
+        assert log.log_record.span_id != 0
+        assert log.log_record.trace_flags == 1  # SAMPLED
+
+    def test_no_trace_context_when_missing(self):
+        emitter, log_exporter, _, lp, mp = _make_emitter()
+        snapshot = self._make_snapshot()
+        snapshot["telemetry_correlation"] = {}
+        emitter.emit_incident_snapshot(snapshot)
+        log = log_exporter.get_finished_logs()[0]
+        assert log.log_record.trace_id == 0
+        assert log.log_record.span_id == 0
+
+
+class TestEndpointErrorMetrics:
+    def test_counter_emitted(self):
+        emitter, _, metric_reader, lp, mp = _make_emitter()
+        metrics = [
+            EndpointErrorMetric(
+                environment="test",
+                service_name="test-svc",
+                operation="GET /error",
+                instance_id="localhost",
+                pid=1234,
+                exception="RuntimeError",
+                count=5,
+            ),
+        ]
+        emitter.emit_endpoint_error_metrics(metrics)
+        # Force metric collection
+        data = metric_reader.get_metrics_data()
+        assert data is not None
+        # Find the counter
+        found = False
+        for rm in data.resource_metrics:
+            for sm in rm.scope_metrics:
+                for m in sm.metrics:
+                    if m.name == "count":
+                        found = True
+                        assert m.unit == "Count"
+                        points = list(m.data.data_points)
+                        assert len(points) == 1
+                        assert points[0].value == 5
+                        attrs = dict(points[0].attributes)
+                        assert attrs["Telemetry.Source"] == "ServiceEvents"
+                        assert attrs["service_name"] == "test-svc"
+                        assert attrs["environment"] == "test"
+                        assert attrs["operation"] == "GET /error"
+                        assert attrs["exception"] == "RuntimeError"
+        assert found, "count metric not found"
+
+    def test_multiple_metrics(self):
+        emitter, _, metric_reader, lp, mp = _make_emitter()
+        metrics = [
+            EndpointErrorMetric(
+                environment="test",
+                service_name="svc",
+                operation="GET /a",
+                instance_id="h",
+                pid=1,
+                exception="TypeError",
+                count=2,
+            ),
+            EndpointErrorMetric(
+                environment="test",
+                service_name="svc",
+                operation="GET /b",
+                instance_id="h",
+                pid=1,
+                exception="ValueError",
+                count=7,
+            ),
+        ]
+        emitter.emit_endpoint_error_metrics(metrics)
+        data = metric_reader.get_metrics_data()
+        total_points = 0
+        for rm in data.resource_metrics:
+            for sm in rm.scope_metrics:
+                for m in sm.metrics:
+                    if m.name == "count":
+                        total_points += len(list(m.data.data_points))
+        assert total_points == 2
+
+
+class TestEdgeCases:
+    def test_emitter_not_initialized_no_crash(self):
+        """Emitter with None providers should not crash on emit."""
+        emitter = ServiceEventsOtlpEmitter(None, None)
+        # Should not raise
+        emitter.emit_deployment_event(DeploymentEventTelemetry.create())
+
+    def test_vcs_attributes_omitted_when_empty_on_non_deployment(self):
+        """VCS/deployment attributes omitted on EndpointSummary when emitter has empty strings."""
+        emitter, log_exporter, _, lp, mp = _make_emitter()
+        # Create emitter with empty VCS fields
+        emitter_empty = ServiceEventsOtlpEmitter(lp, mp, "", "", "")
+        event = EndpointMetricEvent(
+            environment="t",
+            service_name="s",
+            sdk_version="0.14",
+            instance_id="h",
+            operation="GET /x",
+            method="GET",
+            route="/x",
+            pid=1,
+            timestamp="2026-01-01T00:00:00Z",
+            count=1,
+            faults=0,
+            errors=0,
+            incident_count=0,
+            duration=DurationMetrics(values=[1.0], counts=[1], max=1.0, min=1.0, count=1, sum=1.0),
+        )
+        emitter_empty.emit_endpoint_summary(event)
+        attrs = dict(log_exporter.get_finished_logs()[0].log_record.attributes)
+        assert "vcs.ref.head.revision" not in attrs
+        assert "vcs.repository.url.full" not in attrs
+        assert "aws.service_events.deployment.id" not in attrs
+
+    def test_shutdown_safe(self):
+        """Shutdown should not crash even when called multiple times."""
+        emitter, _, _, lp, mp = _make_emitter()
+        emitter.shutdown()
+        emitter.shutdown()  # Should not raise
+
+
+class TestInitialization:
+    def test_initialization_is_idempotent(self):
+        """A second _ensure_initialized call returns early without re-creating instruments."""
+        emitter, log_exporter, _, lp, mp = _make_emitter()
+        emitter._ensure_initialized()
+        first_logger = emitter._otel_logger
+        first_counter = emitter._error_counter
+        emitter._ensure_initialized()  # second call hits the early-return guard
+        assert emitter._otel_logger is first_logger
+        assert emitter._error_counter is first_counter
+
+    def test_init_failure_is_swallowed(self):
+        """A provider that raises during get_logger must not crash and leaves logger unset."""
+        lp = MagicMock()
+        lp.get_logger.side_effect = RuntimeError("boom")
+        mp = MagicMock()
+        emitter = ServiceEventsOtlpEmitter(lp, mp)
+        emitter._ensure_initialized()  # should swallow the exception
+        assert emitter._initialized is False
+        assert emitter._otel_logger is None
+
+
+class TestEmitGuards:
+    def test_emit_endpoint_summary_no_logger_returns(self):
+        """emit_endpoint_summary returns silently when logger init fails."""
+        lp = MagicMock()
+        lp.get_logger.side_effect = RuntimeError("boom")
+        emitter = ServiceEventsOtlpEmitter(lp, MagicMock())
+        event = EndpointMetricEvent(
+            environment="t",
+            service_name="s",
+            sdk_version="0.14",
+            instance_id="h",
+            operation="GET /x",
+            method="GET",
+            route="/x",
+            pid=1,
+            timestamp="2026-01-01T00:00:00Z",
+            count=1,
+        )
+        emitter.emit_endpoint_summary(event)  # should not raise
+
+    def test_emit_incident_snapshot_no_logger_returns(self):
+        """emit_incident_snapshot returns silently when logger init fails."""
+        lp = MagicMock()
+        lp.get_logger.side_effect = RuntimeError("boom")
+        emitter = ServiceEventsOtlpEmitter(lp, MagicMock())
+        emitter.emit_incident_snapshot({"snapshot_id": "x"})  # should not raise
+
+    def test_emit_error_metrics_no_counter_returns(self):
+        """emit_endpoint_error_metrics returns silently when counter init fails."""
+        mp = MagicMock()
+        mp.get_meter.side_effect = RuntimeError("boom")
+        emitter = ServiceEventsOtlpEmitter(MagicMock(), mp)
+        emitter.emit_endpoint_error_metrics(
+            [
+                EndpointErrorMetric(
+                    environment="t",
+                    service_name="s",
+                    operation="GET /x",
+                    instance_id="h",
+                    pid=1,
+                    exception="E",
+                    count=1,
+                )
+            ]
+        )  # should not raise
+
+
+class TestIncidentSnapshotInferredHttp:
+    def test_method_route_inferred_from_operation(self):
+        """When method is absent, http method/route are parsed from operation."""
+        emitter, log_exporter, _, lp, mp = _make_emitter()
+        snapshot = {
+            "snapshot_id": "snap_002",
+            "trigger_type": "exception",
+            "operation": "POST /orders",
+            "telemetry_correlation": {},
+        }
+        emitter.emit_incident_snapshot(snapshot)
+        attrs = dict(log_exporter.get_finished_logs()[0].log_record.attributes)
+        assert attrs["http.request.method"] == "POST"
+        assert attrs["url.route"] == "/orders"
+
+    def test_empty_operation_yields_empty_http_attrs(self):
+        """An empty operation with no method leaves http method/route empty."""
+        emitter, log_exporter, _, lp, mp = _make_emitter()
+        snapshot = {
+            "snapshot_id": "snap_003",
+            "trigger_type": "latency",
+            "operation": "",
+            "telemetry_correlation": {},
+        }
+        emitter.emit_incident_snapshot(snapshot)
+        attrs = dict(log_exporter.get_finished_logs()[0].log_record.attributes)
+        assert attrs["http.request.method"] == ""
+        assert attrs["url.route"] == ""
+
+
+class TestDeploymentFallback:
+    def test_no_context_falls_back_to_emitter_config(self):
+        """With no deployment_context, emitter-level VCS/deploy config is used."""
+        emitter, log_exporter, _, lp, mp = _make_emitter()
+        event = DeploymentEventTelemetry.create(service_name="test", environment="prod")
+        event.deployment_context = None  # force the fallback branch
+        emitter.emit_deployment_event(event)
+        attrs = dict(log_exporter.get_finished_logs()[0].log_record.attributes)
+        assert attrs["vcs.ref.head.revision"] == "sha-abc"
+        assert attrs["vcs.repository.url.full"] == "https://github.com/test"
+        assert attrs["aws.service_events.deployment.id"] == "deploy-1"
+
+
+class TestErrorMetricsFiltering:
+    def test_non_positive_counts_are_skipped(self):
+        """Metrics with count <= 0 emit no data points."""
+        emitter, _, metric_reader, lp, mp = _make_emitter()
+        metrics = [
+            EndpointErrorMetric(
+                environment="t",
+                service_name="s",
+                operation="GET /a",
+                instance_id="h",
+                pid=1,
+                exception="E",
+                count=0,
+            ),
+            EndpointErrorMetric(
+                environment="t",
+                service_name="s",
+                operation="GET /b",
+                instance_id="h",
+                pid=1,
+                exception="E",
+                count=-3,
+            ),
+        ]
+        emitter.emit_endpoint_error_metrics(metrics)
+        data = metric_reader.get_metrics_data()
+        total_points = 0
+        # No positive counts means the counter never records, so collection yields no data.
+        for rm in getattr(data, "resource_metrics", []) or []:
+            for sm in rm.scope_metrics:
+                for m in sm.metrics:
+                    if m.name == "count":
+                        total_points += len(list(m.data.data_points))
+        assert total_points == 0
+
+
+class TestShutdownErrorHandling:
+    def test_logger_provider_flush_error_swallowed(self):
+        """A logger provider that raises on flush must not crash shutdown."""
+        lp = MagicMock()
+        lp.force_flush.side_effect = RuntimeError("flush boom")
+        mp = MagicMock()
+        emitter = ServiceEventsOtlpEmitter(lp, mp)
+        emitter.shutdown()  # should not raise
+        mp.shutdown.assert_called_once()
+
+    def test_meter_provider_shutdown_error_swallowed(self):
+        """A meter provider that raises on shutdown must not crash shutdown."""
+        lp = MagicMock()
+        mp = MagicMock()
+        mp.shutdown.side_effect = RuntimeError("shutdown boom")
+        emitter = ServiceEventsOtlpEmitter(lp, mp)
+        emitter.shutdown()  # should not raise
+        lp.shutdown.assert_called_once()
+
+
+class TestEmitLogErrorHandling:
+    def test_invalid_trace_context_is_ignored(self):
+        """Non-hex trace ids fall through the ValueError guard, leaving ids at 0."""
+        emitter, log_exporter, _, lp, mp = _make_emitter()
+        snapshot = {
+            "snapshot_id": "snap_004",
+            "trigger_type": "exception",
+            "operation": "GET /x",
+            "telemetry_correlation": {"trace_id": "not-hex", "span_id": "also-bad"},
+        }
+        emitter.emit_incident_snapshot(snapshot)
+        log = log_exporter.get_finished_logs()[0]
+        assert log.log_record.trace_id == 0
+        assert log.log_record.span_id == 0
+        assert log.log_record.trace_flags == 0
+
+    def test_emit_failure_is_swallowed(self):
+        """An exception from the underlying logger.emit must not propagate."""
+        emitter, _, _, lp, mp = _make_emitter()
+        emitter._ensure_initialized()
+        emitter._otel_logger = MagicMock()
+        emitter._otel_logger.emit.side_effect = RuntimeError("emit boom")
+        event = DeploymentEventTelemetry.create(service_name="test", environment="prod")
+        emitter.emit_deployment_event(event)  # should not raise
+
+
+class TestBodyConversionHelpers:
+    def test_error_breakdown_converted_to_body(self):
+        """Populated error_breakdown is rendered into the emitted body."""
+        emitter, log_exporter, _, lp, mp = _make_emitter()
+        event = EndpointMetricEvent(
+            environment="t",
+            service_name="s",
+            sdk_version="0.14",
+            instance_id="h",
+            operation="GET /x",
+            method="GET",
+            route="/x",
+            pid=1,
+            timestamp="2026-01-01T00:00:00Z",
+            count=3,
+            error_breakdown=[
+                ErrorBreakdownEntry(
+                    errors=[ErrorDetail(error_type="ValueError", function_name="mod.func")],
+                    count=2,
+                    failure_type="500",
+                ),
+                ErrorBreakdownEntry(errors=[], count=1, failure_type="404"),
+            ],
+        )
+        emitter.emit_endpoint_summary(event)
+        body = log_exporter.get_finished_logs()[0].log_record.body
+        breakdown = body["exception_breakdown"]
+        assert breakdown[0]["count"] == 2
+        assert breakdown[0]["failure_type"] == "500"
+        assert breakdown[0]["exceptions"][0]["exception_type"] == "ValueError"
+        assert breakdown[0]["exceptions"][0]["function_name"] == "mod.func"
+        # Entry with no errors omits the exceptions key.
+        assert "exceptions" not in breakdown[1]
+
+    def test_incidents_exemplar_converted_to_body(self):
+        """Populated incidents_exemplar is rendered into the emitted body."""
+        emitter, log_exporter, _, lp, mp = _make_emitter()
+        event = EndpointMetricEvent(
+            environment="t",
+            service_name="s",
+            sdk_version="0.14",
+            instance_id="h",
+            operation="GET /x",
+            method="GET",
+            route="/x",
+            pid=1,
+            timestamp="2026-01-01T00:00:00Z",
+            count=1,
+            incidents_exemplar=[
+                IncidentExemplar(
+                    snapshot_id="snap_xyz",
+                    trigger_type="exception",
+                    severity="critical",
+                    timestamp=1706745600000,
+                ),
+            ],
+        )
+        emitter.emit_endpoint_summary(event)
+        body = log_exporter.get_finished_logs()[0].log_record.body
+        exemplars = body["incidents_exemplar"]
+        assert exemplars[0]["snapshot_id"] == "snap_xyz"
+        assert exemplars[0]["trigger_type"] == "exception"
+        assert exemplars[0]["timestamp"] == 1706745600000

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/instrumentation/test_django_instrumentation.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/instrumentation/test_django_instrumentation.py
@@ -207,9 +207,10 @@ class TestInstallDjangoHooks(TestCase):
         # load_middleware should have been replaced
         self.assertIsNot(FakeBaseHandler.load_middleware, original_load)
 
-    def test_instrumented_load_middleware_injects_middleware(self):
-        """The wrapped load_middleware prepends the middleware to settings.MIDDLEWARE before building once."""
+    def test_instrumented_load_middleware_injects_for_build_then_restores(self):
+        """SE middleware is at the front DURING the build, and settings.MIDDLEWARE is restored after."""
         call_count = {"n": 0}
+        middleware_during_build = {"value": None}
 
         middleware_path = (
             "amazon.opentelemetry.distro.serviceevents.instrumentation."
@@ -219,8 +220,9 @@ class TestInstallDjangoHooks(TestCase):
         class FakeBaseHandler:
             def load_middleware(self, *args, **kwargs):
                 call_count["n"] += 1
-                # Stack must be built only after SE middleware is already injected, so
-                # every middleware is instantiated exactly once.
+                # Snapshot what the stack build sees: SE middleware must be present and
+                # outermost so its process_view/process_exception hooks get registered.
+                middleware_during_build["value"] = list(fake_settings.MIDDLEWARE)
                 assert fake_settings.MIDDLEWARE[0] == middleware_path
 
         mock_django_handler = MagicMock()
@@ -240,10 +242,13 @@ class TestInstallDjangoHooks(TestCase):
             # Drive the instrumented load_middleware on an instance.
             FakeBaseHandler().load_middleware()
 
-        # Our middleware was prepended to the front of MIDDLEWARE.
-        self.assertEqual(fake_settings.MIDDLEWARE[0], middleware_path)
-        # Original load_middleware called exactly once: the SE middleware is injected before
-        # the single build, so the stack (and every middleware) is built only once on first init.
+        # During the build the stack saw SE middleware prepended (outermost).
+        self.assertEqual(middleware_during_build["value"][0], middleware_path)
+        # After the build the customer's MIDDLEWARE is restored unchanged — no persistent
+        # global side effect (the chain was already materialized during the build).
+        self.assertEqual(fake_settings.MIDDLEWARE, ["django.middleware.common.CommonMiddleware"])
+        # Original load_middleware called exactly once: SE middleware is injected before the
+        # single build, so the stack (and every middleware) is built only once on first init.
         self.assertEqual(call_count["n"], 1)
 
     def test_instrumented_load_middleware_skips_when_already_present(self):

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/instrumentation/test_django_instrumentation.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/instrumentation/test_django_instrumentation.py
@@ -1,0 +1,816 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest import TestCase
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import amazon.opentelemetry.distro.serviceevents.instrumentation.django_instrumentation as django_mod
+from amazon.opentelemetry.distro.serviceevents.instrumentation.django_instrumentation import (
+    ServiceEventsDjangoMiddleware,
+    _finalize_request,
+    _get_endpoint_name,
+    _get_request_body,
+    _get_route_pattern,
+    install_django_hooks,
+)
+from amazon.opentelemetry.distro.serviceevents.python_monitor import _ServiceEventsMonitorState
+
+
+class TestGetRoutePattern(TestCase):
+    """Tests for _get_route_pattern."""
+
+    def test_get_route_pattern_from_resolver_match(self):
+        """resolver_match.route is returned when available."""
+        request = MagicMock()
+        request.resolver_match = MagicMock()
+        request.resolver_match.route = "users/<int:id>"
+        result = _get_route_pattern(request)
+        self.assertEqual(result, "/users/<int:id>")
+
+    def test_get_route_pattern_from_path_info(self):
+        """Falls back to path_info when resolver_match is None."""
+        request = MagicMock()
+        request.resolver_match = None
+        request.path_info = "/api/users/42"
+        result = _get_route_pattern(request)
+        self.assertEqual(result, "/api/users/42")
+
+    def test_get_route_pattern_from_path(self):
+        """Falls back to path when both resolver_match and path_info are unavailable."""
+        request = MagicMock()
+        request.resolver_match = None
+        request.path_info = None
+        request.path = "/api/users/42"
+        result = _get_route_pattern(request)
+        self.assertEqual(result, "/api/users/42")
+
+    def test_get_route_pattern_adds_leading_slash(self):
+        """Leading slash is added if route doesn't start with one."""
+        request = MagicMock()
+        request.resolver_match = MagicMock()
+        request.resolver_match.route = "api/orders"
+        result = _get_route_pattern(request)
+        self.assertEqual(result, "/api/orders")
+
+
+class TestGetRequestBody(TestCase):
+    """Tests for _get_request_body."""
+
+    def test_get_request_body_json(self):
+        """Returns parsed JSON when request.body contains valid JSON."""
+        request = MagicMock()
+        request.body = b'{"key": "value"}'
+        request.content_type = "application/json"
+        result = _get_request_body(request)
+        self.assertEqual(result, {"key": "value"})
+
+    def test_get_request_body_form(self):
+        """Returns form dict when JSON parsing fails but form data exists."""
+        request = MagicMock()
+        # Make body raise on JSON parse
+        request.body = b"not-json"
+        request.content_type = "application/x-www-form-urlencoded"
+        request.POST = MagicMock()
+        request.POST.dict.return_value = {"field": "data"}
+        # Ensure JSON path fails
+        with patch("json.loads", side_effect=ValueError("not json")):
+            result = _get_request_body(request)
+        self.assertEqual(result, {"field": "data"})
+
+    def test_get_request_body_raw(self):
+        """Returns raw body decoded as string when JSON and form fail."""
+        request = MagicMock()
+        request.body = b"raw body content"
+        request.content_type = "text/plain"
+        request.POST = MagicMock()
+        request.POST.dict.side_effect = Exception("no form")
+        # Ensure JSON path fails
+        with patch("json.loads", side_effect=ValueError("not json")):
+            result = _get_request_body(request)
+        self.assertEqual(result, "raw body content")
+
+    def test_get_request_body_json_parse_error_falls_through(self):
+        """A JSON content-type whose body is invalid JSON swallows the error and falls through."""
+        request = MagicMock()
+        # content_type contains "json" so the JSON branch runs, but the body is not valid JSON.
+        request.content_type = "application/json"
+        request.body = b"{not valid json"
+        request.POST = MagicMock()
+        request.POST.dict.return_value = {"field": "data"}
+        result = _get_request_body(request)
+        # JSON parse raises -> caught -> form data returned instead.
+        self.assertEqual(result, {"field": "data"})
+
+    def test_get_request_body_json_none_value_falls_through(self):
+        """JSON parsing to None skips the JSON return and falls through to later branches."""
+        request = MagicMock()
+        request.content_type = "application/json"
+        # Valid JSON that decodes to None: the `if body is not None` guard fails.
+        request.body = b"null"
+        request.POST = MagicMock()
+        request.POST.dict.return_value = {"form": "value"}
+        result = _get_request_body(request)
+        self.assertEqual(result, {"form": "value"})
+
+    def test_get_request_body_none(self):
+        """Returns None when all extraction methods fail."""
+        request = MagicMock()
+        type(request).body = PropertyMock(side_effect=Exception("no body"))
+        request.POST = MagicMock()
+        request.POST.dict.side_effect = Exception("no form")
+        result = _get_request_body(request)
+        self.assertIsNone(result)
+
+    def test_get_request_body_large_payload(self):
+        """Returns truncation message for payloads over 10KB."""
+        request = MagicMock()
+        large_data = b"x" * 20000
+        request.body = large_data
+        request.content_type = "application/octet-stream"
+        request.POST = MagicMock()
+        request.POST.dict.side_effect = Exception("no form")
+        # Ensure JSON path fails
+        with patch("json.loads", side_effect=ValueError("not json")):
+            result = _get_request_body(request)
+        self.assertIn("payload too large", result)
+        self.assertIn("20000", result)
+
+
+class TestGetEndpointName(TestCase):
+    """Tests for _get_endpoint_name."""
+
+    def test_get_endpoint_name_from_resolver(self):
+        """resolver_match.view_name is returned when available."""
+        request = MagicMock()
+        request.resolver_match = MagicMock()
+        request.resolver_match.view_name = "user_detail"
+        result = _get_endpoint_name(request)
+        self.assertEqual(result, "user_detail")
+
+    def test_get_endpoint_name_no_resolver(self):
+        """Returns 'unknown' when resolver_match is None."""
+        request = MagicMock()
+        request.resolver_match = None
+        result = _get_endpoint_name(request)
+        self.assertEqual(result, "unknown")
+
+
+class TestInstallDjangoHooks(TestCase):
+    """Tests for install_django_hooks."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+        django_mod._endpoint_collector = None
+        django_mod._incident_snapshot_collector = None
+        django_mod._serviceevents_config = None
+
+    def test_install_django_hooks_stores_collectors(self):
+        """Module globals are set after install_django_hooks call."""
+        mock_ec = MagicMock()
+        mock_isc = MagicMock()
+        mock_cfg = MagicMock()
+
+        # Use a real class so load_middleware can be patched
+        class FakeBaseHandler:
+            def load_middleware(self, *args, **kwargs):
+                pass
+
+        mock_django_handler = MagicMock()
+        mock_django_handler.BaseHandler = FakeBaseHandler
+
+        with patch.dict("sys.modules", {"django.core.handlers.base": mock_django_handler}):
+            install_django_hooks(
+                endpoint_collector=mock_ec,
+                incident_snapshot_collector=mock_isc,
+                config=mock_cfg,
+            )
+
+        self.assertIs(django_mod._endpoint_collector, mock_ec)
+        self.assertIs(django_mod._incident_snapshot_collector, mock_isc)
+        self.assertIs(django_mod._serviceevents_config, mock_cfg)
+
+    def test_install_django_hooks_patches_load_middleware(self):
+        """BaseHandler.load_middleware is replaced with instrumented version."""
+
+        class FakeBaseHandler:
+            def load_middleware(self, *args, **kwargs):
+                pass
+
+        original_load = FakeBaseHandler.load_middleware
+
+        mock_django_handler = MagicMock()
+        mock_django_handler.BaseHandler = FakeBaseHandler
+
+        with patch.dict("sys.modules", {"django.core.handlers.base": mock_django_handler}):
+            install_django_hooks()
+
+        # load_middleware should have been replaced
+        self.assertIsNot(FakeBaseHandler.load_middleware, original_load)
+
+    def test_instrumented_load_middleware_injects_middleware(self):
+        """The wrapped load_middleware prepends the middleware to settings.MIDDLEWARE and reloads."""
+        call_count = {"n": 0}
+
+        class FakeBaseHandler:
+            def load_middleware(self, *args, **kwargs):
+                call_count["n"] += 1
+
+        mock_django_handler = MagicMock()
+        mock_django_handler.BaseHandler = FakeBaseHandler
+
+        # Fake django.conf with a settings object whose MIDDLEWARE starts without ours.
+        fake_settings = MagicMock()
+        fake_settings.MIDDLEWARE = ["django.middleware.common.CommonMiddleware"]
+        mock_django_conf = MagicMock()
+        mock_django_conf.settings = fake_settings
+
+        with patch.dict(
+            "sys.modules",
+            {"django.core.handlers.base": mock_django_handler, "django.conf": mock_django_conf},
+        ):
+            install_django_hooks()
+            # Drive the instrumented load_middleware on an instance.
+            FakeBaseHandler().load_middleware()
+
+        middleware_path = (
+            "amazon.opentelemetry.distro.serviceevents.instrumentation."
+            "django_instrumentation.ServiceEventsDjangoMiddleware"
+        )
+        # Our middleware was prepended to the front of MIDDLEWARE.
+        self.assertEqual(fake_settings.MIDDLEWARE[0], middleware_path)
+        # Original load_middleware called twice: once initially, once after injection.
+        self.assertEqual(call_count["n"], 2)
+
+    def test_instrumented_load_middleware_skips_when_already_present(self):
+        """The wrapped load_middleware does not re-inject when its middleware is already listed."""
+        call_count = {"n": 0}
+
+        class FakeBaseHandler:
+            def load_middleware(self, *args, **kwargs):
+                call_count["n"] += 1
+
+        mock_django_handler = MagicMock()
+        mock_django_handler.BaseHandler = FakeBaseHandler
+
+        middleware_path = (
+            "amazon.opentelemetry.distro.serviceevents.instrumentation."
+            "django_instrumentation.ServiceEventsDjangoMiddleware"
+        )
+        fake_settings = MagicMock()
+        fake_settings.MIDDLEWARE = [middleware_path]
+        mock_django_conf = MagicMock()
+        mock_django_conf.settings = fake_settings
+
+        with patch.dict(
+            "sys.modules",
+            {"django.core.handlers.base": mock_django_handler, "django.conf": mock_django_conf},
+        ):
+            install_django_hooks()
+            FakeBaseHandler().load_middleware()
+
+        # Already present: no re-injection and original load_middleware called only once.
+        self.assertEqual(fake_settings.MIDDLEWARE, [middleware_path])
+        self.assertEqual(call_count["n"], 1)
+
+    def test_instrumented_load_middleware_swallows_injection_error(self):
+        """An error while injecting middleware is logged and does not propagate."""
+        call_count = {"n": 0}
+
+        class FakeBaseHandler:
+            def load_middleware(self, *args, **kwargs):
+                call_count["n"] += 1
+
+        mock_django_handler = MagicMock()
+        mock_django_handler.BaseHandler = FakeBaseHandler
+
+        # Make accessing settings.MIDDLEWARE raise to hit the except branch.
+        fake_settings = MagicMock()
+        type(fake_settings).MIDDLEWARE = PropertyMock(side_effect=RuntimeError("settings boom"))
+        mock_django_conf = MagicMock()
+        mock_django_conf.settings = fake_settings
+
+        with patch.dict(
+            "sys.modules",
+            {"django.core.handlers.base": mock_django_handler, "django.conf": mock_django_conf},
+        ):
+            install_django_hooks()
+            # Must not raise even though injection fails.
+            FakeBaseHandler().load_middleware()
+
+        # Original load_middleware still ran once before the failure.
+        self.assertEqual(call_count["n"], 1)
+
+    def test_install_django_hooks_import_error(self):
+        """Gracefully handles missing Django (ImportError)."""
+        import sys
+
+        saved = sys.modules.get("django.core.handlers.base")
+        sys.modules["django.core.handlers.base"] = None  # Force ImportError
+
+        try:
+            django_mod._endpoint_collector = None
+            install_django_hooks(endpoint_collector=MagicMock())
+            # Collectors should remain None since Django import failed
+            self.assertIsNone(django_mod._endpoint_collector)
+        finally:
+            if saved is not None:
+                sys.modules["django.core.handlers.base"] = saved
+            else:
+                sys.modules.pop("django.core.handlers.base", None)
+
+
+class TestServiceEventsDjangoMiddleware(TestCase):
+    """Tests for ServiceEventsDjangoMiddleware."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+        django_mod._endpoint_collector = None
+        django_mod._incident_snapshot_collector = None
+        django_mod._serviceevents_config = None
+
+    def _make_request(self, method="GET", path="/api/test", route="api/test", view_name="test_view"):
+        """Helper to create a mock Django request object."""
+        request = MagicMock()
+        request.method = method
+        request.path = path
+        request.path_info = path
+        request.resolver_match = MagicMock()
+        request.resolver_match.route = route
+        request.resolver_match.view_name = view_name
+        request.body = b'{"key": "value"}'
+        request.content_type = "application/json"
+        request.POST = MagicMock()
+        request.POST.dict.return_value = {}
+        request.META = {}
+        # Ensure _serviceevents attributes are not pre-set
+        del request._serviceevents_start_time
+        del request._serviceevents_exception
+        del request._serviceevents_skip
+        return request
+
+    def test_call_wraps_get_response(self):
+        """__call__ calls get_response(request) and returns the response."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_get_response = MagicMock(return_value=mock_response)
+
+        middleware = ServiceEventsDjangoMiddleware(mock_get_response)
+        request = self._make_request()
+
+        result = middleware(request)
+
+        mock_get_response.assert_called_once_with(request)
+        self.assertIs(result, mock_response)
+
+    def test_call_records_start_time(self):
+        """request._serviceevents_start_time is set during __call__."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_get_response = MagicMock(return_value=mock_response)
+
+        middleware = ServiceEventsDjangoMiddleware(mock_get_response)
+        request = self._make_request()
+
+        with patch(
+            "amazon.opentelemetry.distro.serviceevents.instrumentation.django_instrumentation.time"
+        ) as mock_time:
+            mock_time.perf_counter_ns.return_value = 1000000000
+            middleware(request)
+
+        self.assertEqual(request._serviceevents_start_time, 1000000000)
+
+    def test_call_handles_exception(self):
+        """When get_response raises, exception is stored and re-raised."""
+        exc = RuntimeError("handler error")
+        mock_get_response = MagicMock(side_effect=exc)
+
+        middleware = ServiceEventsDjangoMiddleware(mock_get_response)
+        request = self._make_request()
+
+        with self.assertRaises(RuntimeError):
+            middleware(request)
+
+        self.assertIs(request._serviceevents_exception, exc)
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.django_instrumentation.set_current_operation")
+    def test_process_view_sets_operation_context(self, mock_set_operation):
+        """process_view calls set_current_operation with a METHOD /route string."""
+        mock_get_response = MagicMock()
+        middleware = ServiceEventsDjangoMiddleware(mock_get_response)
+        request = self._make_request()
+
+        middleware.process_view(request, MagicMock(), [], {})
+
+        mock_set_operation.assert_called_once()
+        # The operation should be "METHOD /route"
+        call_args = mock_set_operation.call_args[0][0]
+        self.assertEqual(call_args, "GET /api/test")
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.django_instrumentation.set_current_operation")
+    def test_process_view_begins_investigation(self, mock_set_operation):
+        """process_view calls monitor_state.begin_investigation()."""
+        mock_get_response = MagicMock()
+        middleware = ServiceEventsDjangoMiddleware(mock_get_response)
+        request = self._make_request()
+
+        with patch.object(_ServiceEventsMonitorState, "get_instance") as mock_get_inst:
+            mock_state = MagicMock()
+            mock_get_inst.return_value = mock_state
+            middleware.process_view(request, MagicMock(), [], {})
+
+        mock_state.begin_investigation.assert_called_once()
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.django_instrumentation.set_current_operation")
+    def test_process_view_skips_filtered_endpoints(self, mock_set_operation):
+        """Sets _serviceevents_skip = True for filtered endpoints."""
+        mock_config = MagicMock()
+        mock_config.should_track_endpoint.return_value = False
+        django_mod._serviceevents_config = mock_config
+
+        mock_get_response = MagicMock()
+        middleware = ServiceEventsDjangoMiddleware(mock_get_response)
+        request = self._make_request()
+
+        middleware.process_view(request, MagicMock(), [], {})
+
+        self.assertTrue(request._serviceevents_skip)
+        # set_current_operation should NOT have been called
+        mock_set_operation.assert_not_called()
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.django_instrumentation.set_current_operation")
+    def test_process_view_captures_trace_id(self, mock_set_operation):
+        """Captures trace_id and span_id from OTel span context."""
+        mock_get_response = MagicMock()
+        middleware = ServiceEventsDjangoMiddleware(mock_get_response)
+        request = self._make_request()
+
+        mock_span = MagicMock()
+        mock_span_context = MagicMock()
+        mock_span_context.is_valid = True
+        mock_span_context.trace_id = 12345678
+        mock_span_context.span_id = 87654321
+        mock_span.get_span_context.return_value = mock_span_context
+
+        with patch("opentelemetry.trace.get_current_span", return_value=mock_span):
+            middleware.process_view(request, MagicMock(), [], {})
+
+        self.assertEqual(request._serviceevents_trace_id, 12345678)
+        self.assertEqual(request._serviceevents_span_id, 87654321)
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.django_instrumentation.set_current_operation")
+    def test_process_view_captures_trace_id_from_meta_fallback(self, mock_set_operation):
+        """Falls back to the OTel span stored in request.META when the context API has no span."""
+        mock_get_response = MagicMock()
+        middleware = ServiceEventsDjangoMiddleware(mock_get_response)
+        request = self._make_request()
+
+        # Span stored in request.META by the OTel Django middleware.
+        meta_span = MagicMock()
+        meta_span_context = MagicMock()
+        meta_span_context.is_valid = True
+        meta_span_context.trace_id = 111
+        meta_span_context.span_id = 222
+        meta_span.get_span_context.return_value = meta_span_context
+        request.META = {"opentelemetry-instrumentor-django.span_key": meta_span}
+
+        # PRIMARY context API returns no usable span so the META fallback runs.
+        with patch("opentelemetry.trace.get_current_span", return_value=None):
+            middleware.process_view(request, MagicMock(), [], {})
+
+        self.assertEqual(request._serviceevents_trace_id, 111)
+        self.assertEqual(request._serviceevents_span_id, 222)
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.django_instrumentation.set_current_operation")
+    def test_process_view_swallows_trace_capture_failure(self, mock_set_operation):
+        """A failure during trace correlation capture is swallowed and does not abort the request."""
+        mock_get_response = MagicMock()
+        middleware = ServiceEventsDjangoMiddleware(mock_get_response)
+        request = self._make_request()
+
+        # get_current_span raises: the trace-capture try/except must swallow it.
+        with patch("opentelemetry.trace.get_current_span", side_effect=RuntimeError("otel boom")):
+            result = middleware.process_view(request, MagicMock(), [], {})
+
+        self.assertIsNone(result)
+        # Setup block ran before the trace capture failed, so route context was stored.
+        self.assertEqual(request._serviceevents_route, "/api/test")
+
+    @patch(
+        "amazon.opentelemetry.distro.serviceevents.instrumentation.django_instrumentation.set_current_operation",
+        side_effect=RuntimeError("telemetry exploded"),
+    )
+    def test_process_view_swallows_telemetry_failure(self, _mock_set_op):
+        """A telemetry failure in process_view must not abort the request.
+
+        It must return None (let the view run) and mark the request skipped so
+        finalize stays a no-op.
+        """
+        mock_get_response = MagicMock()
+        middleware = ServiceEventsDjangoMiddleware(mock_get_response)
+        request = self._make_request()
+
+        # Must not raise.
+        result = middleware.process_view(request, MagicMock(), [], {})
+        self.assertIsNone(result)
+        self.assertTrue(request._serviceevents_skip)
+
+    def test_process_exception_stores_exception(self):
+        """Stores exception on request._serviceevents_exception."""
+        mock_get_response = MagicMock()
+        middleware = ServiceEventsDjangoMiddleware(mock_get_response)
+        request = self._make_request()
+
+        exc = ValueError("bad input")
+        middleware.process_exception(request, exc)
+
+        self.assertIs(request._serviceevents_exception, exc)
+
+
+class TestFinalizeRequest(TestCase):
+    """Tests for _finalize_request."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+        django_mod._endpoint_collector = None
+        django_mod._incident_snapshot_collector = None
+        django_mod._serviceevents_config = None
+
+    def _make_request(self, method="GET", path="/api/test", route="api/test", view_name="test_view"):
+        """Helper to create a mock Django request object with serviceevents attributes."""
+        request = MagicMock()
+        request.method = method
+        request.path = path
+        request.path_info = path
+        request.resolver_match = MagicMock()
+        request.resolver_match.route = route
+        request.resolver_match.view_name = view_name
+        request.body = b'{"key": "value"}'
+        request.content_type = "application/json"
+        request.POST = MagicMock()
+        request.POST.dict.return_value = {}
+        request.META = {}
+        request._serviceevents_start_time = 1000000000
+        request._serviceevents_skip = False
+        # Set serviceevents context attributes (normally set by process_view)
+        request._serviceevents_route = "/" + route if not route.startswith("/") else route
+        request._serviceevents_method = method
+        request._serviceevents_path = path
+        request._serviceevents_endpoint = view_name
+        # Remove attributes that should not exist by default
+        del request._serviceevents_exception
+        return request
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.django_instrumentation.clear_current_operation")
+    def test_records_endpoint_metric(self, mock_clear):
+        """Calls endpoint_collector.record_request() with correct parameters."""
+        mock_ec = MagicMock()
+        django_mod._endpoint_collector = mock_ec
+
+        request = self._make_request()
+        response = MagicMock()
+        response.status_code = 200
+
+        with patch(
+            "amazon.opentelemetry.distro.serviceevents.instrumentation.django_instrumentation.time"
+        ) as mock_time:
+            mock_time.perf_counter_ns.return_value = 1200000000
+            _finalize_request(request, response, None)
+
+        mock_ec.record_request.assert_called_once()
+        call_kwargs = mock_ec.record_request.call_args[1]
+        self.assertEqual(call_kwargs["route"], "/api/test")
+        self.assertEqual(call_kwargs["method"], "GET")
+        self.assertEqual(call_kwargs["status_code"], 200)
+        self.assertIsNone(call_kwargs["error_info"])
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.django_instrumentation.clear_current_operation")
+    def test_processes_incident_on_500(self, mock_clear):
+        """Calls incident_snapshot_collector.process_potential_incident() on 500 status."""
+        mock_ec = MagicMock()
+        mock_isc = MagicMock()
+        django_mod._endpoint_collector = mock_ec
+        django_mod._incident_snapshot_collector = mock_isc
+
+        request = self._make_request(method="POST", path="/api/orders", route="api/orders", view_name="create_order")
+        response = MagicMock()
+        response.status_code = 500
+
+        exc = RuntimeError("DB connection failed")
+
+        with patch(
+            "amazon.opentelemetry.distro.serviceevents.instrumentation.django_instrumentation.time"
+        ) as mock_time:
+            mock_time.perf_counter_ns.return_value = 1050000000
+            _finalize_request(request, response, exc)
+
+        mock_isc.process_potential_incident.assert_called_once()
+        call_kwargs = mock_isc.process_potential_incident.call_args[1]
+        self.assertEqual(call_kwargs["status_code"], 500)
+        self.assertIs(call_kwargs["exception"], exc)
+
+        # Error info should be passed to endpoint collector
+        ec_kwargs = mock_ec.record_request.call_args[1]
+        self.assertIsNotNone(ec_kwargs["error_info"])
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.django_instrumentation.clear_current_operation")
+    def test_infers_500_from_exception(self, mock_clear):
+        """When no response is provided, status 500 is inferred from exception."""
+        mock_ec = MagicMock()
+        django_mod._endpoint_collector = mock_ec
+
+        request = self._make_request()
+        exc = ValueError("bad input")
+
+        with patch(
+            "amazon.opentelemetry.distro.serviceevents.instrumentation.django_instrumentation.time"
+        ) as mock_time:
+            mock_time.perf_counter_ns.return_value = 1050000000
+            _finalize_request(request, None, exc)
+
+        ec_kwargs = mock_ec.record_request.call_args[1]
+        self.assertEqual(ec_kwargs["status_code"], 500)
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.django_instrumentation.clear_current_operation")
+    def test_always_clears_operation(self, mock_clear):
+        """clear_current_operation() is called even when endpoint_collector raises."""
+        mock_ec = MagicMock()
+        mock_ec.record_request.side_effect = Exception("collector error")
+        django_mod._endpoint_collector = mock_ec
+
+        request = self._make_request()
+        response = MagicMock()
+        response.status_code = 200
+
+        with patch(
+            "amazon.opentelemetry.distro.serviceevents.instrumentation.django_instrumentation.time"
+        ) as mock_time:
+            mock_time.perf_counter_ns.return_value = 1200000000
+            # Should not raise, error is logged internally
+            _finalize_request(request, response, None)
+
+        mock_clear.assert_called_once()
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.django_instrumentation.clear_current_operation")
+    def test_skips_when_serviceevents_skip_true(self, mock_clear):
+        """Does nothing when _serviceevents_skip is True."""
+        mock_ec = MagicMock()
+        django_mod._endpoint_collector = mock_ec
+
+        request = self._make_request()
+        request._serviceevents_skip = True
+        response = MagicMock()
+        response.status_code = 200
+
+        _finalize_request(request, response, None)
+
+        # record_request should NOT have been called
+        mock_ec.record_request.assert_not_called()
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.django_instrumentation.clear_current_operation")
+    def test_skips_when_no_start_time(self, mock_clear):
+        """Does nothing when _serviceevents_start_time is not set."""
+        mock_ec = MagicMock()
+        django_mod._endpoint_collector = mock_ec
+
+        request = self._make_request()
+        del request._serviceevents_start_time
+        response = MagicMock()
+        response.status_code = 200
+
+        _finalize_request(request, response, None)
+
+        # record_request should NOT have been called
+        mock_ec.record_request.assert_not_called()
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.django_instrumentation.clear_current_operation")
+    def test_unmatched_route_collapses_to_sentinel(self, mock_clear):
+        """An unmatched-route 404 (process_view never ran) records the sentinel, not the raw path."""
+        mock_ec = MagicMock()
+        django_mod._endpoint_collector = mock_ec
+
+        # Simulate an unmatched 404: __call__ ran (start_time, skip=False) but process_view
+        # never did, so none of the _serviceevents_route/method/path attrs were stored.
+        request = MagicMock()
+        request.method = "GET"
+        request.path = "/wp-admin/setup-config.php"
+        request.path_info = "/wp-admin/setup-config.php"
+        request.resolver_match = None  # no URL match
+        request.META = {}
+        request.headers = {}
+        request.GET = MagicMock()
+        request.GET.dict.return_value = {}
+        request._serviceevents_start_time = 1000000000
+        request._serviceevents_skip = False
+        del request._serviceevents_exception
+        del request._serviceevents_route
+        del request._serviceevents_method
+        del request._serviceevents_path
+        del request._serviceevents_endpoint
+
+        response = MagicMock()
+        response.status_code = 404
+
+        with patch(
+            "amazon.opentelemetry.distro.serviceevents.instrumentation.django_instrumentation.time"
+        ) as mock_time:
+            mock_time.perf_counter_ns.return_value = 1200000000
+            _finalize_request(request, response, None)
+
+        mock_ec.record_request.assert_called_once()
+        call_kwargs = mock_ec.record_request.call_args[1]
+        # Must be the collapsed sentinel, NOT the raw probed path.
+        self.assertEqual(call_kwargs["route"], "<unmatched>")
+        self.assertNotIn("wp-admin", call_kwargs["route"])
+        self.assertEqual(call_kwargs["status_code"], 404)
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.django_instrumentation.clear_current_operation")
+    def test_matched_route_unaffected_by_sentinel(self, mock_clear):
+        """A normally-resolved request still records its real route, not the sentinel."""
+        mock_ec = MagicMock()
+        django_mod._endpoint_collector = mock_ec
+
+        request = self._make_request(method="GET", path="/users/42", route="users/<int:id>", view_name="user_detail")
+        response = MagicMock()
+        response.status_code = 200
+
+        with patch(
+            "amazon.opentelemetry.distro.serviceevents.instrumentation.django_instrumentation.time"
+        ) as mock_time:
+            mock_time.perf_counter_ns.return_value = 1200000000
+            _finalize_request(request, response, None)
+
+        call_kwargs = mock_ec.record_request.call_args[1]
+        self.assertEqual(call_kwargs["route"], "/users/<int:id>")
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.django_instrumentation.clear_current_operation")
+    def test_passes_correct_request_data(self, mock_clear):
+        """Verifies that request_data dict structure is correct for incident processing."""
+        mock_ec = MagicMock()
+        mock_isc = MagicMock()
+        django_mod._endpoint_collector = mock_ec
+        django_mod._incident_snapshot_collector = mock_isc
+
+        request = self._make_request(method="POST", path="/api/items", route="api/items", view_name="create_item")
+        request._serviceevents_trace_id = 99999
+        request._serviceevents_span_id = 88888
+        response = MagicMock()
+        response.status_code = 500
+
+        exc = RuntimeError("server error")
+
+        with patch(
+            "amazon.opentelemetry.distro.serviceevents.instrumentation.django_instrumentation.time"
+        ) as mock_time:
+            mock_time.perf_counter_ns.return_value = 1100000000
+            _finalize_request(request, response, exc)
+
+        call_kwargs = mock_isc.process_potential_incident.call_args[1]
+        req_data = call_kwargs["request_data"]
+
+        self.assertEqual(req_data["path"], "/api/items")
+        self.assertEqual(req_data["endpoint"], "create_item")
+        self.assertEqual(req_data["method"], "POST")
+        self.assertEqual(req_data["trace_id"], 99999)
+        self.assertEqual(req_data["span_id"], 88888)
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.django_instrumentation.clear_current_operation")
+    def test_defaults_status_200_when_no_response_or_exception(self, mock_clear):
+        """Status defaults to 200 when neither a response nor an exception is present."""
+        mock_ec = MagicMock()
+        django_mod._endpoint_collector = mock_ec
+
+        request = self._make_request()
+
+        with patch(
+            "amazon.opentelemetry.distro.serviceevents.instrumentation.django_instrumentation.time"
+        ) as mock_time:
+            mock_time.perf_counter_ns.return_value = 1200000000
+            _finalize_request(request, None, None)
+
+        ec_kwargs = mock_ec.record_request.call_args[1]
+        self.assertEqual(ec_kwargs["status_code"], 200)
+        self.assertIsNone(ec_kwargs["error_info"])
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.django_instrumentation.clear_current_operation")
+    def test_incident_snapshot_error_is_swallowed(self, mock_clear):
+        """An error from the incident snapshot collector is logged and does not propagate."""
+        mock_ec = MagicMock()
+        mock_isc = MagicMock()
+        mock_isc.process_potential_incident.side_effect = Exception("snapshot boom")
+        django_mod._endpoint_collector = mock_ec
+        django_mod._incident_snapshot_collector = mock_isc
+
+        request = self._make_request(method="POST", path="/api/orders", route="api/orders", view_name="create_order")
+        response = MagicMock()
+        response.status_code = 500
+
+        with patch(
+            "amazon.opentelemetry.distro.serviceevents.instrumentation.django_instrumentation.time"
+        ) as mock_time:
+            mock_time.perf_counter_ns.return_value = 1050000000
+            # Must not raise despite the collector error.
+            _finalize_request(request, response, RuntimeError("db down"))
+
+        mock_isc.process_potential_incident.assert_called_once()
+        # Operation context is still cleared.
+        mock_clear.assert_called_once()

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/instrumentation/test_django_instrumentation.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/instrumentation/test_django_instrumentation.py
@@ -208,12 +208,20 @@ class TestInstallDjangoHooks(TestCase):
         self.assertIsNot(FakeBaseHandler.load_middleware, original_load)
 
     def test_instrumented_load_middleware_injects_middleware(self):
-        """The wrapped load_middleware prepends the middleware to settings.MIDDLEWARE and reloads."""
+        """The wrapped load_middleware prepends the middleware to settings.MIDDLEWARE before building once."""
         call_count = {"n": 0}
+
+        middleware_path = (
+            "amazon.opentelemetry.distro.serviceevents.instrumentation."
+            "django_instrumentation.ServiceEventsDjangoMiddleware"
+        )
 
         class FakeBaseHandler:
             def load_middleware(self, *args, **kwargs):
                 call_count["n"] += 1
+                # Stack must be built only after SE middleware is already injected, so
+                # every middleware is instantiated exactly once.
+                assert fake_settings.MIDDLEWARE[0] == middleware_path
 
         mock_django_handler = MagicMock()
         mock_django_handler.BaseHandler = FakeBaseHandler
@@ -232,14 +240,11 @@ class TestInstallDjangoHooks(TestCase):
             # Drive the instrumented load_middleware on an instance.
             FakeBaseHandler().load_middleware()
 
-        middleware_path = (
-            "amazon.opentelemetry.distro.serviceevents.instrumentation."
-            "django_instrumentation.ServiceEventsDjangoMiddleware"
-        )
         # Our middleware was prepended to the front of MIDDLEWARE.
         self.assertEqual(fake_settings.MIDDLEWARE[0], middleware_path)
-        # Original load_middleware called twice: once initially, once after injection.
-        self.assertEqual(call_count["n"], 2)
+        # Original load_middleware called exactly once: the SE middleware is injected before
+        # the single build, so the stack (and every middleware) is built only once on first init.
+        self.assertEqual(call_count["n"], 1)
 
     def test_instrumented_load_middleware_skips_when_already_present(self):
         """The wrapped load_middleware does not re-inject when its middleware is already listed."""

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/instrumentation/test_fastapi_instrumentation.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/instrumentation/test_fastapi_instrumentation.py
@@ -297,6 +297,35 @@ class TestInstallFastAPIHooks(TestCase):
         self.assertTrue(original_init_called["called"])
         app.add_middleware.assert_called_once_with(ServiceEventsFastAPIMiddleware)
 
+    def test_instrumented_init_swallows_middleware_install_failure(self):
+        """Crash-safety: if add_middleware raises, app construction must still succeed.
+
+        Telemetry must never break the host app. The original FastAPI __init__ must run
+        and the constructed instance must be usable even when installing our middleware
+        fails. The failure is swallowed (logged at debug), not propagated.
+        """
+        original_init_called = {}
+
+        class FakeFastAPI:
+            def __init__(self, *args, **kwargs):
+                original_init_called["called"] = True
+                self.title = "test-app"
+                # add_middleware blows up the way a framework-internal failure would.
+                self.add_middleware = MagicMock(side_effect=RuntimeError("middleware exploded"))
+
+        mock_fastapi_module = MagicMock()
+        mock_fastapi_module.FastAPI = FakeFastAPI
+
+        with patch.dict("sys.modules", {"fastapi": mock_fastapi_module}):
+            install_fastapi_hooks()
+            # Must NOT raise even though add_middleware throws inside instrumented_init.
+            app = FakeFastAPI()
+
+        # Original init ran and the app was constructed despite the telemetry failure.
+        self.assertTrue(original_init_called["called"])
+        self.assertEqual(app.title, "test-app")
+        app.add_middleware.assert_called_once_with(ServiceEventsFastAPIMiddleware)
+
 
 class TestFastAPIMiddleware(unittest.IsolatedAsyncioTestCase):
     """Async tests for ServiceEventsFastAPIMiddleware."""

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/instrumentation/test_fastapi_instrumentation.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/instrumentation/test_fastapi_instrumentation.py
@@ -6,6 +6,7 @@ from unittest import TestCase
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation as fastapi_mod
+from amazon.opentelemetry.distro.serviceevents.instrumentation._constants import UNMATCHED_ROUTE
 from amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation import (
     ServiceEventsFastAPIMiddleware,
     _get_request_body,
@@ -28,24 +29,27 @@ class TestGetRoutePattern(TestCase):
         result = _get_route_pattern(scope)
         self.assertEqual(result, "/api/users/{id}")
 
-    def test_get_route_pattern_from_path(self):
-        """Falls back to scope path when route object is absent."""
+    def test_get_route_pattern_unmatched_uses_sentinel(self):
+        """When no route object is set and the template can't be pre-resolved (no app
+        routes), collapse to the <unmatched> sentinel rather than the raw path, to bound
+        metric cardinality for scanner/bot traffic. Parity with Flask/Django."""
         scope = {"path": "/api/users/42"}
         result = _get_route_pattern(scope)
-        self.assertEqual(result, "/api/users/42")
+        self.assertEqual(result, UNMATCHED_ROUTE)
 
-    def test_get_route_pattern_no_route_no_path(self):
-        """Returns /unknown when neither route nor path exists."""
+    def test_get_route_pattern_empty_scope_uses_sentinel(self):
+        """An empty scope (no route, no path, no app) yields the <unmatched> sentinel."""
         scope = {}
         result = _get_route_pattern(scope)
-        self.assertEqual(result, "/unknown")
+        self.assertEqual(result, UNMATCHED_ROUTE)
 
-    def test_get_route_pattern_route_without_path_attr(self):
-        """Falls back when route object exists but has no path attribute."""
+    def test_get_route_pattern_route_without_path_attr_uses_sentinel(self):
+        """A route object without a .path attribute (and no resolvable template) falls
+        through to the <unmatched> sentinel."""
         route_obj = "not-a-route-object"  # has no .path attribute
         scope = {"route": route_obj, "path": "/fallback"}
         result = _get_route_pattern(scope)
-        self.assertEqual(result, "/fallback")
+        self.assertEqual(result, UNMATCHED_ROUTE)
 
     def test_get_route_pattern_preresolves_template_before_routing(self):
         """When scope['route'] is unset, the template is resolved from the app's routes
@@ -73,7 +77,7 @@ class TestGetRoutePattern(TestCase):
         self.assertIsNone(_resolve_route_template({"type": "http", "path": "/x"}))
 
     def test_resolve_route_template_returns_none_on_no_match(self):
-        """A path that matches no route resolves to None (caller falls back to raw path)."""
+        """A path that matches no route resolves to None (caller then uses the sentinel)."""
         from starlette.applications import Starlette  # pylint: disable=import-outside-toplevel
         from starlette.responses import PlainTextResponse  # pylint: disable=import-outside-toplevel
         from starlette.routing import Route  # pylint: disable=import-outside-toplevel
@@ -362,10 +366,16 @@ class TestFastAPIMiddleware(unittest.IsolatedAsyncioTestCase):
             await send({"type": "http.response.body", "body": b"ok"})
 
         middleware = ServiceEventsFastAPIMiddleware(mock_app)
+        # A genuinely-matched request carries a resolved route object, so the recorded
+        # route is the template. (Unmatched requests now collapse to the <unmatched>
+        # sentinel — covered by the _get_route_pattern tests.)
+        route_obj = MagicMock()
+        route_obj.path = "/api/users"
         scope = {
             "type": "http",
             "method": "GET",
             "path": "/api/users",
+            "route": route_obj,
             "headers": [],
             "query_string": b"",
         }

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/instrumentation/test_fastapi_instrumentation.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/instrumentation/test_fastapi_instrumentation.py
@@ -466,6 +466,41 @@ class TestFastAPIMiddleware(unittest.IsolatedAsyncioTestCase):
 
     @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.clear_current_operation")
     @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.set_current_operation")
+    async def test_middleware_send_failure_does_not_mask_app_exception(self, mock_set_op, mock_clear_op):
+        """If the error-response send() raises, the ORIGINAL app exception must still propagate.
+
+        Crash-safety: a client disconnect / broken pipe during our best-effort 500 send must
+        not replace the application's own exception with the send error — telemetry must never
+        alter which exception the host application sees.
+        """
+        fastapi_mod._endpoint_collector = MagicMock()
+
+        async def mock_app(scope, receive, send):
+            raise RuntimeError("original app error")
+
+        async def mock_send(msg):
+            # Simulate the client connection dropping while we try to emit the 500.
+            raise OSError("broken pipe")
+
+        middleware = ServiceEventsFastAPIMiddleware(mock_app)
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/api/broken",
+            "headers": [],
+            "query_string": b"",
+        }
+
+        # The original RuntimeError must surface, NOT the OSError from send().
+        with self.assertRaises(RuntimeError) as ctx:
+            await middleware(scope, AsyncMock(), mock_send)
+        self.assertEqual(str(ctx.exception), "original app error")
+
+        # Operation context is still cleared despite the send failure.
+        mock_clear_op.assert_called_once()
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.clear_current_operation")
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.set_current_operation")
     async def test_middleware_clears_operation(self, mock_set_op, mock_clear_op):
         """clear_current_operation is always called in the finally block."""
 

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/instrumentation/test_fastapi_instrumentation.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/instrumentation/test_fastapi_instrumentation.py
@@ -1,0 +1,905 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+from unittest import TestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation as fastapi_mod
+from amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation import (
+    ServiceEventsFastAPIMiddleware,
+    _get_request_body,
+    _get_route_pattern,
+    _parse_query_string,
+    _resolve_route_template,
+    install_fastapi_hooks,
+)
+from amazon.opentelemetry.distro.serviceevents.python_monitor import _ServiceEventsMonitorState
+
+
+class TestGetRoutePattern(TestCase):
+    """Tests for _get_route_pattern."""
+
+    def test_get_route_pattern_from_scope(self):
+        """Route pattern is extracted from scope route object's path attribute."""
+        route_obj = MagicMock()
+        route_obj.path = "/api/users/{id}"
+        scope = {"route": route_obj, "path": "/api/users/42"}
+        result = _get_route_pattern(scope)
+        self.assertEqual(result, "/api/users/{id}")
+
+    def test_get_route_pattern_from_path(self):
+        """Falls back to scope path when route object is absent."""
+        scope = {"path": "/api/users/42"}
+        result = _get_route_pattern(scope)
+        self.assertEqual(result, "/api/users/42")
+
+    def test_get_route_pattern_no_route_no_path(self):
+        """Returns /unknown when neither route nor path exists."""
+        scope = {}
+        result = _get_route_pattern(scope)
+        self.assertEqual(result, "/unknown")
+
+    def test_get_route_pattern_route_without_path_attr(self):
+        """Falls back when route object exists but has no path attribute."""
+        route_obj = "not-a-route-object"  # has no .path attribute
+        scope = {"route": route_obj, "path": "/fallback"}
+        result = _get_route_pattern(scope)
+        self.assertEqual(result, "/fallback")
+
+    def test_get_route_pattern_preresolves_template_before_routing(self):
+        """When scope['route'] is unset, the template is resolved from the app's routes
+        so the per-request operation keys on /users/{id}, not the raw /users/42."""
+        from starlette.applications import Starlette  # pylint: disable=import-outside-toplevel
+        from starlette.responses import PlainTextResponse  # pylint: disable=import-outside-toplevel
+        from starlette.routing import Route  # pylint: disable=import-outside-toplevel
+
+        async def handler(_request):
+            return PlainTextResponse("ok")
+
+        app = Starlette(routes=[Route("/users/{id}", handler)])
+        # Scope as seen at middleware entry: app set, route NOT yet populated.
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/users/42",
+            "app": app,
+            "headers": [],
+        }
+        self.assertEqual(_get_route_pattern(scope), "/users/{id}")
+
+    def test_resolve_route_template_returns_none_without_app(self):
+        """No app in scope → no pre-resolution (graceful)."""
+        self.assertIsNone(_resolve_route_template({"type": "http", "path": "/x"}))
+
+    def test_resolve_route_template_returns_none_on_no_match(self):
+        """A path that matches no route resolves to None (caller falls back to raw path)."""
+        from starlette.applications import Starlette  # pylint: disable=import-outside-toplevel
+        from starlette.responses import PlainTextResponse  # pylint: disable=import-outside-toplevel
+        from starlette.routing import Route  # pylint: disable=import-outside-toplevel
+
+        async def handler(_request):
+            return PlainTextResponse("ok")
+
+        app = Starlette(routes=[Route("/users/{id}", handler)])
+        scope = {"type": "http", "method": "GET", "path": "/nope/here", "app": app, "headers": []}
+        self.assertIsNone(_resolve_route_template(scope))
+
+    def test_resolve_route_template_skips_route_missing_matches(self):
+        """Routes without a matches() callable or path attribute are skipped."""
+        bad_route = MagicMock()
+        bad_route.matches = None
+        bad_route.path = None
+        app = MagicMock()
+        app.routes = [bad_route]
+        scope = {"type": "http", "method": "GET", "path": "/x", "app": app}
+        self.assertIsNone(_resolve_route_template(scope))
+
+    def test_resolve_route_template_returns_none_on_exception(self):
+        """A route whose matches() raises is swallowed and resolves to None."""
+        boom_route = MagicMock()
+        boom_route.path = "/x/{id}"
+        boom_route.matches.side_effect = RuntimeError("routing exploded")
+        app = MagicMock()
+        app.routes = [boom_route]
+        scope = {"type": "http", "method": "GET", "path": "/x/1", "app": app}
+        self.assertIsNone(_resolve_route_template(scope))
+
+
+class TestParseQueryString(TestCase):
+    """Tests for _parse_query_string."""
+
+    def test_parse_query_string(self):
+        """Single key-value pair is parsed correctly."""
+        result = _parse_query_string(b"key=val")
+        self.assertEqual(result, {"key": "val"})
+
+    def test_parse_query_string_multi(self):
+        """Multiple values for same key become a list."""
+        result = _parse_query_string(b"k=a&k=b")
+        self.assertEqual(result, {"k": ["a", "b"]})
+
+    def test_parse_query_string_empty(self):
+        """Empty bytes returns empty dict."""
+        result = _parse_query_string(b"")
+        self.assertEqual(result, {})
+
+    def test_parse_query_string_none(self):
+        """None input returns empty dict."""
+        result = _parse_query_string(None)
+        self.assertEqual(result, {})
+
+    def test_parse_query_string_multiple_params(self):
+        """Multiple different keys are parsed."""
+        result = _parse_query_string(b"page=1&limit=20&sort=name")
+        self.assertEqual(result, {"page": "1", "limit": "20", "sort": "name"})
+
+    def test_parse_query_string_decode_error_returns_empty(self):
+        """A query string whose decode raises is swallowed and yields an empty dict."""
+        bad = MagicMock()
+        bad.__bool__ = lambda self: True
+        bad.decode.side_effect = UnicodeDecodeError("utf-8", b"", 0, 1, "bad")
+        result = _parse_query_string(bad)
+        self.assertEqual(result, {})
+
+
+class TestGetRequestBody(unittest.IsolatedAsyncioTestCase):
+    """Tests for the async _get_request_body fallback chain."""
+
+    async def test_returns_json_body(self):
+        """JSON body is returned when request.json() succeeds."""
+        request = MagicMock()
+        request.json = AsyncMock(return_value={"name": "test"})
+        result = await _get_request_body(request)
+        self.assertEqual(result, {"name": "test"})
+
+    async def test_falls_back_to_form_data(self):
+        """When JSON parsing fails, form data is returned as a dict."""
+        request = MagicMock()
+        request.json = AsyncMock(side_effect=ValueError("not json"))
+        request.form = AsyncMock(return_value={"field": "value"})
+        result = await _get_request_body(request)
+        self.assertEqual(result, {"field": "value"})
+
+    async def test_falls_back_to_raw_body(self):
+        """When JSON and form fail, raw bytes are decoded to a string."""
+        request = MagicMock()
+        request.json = AsyncMock(side_effect=ValueError("not json"))
+        request.form = AsyncMock(return_value={})
+        request.body = AsyncMock(return_value=b"raw payload")
+        result = await _get_request_body(request)
+        self.assertEqual(result, "raw payload")
+
+    async def test_raw_body_too_large(self):
+        """Raw bodies over the 10KB limit are summarized, not decoded."""
+        request = MagicMock()
+        request.json = AsyncMock(side_effect=ValueError("not json"))
+        request.form = AsyncMock(return_value={})
+        big = b"x" * 10241
+        request.body = AsyncMock(return_value=big)
+        result = await _get_request_body(request)
+        self.assertEqual(result, "<payload too large: 10241 bytes>")
+
+    async def test_form_error_falls_through_to_raw_body(self):
+        """A raised form() is swallowed and extraction continues to the raw body."""
+        request = MagicMock()
+        request.json = AsyncMock(side_effect=ValueError("not json"))
+        request.form = AsyncMock(side_effect=RuntimeError("form exploded"))
+        request.body = AsyncMock(return_value=b"raw")
+        result = await _get_request_body(request)
+        self.assertEqual(result, "raw")
+
+    async def test_raw_body_error_returns_none(self):
+        """A raised body() is swallowed and None is returned."""
+        request = MagicMock()
+        request.json = AsyncMock(side_effect=ValueError("not json"))
+        request.form = AsyncMock(return_value={})
+        request.body = AsyncMock(side_effect=RuntimeError("body exploded"))
+        result = await _get_request_body(request)
+        self.assertIsNone(result)
+
+    async def test_returns_none_when_all_fail(self):
+        """When every extraction path fails or is empty, None is returned."""
+        request = MagicMock()
+        request.json = AsyncMock(side_effect=ValueError("not json"))
+        request.form = AsyncMock(return_value={})
+        request.body = AsyncMock(return_value=b"")
+        result = await _get_request_body(request)
+        self.assertIsNone(result)
+
+
+class TestInstallFastAPIHooks(TestCase):
+    """Tests for install_fastapi_hooks."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+        fastapi_mod._endpoint_collector = None
+        fastapi_mod._incident_snapshot_collector = None
+        fastapi_mod._serviceevents_config = None
+
+    def test_install_stores_collectors(self):
+        """Module globals are set after install_fastapi_hooks call."""
+        mock_ec = MagicMock()
+        mock_isc = MagicMock()
+        mock_cfg = MagicMock()
+
+        # Use a real class so __init__ can be patched
+        class FakeFastAPI:
+            def __init__(self, *args, **kwargs):
+                pass
+
+        mock_fastapi_module = MagicMock()
+        mock_fastapi_module.FastAPI = FakeFastAPI
+
+        with patch.dict("sys.modules", {"fastapi": mock_fastapi_module}):
+            install_fastapi_hooks(
+                endpoint_collector=mock_ec,
+                incident_snapshot_collector=mock_isc,
+                config=mock_cfg,
+            )
+
+        self.assertIs(fastapi_mod._endpoint_collector, mock_ec)
+        self.assertIs(fastapi_mod._incident_snapshot_collector, mock_isc)
+        self.assertIs(fastapi_mod._serviceevents_config, mock_cfg)
+
+    def test_install_import_error(self):
+        """Gracefully handles missing FastAPI."""
+        import sys
+
+        saved = sys.modules.get("fastapi")
+        sys.modules["fastapi"] = None  # Force ImportError
+
+        try:
+            fastapi_mod._endpoint_collector = None
+            install_fastapi_hooks(endpoint_collector=MagicMock())
+            # Collectors should remain None since FastAPI import failed
+            self.assertIsNone(fastapi_mod._endpoint_collector)
+        finally:
+            if saved is not None:
+                sys.modules["fastapi"] = saved
+            else:
+                sys.modules.pop("fastapi", None)
+
+    def test_install_patches_fastapi_init(self):
+        """FastAPI.__init__ is replaced with instrumented version."""
+
+        class FakeFastAPI:
+            def __init__(self, *args, **kwargs):
+                pass
+
+        original_init = FakeFastAPI.__init__
+
+        mock_fastapi_module = MagicMock()
+        mock_fastapi_module.FastAPI = FakeFastAPI
+
+        with patch.dict("sys.modules", {"fastapi": mock_fastapi_module}):
+            install_fastapi_hooks()
+
+        self.assertIsNot(FakeFastAPI.__init__, original_init)
+
+    def test_instrumented_init_adds_middleware(self):
+        """Instantiating a patched app calls original init and adds the middleware."""
+        original_init_called = {}
+
+        class FakeFastAPI:
+            def __init__(self, *args, **kwargs):
+                original_init_called["called"] = True
+                self.title = "test-app"
+                self.add_middleware = MagicMock()
+
+        mock_fastapi_module = MagicMock()
+        mock_fastapi_module.FastAPI = FakeFastAPI
+
+        with patch.dict("sys.modules", {"fastapi": mock_fastapi_module}):
+            install_fastapi_hooks()
+            app = FakeFastAPI()
+
+        self.assertTrue(original_init_called["called"])
+        app.add_middleware.assert_called_once_with(ServiceEventsFastAPIMiddleware)
+
+
+class TestFastAPIMiddleware(unittest.IsolatedAsyncioTestCase):
+    """Async tests for ServiceEventsFastAPIMiddleware."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+        fastapi_mod._endpoint_collector = None
+        fastapi_mod._incident_snapshot_collector = None
+        fastapi_mod._serviceevents_config = None
+
+    async def test_middleware_skips_non_http(self):
+        """Websocket scope passes through to app without instrumentation."""
+        app_called = False
+
+        async def mock_app(scope, receive, send):
+            nonlocal app_called
+            app_called = True
+
+        middleware = ServiceEventsFastAPIMiddleware(mock_app)
+        scope = {"type": "websocket", "path": "/ws"}
+
+        await middleware(scope, AsyncMock(), AsyncMock())
+        self.assertTrue(app_called)
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.clear_current_operation")
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.set_current_operation")
+    async def test_middleware_records_endpoint_metric(self, mock_set_op, mock_clear_op):
+        """Endpoint collector record_request is called with correct args."""
+        mock_ec = MagicMock()
+        fastapi_mod._endpoint_collector = mock_ec
+
+        async def mock_app(scope, receive, send):
+            await send({"type": "http.response.start", "status": 200})
+            await send({"type": "http.response.body", "body": b"ok"})
+
+        middleware = ServiceEventsFastAPIMiddleware(mock_app)
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/api/users",
+            "headers": [],
+            "query_string": b"",
+        }
+
+        sent_messages = []
+
+        async def mock_send(msg):
+            sent_messages.append(msg)
+
+        await middleware(scope, AsyncMock(), mock_send)
+
+        mock_ec.record_request.assert_called_once()
+        call_kwargs = mock_ec.record_request.call_args[1]
+        self.assertEqual(call_kwargs["route"], "/api/users")
+        self.assertEqual(call_kwargs["method"], "GET")
+        self.assertEqual(call_kwargs["status_code"], 200)
+        self.assertIsNone(call_kwargs["error_info"])
+        mock_clear_op.assert_called_once()
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.clear_current_operation")
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.set_current_operation")
+    async def test_middleware_processes_incident_on_500(self, mock_set_op, mock_clear_op):
+        """Status 500 triggers incident snapshot processing."""
+        mock_ec = MagicMock()
+        mock_isc = MagicMock()
+        fastapi_mod._endpoint_collector = mock_ec
+        fastapi_mod._incident_snapshot_collector = mock_isc
+
+        async def mock_app(scope, receive, send):
+            await send({"type": "http.response.start", "status": 500})
+            await send({"type": "http.response.body", "body": b"error"})
+
+        middleware = ServiceEventsFastAPIMiddleware(mock_app)
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/api/orders",
+            "headers": [],
+            "query_string": b"",
+        }
+
+        await middleware(scope, AsyncMock(), AsyncMock())
+
+        mock_isc.process_potential_incident.assert_called_once()
+        call_kwargs = mock_isc.process_potential_incident.call_args[1]
+        self.assertEqual(call_kwargs["status_code"], 500)
+
+        # Error info should be passed to endpoint collector
+        ec_kwargs = mock_ec.record_request.call_args[1]
+        self.assertIsNotNone(ec_kwargs["error_info"])
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.clear_current_operation")
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.set_current_operation")
+    async def test_middleware_handles_app_exception(self, mock_set_op, mock_clear_op):
+        """App exception is caught, 500 is sent, and exception is re-raised."""
+        mock_ec = MagicMock()
+        fastapi_mod._endpoint_collector = mock_ec
+
+        async def mock_app(scope, receive, send):
+            raise RuntimeError("app crashed")
+
+        middleware = ServiceEventsFastAPIMiddleware(mock_app)
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/api/broken",
+            "headers": [],
+            "query_string": b"",
+        }
+
+        sent_messages = []
+
+        async def mock_send(msg):
+            sent_messages.append(msg)
+
+        with self.assertRaises(RuntimeError):
+            await middleware(scope, AsyncMock(), mock_send)
+
+        # Should have sent 500 error response
+        self.assertTrue(any(m.get("status") == 500 for m in sent_messages))
+
+        # Endpoint collector should record 500
+        ec_kwargs = mock_ec.record_request.call_args[1]
+        self.assertEqual(ec_kwargs["status_code"], 500)
+
+        # Operation should still be cleared
+        mock_clear_op.assert_called_once()
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.clear_current_operation")
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.set_current_operation")
+    async def test_middleware_clears_operation(self, mock_set_op, mock_clear_op):
+        """clear_current_operation is always called in the finally block."""
+
+        async def mock_app(scope, receive, send):
+            await send({"type": "http.response.start", "status": 200})
+            await send({"type": "http.response.body", "body": b"ok"})
+
+        middleware = ServiceEventsFastAPIMiddleware(mock_app)
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/api/test",
+            "headers": [],
+            "query_string": b"",
+        }
+
+        await middleware(scope, AsyncMock(), AsyncMock())
+
+        mock_set_op.assert_called_once()
+        mock_clear_op.assert_called_once()
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.clear_current_operation")
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.set_current_operation")
+    async def test_send_wrapper_captures_status_code(self, mock_set_op, mock_clear_op):
+        """Status code is extracted from http.response.start message."""
+        mock_ec = MagicMock()
+        fastapi_mod._endpoint_collector = mock_ec
+
+        async def mock_app(scope, receive, send):
+            await send({"type": "http.response.start", "status": 201})
+            await send({"type": "http.response.body", "body": b"created"})
+
+        middleware = ServiceEventsFastAPIMiddleware(mock_app)
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/api/items",
+            "headers": [],
+            "query_string": b"",
+        }
+
+        await middleware(scope, AsyncMock(), AsyncMock())
+
+        ec_kwargs = mock_ec.record_request.call_args[1]
+        self.assertEqual(ec_kwargs["status_code"], 201)
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.clear_current_operation")
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.set_current_operation")
+    async def test_middleware_skips_filtered_endpoint(self, mock_set_op, mock_clear_op):
+        """Middleware passes through when config filters out the endpoint."""
+        mock_config = MagicMock()
+        mock_config.should_track_endpoint.return_value = False
+        fastapi_mod._serviceevents_config = mock_config
+
+        app_called = False
+
+        async def mock_app(scope, receive, send):
+            nonlocal app_called
+            app_called = True
+            await send({"type": "http.response.start", "status": 200})
+            await send({"type": "http.response.body", "body": b"ok"})
+
+        middleware = ServiceEventsFastAPIMiddleware(mock_app)
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/health",
+            "headers": [],
+            "query_string": b"",
+        }
+
+        await middleware(scope, AsyncMock(), AsyncMock())
+
+        self.assertTrue(app_called)
+        # set_current_operation should NOT have been called
+        mock_set_op.assert_not_called()
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.clear_current_operation")
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.set_current_operation")
+    async def test_middleware_parses_headers_and_query(self, mock_set_op, mock_clear_op):
+        """Incident snapshot receives parsed headers and query params."""
+        mock_isc = MagicMock()
+        fastapi_mod._incident_snapshot_collector = mock_isc
+
+        async def mock_app(scope, receive, send):
+            await send({"type": "http.response.start", "status": 500})
+            await send({"type": "http.response.body", "body": b"error"})
+
+        middleware = ServiceEventsFastAPIMiddleware(mock_app)
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/api/search",
+            "headers": [(b"content-type", b"application/json"), (b"x-request-id", b"abc123")],
+            "query_string": b"q=test&page=1",
+            "path_params": {"id": "42"},
+        }
+
+        await middleware(scope, AsyncMock(), AsyncMock())
+
+        call_kwargs = mock_isc.process_potential_incident.call_args[1]
+        req_data = call_kwargs["request_data"]
+        self.assertEqual(req_data["headers"]["content-type"], "application/json")
+        self.assertEqual(req_data["args"]["q"], "test")
+        self.assertEqual(req_data["args"]["page"], "1")
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.clear_current_operation")
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.set_current_operation")
+    async def test_middleware_caches_request_body(self, mock_set_op, mock_clear_op):
+        """Request body is captured via receive_wrapper and passed to incident collector."""
+        mock_isc = MagicMock()
+        fastapi_mod._incident_snapshot_collector = mock_isc
+
+        body_content = b'{"name": "test"}'
+
+        async def mock_app(scope, receive, send):
+            # App reads the body
+            await receive()
+            await send({"type": "http.response.start", "status": 500})
+            await send({"type": "http.response.body", "body": b"error"})
+
+        middleware = ServiceEventsFastAPIMiddleware(mock_app)
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/api/items",
+            "headers": [],
+            "query_string": b"",
+        }
+
+        call_count = 0
+
+        async def mock_receive():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return {"type": "http.request", "body": body_content, "more_body": False}
+            return {"type": "http.disconnect"}
+
+        await middleware(scope, mock_receive, AsyncMock())
+
+        call_kwargs = mock_isc.process_potential_incident.call_args[1]
+        req_data = call_kwargs["request_data"]
+        self.assertIn("cached_body", req_data)
+        self.assertIn("test", req_data["cached_body"])
+
+
+class TestFastAPIMiddlewareRouteResolution(unittest.IsolatedAsyncioTestCase):
+    """The exported endpoint telemetry must use the route template, not the raw path.
+
+    At middleware entry scope["route"] is unset, so the entry-time value is the raw
+    URL. Starlette/FastAPI routing populates scope["route"] in place during dispatch,
+    so the middleware re-resolves it in the finally block before recording metrics.
+    """
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+        fastapi_mod._endpoint_collector = None
+        fastapi_mod._incident_snapshot_collector = None
+        fastapi_mod._serviceevents_config = None
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.clear_current_operation")
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.set_current_operation")
+    async def test_route_template_used_after_routing(self, mock_set_op, mock_clear_op):
+        """record_request gets the template (/users/{id}) once routing populates scope."""
+        mock_ec = MagicMock()
+        fastapi_mod._endpoint_collector = mock_ec
+
+        route_obj = MagicMock()
+        route_obj.path = "/users/{id}"
+
+        async def mock_app(scope, receive, send):
+            # Simulate FastAPI routing mutating the scope dict in place during dispatch.
+            scope["route"] = route_obj
+            await send({"type": "http.response.start", "status": 200})
+            await send({"type": "http.response.body", "body": b"ok"})
+
+        middleware = ServiceEventsFastAPIMiddleware(mock_app)
+        # Raw path as the client hit it — no "route" key yet at entry.
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/users/42",
+            "headers": [],
+            "query_string": b"",
+        }
+
+        await middleware(scope, AsyncMock(), AsyncMock())
+
+        call_kwargs = mock_ec.record_request.call_args[1]
+        self.assertEqual(call_kwargs["route"], "/users/{id}")
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.clear_current_operation")
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.set_current_operation")
+    async def test_route_template_used_on_exception_path(self, mock_set_op, mock_clear_op):
+        """Even when the view raises, the re-resolved template is used for telemetry."""
+        mock_ec = MagicMock()
+        fastapi_mod._endpoint_collector = mock_ec
+
+        route_obj = MagicMock()
+        route_obj.path = "/boom/{id}"
+
+        async def mock_app(scope, receive, send):
+            scope["route"] = route_obj  # routing resolved before the handler raised
+            raise RuntimeError("app crashed")
+
+        middleware = ServiceEventsFastAPIMiddleware(mock_app)
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/boom/7",
+            "headers": [],
+            "query_string": b"",
+        }
+
+        with self.assertRaises(RuntimeError):
+            await middleware(scope, AsyncMock(), AsyncMock())
+
+        call_kwargs = mock_ec.record_request.call_args[1]
+        self.assertEqual(call_kwargs["route"], "/boom/{id}")
+        self.assertEqual(call_kwargs["status_code"], 500)
+
+
+class TestFastAPIMiddlewareTraceFallback(unittest.IsolatedAsyncioTestCase):
+    """On the exception path, http.response.start never fires, so send_wrapper never
+    captures trace correlation. The finally recovers it from the active OTel span so
+    IncidentSnapshot stays joinable on the error path.
+    """
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+        fastapi_mod._endpoint_collector = None
+        fastapi_mod._incident_snapshot_collector = None
+        fastapi_mod._serviceevents_config = None
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.clear_current_operation")
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.set_current_operation")
+    async def test_trace_recovered_from_active_span_on_exception(self, mock_set_op, mock_clear_op):
+        """When the app raises before responding, trace_id/span_id come from the live span."""
+        mock_isc = MagicMock()
+        fastapi_mod._incident_snapshot_collector = mock_isc
+
+        async def mock_app(scope, receive, send):
+            # No http.response.start — exception before any response is sent.
+            raise RuntimeError("app crashed")
+
+        middleware = ServiceEventsFastAPIMiddleware(mock_app)
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/api/broken",
+            "headers": [],
+            "query_string": b"",
+        }
+
+        # A valid span still active in the finally block (OTel-outer nesting).
+        mock_span = MagicMock()
+        span_ctx = MagicMock()
+        span_ctx.is_valid = True
+        span_ctx.trace_id = 0x0123456789ABCDEF0123456789ABCDEF
+        span_ctx.span_id = 0x0123456789ABCDEF
+        mock_span.get_span_context.return_value = span_ctx
+
+        with patch("opentelemetry.trace.get_current_span", return_value=mock_span):
+            with self.assertRaises(RuntimeError):
+                await middleware(scope, AsyncMock(), AsyncMock())
+
+        call_kwargs = mock_isc.process_potential_incident.call_args[1]
+        req_data = call_kwargs["request_data"]
+        self.assertEqual(req_data["trace_id"], 0x0123456789ABCDEF0123456789ABCDEF)
+        self.assertEqual(req_data["span_id"], 0x0123456789ABCDEF)
+
+
+class TestFastAPIMiddlewareCrashSafety(unittest.IsolatedAsyncioTestCase):
+    """The middleware must never stop a request when telemetry setup fails."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+        fastapi_mod._endpoint_collector = None
+        fastapi_mod._incident_snapshot_collector = None
+        fastapi_mod._serviceevents_config = None
+
+    @patch(
+        "amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.set_current_operation",
+        side_effect=RuntimeError("telemetry exploded"),
+    )
+    async def test_pre_await_failure_still_dispatches_app(self, _mock_set_op):
+        """If pre-await telemetry setup raises, the app must still be invoked and served."""
+        app_called = False
+
+        async def mock_app(scope, receive, send):
+            nonlocal app_called
+            app_called = True
+            await send({"type": "http.response.start", "status": 200})
+            await send({"type": "http.response.body", "body": b"ok"})
+
+        middleware = ServiceEventsFastAPIMiddleware(mock_app)
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/api/users",
+            "headers": [],
+            "query_string": b"",
+        }
+
+        sent = []
+
+        async def mock_send(msg):
+            sent.append(msg)
+
+        # Must not raise; the app must still run.
+        await middleware(scope, AsyncMock(), mock_send)
+        self.assertTrue(app_called)
+        self.assertEqual(sent[0]["status"], 200)
+
+
+class TestFastAPIMiddlewareErrorBranches(unittest.IsolatedAsyncioTestCase):
+    """Telemetry failures inside the request lifecycle must be swallowed, never raised."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+        fastapi_mod._endpoint_collector = None
+        fastapi_mod._incident_snapshot_collector = None
+        fastapi_mod._serviceevents_config = None
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.clear_current_operation")
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.set_current_operation")
+    async def test_receive_wrapper_swallows_caching_error(self, mock_set_op, mock_clear_op):
+        """A malformed receive message must still be returned despite a caching failure."""
+        mock_isc = MagicMock()
+        fastapi_mod._incident_snapshot_collector = mock_isc
+
+        # An object whose __getitem__ raises, so message["type"] inside the try blows up.
+        class BadMessage:
+            def __getitem__(self, key):
+                raise KeyError("no type")
+
+        bad_message = BadMessage()
+
+        received = []
+
+        async def mock_app(scope, receive, send):
+            received.append(await receive())
+            await send({"type": "http.response.start", "status": 200})
+            await send({"type": "http.response.body", "body": b"ok"})
+
+        async def mock_receive():
+            return bad_message
+
+        middleware = ServiceEventsFastAPIMiddleware(mock_app)
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/api/users",
+            "headers": [],
+            "query_string": b"",
+        }
+
+        await middleware(scope, mock_receive, AsyncMock())
+
+        # The original message is returned to the app unchanged.
+        self.assertIs(received[0], bad_message)
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.clear_current_operation")
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.set_current_operation")
+    async def test_send_wrapper_captures_trace_on_success(self, mock_set_op, mock_clear_op):
+        """A valid active span at http.response.start populates trace correlation."""
+        mock_isc = MagicMock()
+        fastapi_mod._incident_snapshot_collector = mock_isc
+
+        async def mock_app(scope, receive, send):
+            await send({"type": "http.response.start", "status": 500})
+            await send({"type": "http.response.body", "body": b"err"})
+
+        middleware = ServiceEventsFastAPIMiddleware(mock_app)
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/api/users",
+            "headers": [],
+            "query_string": b"",
+        }
+
+        mock_span = MagicMock()
+        span_ctx = MagicMock()
+        span_ctx.is_valid = True
+        span_ctx.trace_id = 0xAABBCCDDEEFF00112233445566778899
+        span_ctx.span_id = 0xAABBCCDDEEFF0011
+        mock_span.get_span_context.return_value = span_ctx
+
+        with patch("opentelemetry.trace.get_current_span", return_value=mock_span):
+            await middleware(scope, AsyncMock(), AsyncMock())
+
+        req_data = mock_isc.process_potential_incident.call_args[1]["request_data"]
+        self.assertEqual(req_data["trace_id"], 0xAABBCCDDEEFF00112233445566778899)
+        self.assertEqual(req_data["span_id"], 0xAABBCCDDEEFF0011)
+
+    @patch.object(fastapi_mod, "_extract_error_from_call_path")
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.clear_current_operation")
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.set_current_operation")
+    async def test_error_info_extraction_failure_swallowed(self, mock_set_op, mock_clear_op, mock_extract):
+        """A failure extracting error info on a 4xx/5xx must not break the request."""
+        mock_extract.side_effect = RuntimeError("extract exploded")
+        mock_ec = MagicMock()
+        fastapi_mod._endpoint_collector = mock_ec
+
+        async def mock_app(scope, receive, send):
+            await send({"type": "http.response.start", "status": 500})
+            await send({"type": "http.response.body", "body": b"err"})
+
+        middleware = ServiceEventsFastAPIMiddleware(mock_app)
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/api/fail",
+            "headers": [],
+            "query_string": b"",
+        }
+
+        await middleware(scope, AsyncMock(), AsyncMock())
+
+        # error_info stays None because extraction failed, but the metric is still recorded.
+        ec_kwargs = mock_ec.record_request.call_args[1]
+        self.assertIsNone(ec_kwargs["error_info"])
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.clear_current_operation")
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.set_current_operation")
+    async def test_record_request_failure_swallowed(self, mock_set_op, mock_clear_op):
+        """An exception from record_request is logged, not propagated."""
+        mock_ec = MagicMock()
+        mock_ec.record_request.side_effect = RuntimeError("collector exploded")
+        fastapi_mod._endpoint_collector = mock_ec
+
+        async def mock_app(scope, receive, send):
+            await send({"type": "http.response.start", "status": 200})
+            await send({"type": "http.response.body", "body": b"ok"})
+
+        middleware = ServiceEventsFastAPIMiddleware(mock_app)
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/api/users",
+            "headers": [],
+            "query_string": b"",
+        }
+
+        # Must not raise.
+        await middleware(scope, AsyncMock(), AsyncMock())
+        mock_ec.record_request.assert_called_once()
+        mock_clear_op.assert_called_once()
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.clear_current_operation")
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation.set_current_operation")
+    async def test_process_incident_failure_swallowed(self, mock_set_op, mock_clear_op):
+        """An exception from process_potential_incident is logged, not propagated."""
+        mock_isc = MagicMock()
+        mock_isc.process_potential_incident.side_effect = RuntimeError("incident exploded")
+        fastapi_mod._incident_snapshot_collector = mock_isc
+
+        async def mock_app(scope, receive, send):
+            await send({"type": "http.response.start", "status": 500})
+            await send({"type": "http.response.body", "body": b"err"})
+
+        middleware = ServiceEventsFastAPIMiddleware(mock_app)
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/api/users",
+            "headers": [],
+            "query_string": b"",
+        }
+
+        # Must not raise.
+        await middleware(scope, AsyncMock(), AsyncMock())
+        mock_isc.process_potential_incident.assert_called_once()
+        mock_clear_op.assert_called_once()

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/instrumentation/test_flask_instrumentation.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/instrumentation/test_flask_instrumentation.py
@@ -1,0 +1,911 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest import TestCase
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation as flask_mod
+from amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation import (
+    _after_request_hook,
+    _before_request_hook,
+    _capture_active_trace_context,
+    _extract_error_from_call_path,
+    _get_request_body,
+    _get_route_pattern,
+    _teardown_request_hook,
+    install_flask_hooks,
+)
+from amazon.opentelemetry.distro.serviceevents.python_monitor import _ServiceEventsMonitorState
+
+
+class TestGetRoutePattern(TestCase):
+    """Tests for _get_route_pattern."""
+
+    def test_get_route_pattern_from_url_rule(self):
+        """url_rule.rule is returned when available."""
+        request = MagicMock()
+        request.url_rule = MagicMock()
+        request.url_rule.rule = "/users/<int:id>"
+        result = _get_route_pattern(request)
+        self.assertEqual(result, "/users/<int:id>")
+
+    def test_get_route_pattern_from_endpoint(self):
+        """Falls back to endpoint name when url_rule is None."""
+        request = MagicMock()
+        request.url_rule = None
+        request.endpoint = "user_detail"
+        result = _get_route_pattern(request)
+        self.assertEqual(result, "/user_detail")
+
+    def test_get_route_pattern_from_path(self):
+        """Falls back to path when both url_rule and endpoint are None."""
+        request = MagicMock()
+        request.url_rule = None
+        request.endpoint = None
+        request.path = "/users/42"
+        result = _get_route_pattern(request)
+        self.assertEqual(result, "/users/42")
+
+
+class TestGetRequestBody(TestCase):
+    """Tests for _get_request_body."""
+
+    def test_get_request_body_json(self):
+        """Returns parsed JSON when get_json succeeds."""
+        request = MagicMock()
+        request.get_json.return_value = {"key": "value"}
+        result = _get_request_body(request)
+        self.assertEqual(result, {"key": "value"})
+
+    def test_get_request_body_form(self):
+        """Returns form dict when JSON fails but form data exists."""
+        request = MagicMock()
+        request.get_json.return_value = None
+        form_data = MagicMock()
+        form_data.__bool__ = lambda self: True
+        form_data.to_dict.return_value = {"field": "data"}
+        request.form = form_data
+        result = _get_request_body(request)
+        self.assertEqual(result, {"field": "data"})
+
+    def test_get_request_body_raw(self):
+        """Returns raw data decoded as string when JSON and form fail."""
+        request = MagicMock()
+        request.get_json.return_value = None
+        request.form = MagicMock()
+        request.form.__bool__ = lambda self: False
+        request.get_data.return_value = b"raw body content"
+        result = _get_request_body(request)
+        self.assertEqual(result, "raw body content")
+
+    def test_get_request_body_none(self):
+        """Returns None when all extraction methods fail."""
+        request = MagicMock()
+        request.get_json.side_effect = Exception("no json")
+        request.form = MagicMock()
+        type(request.form).__bool__ = PropertyMock(side_effect=Exception("no form"))
+        request.get_data.side_effect = Exception("no data")
+        result = _get_request_body(request)
+        self.assertIsNone(result)
+
+    def test_get_request_body_large_payload(self):
+        """Returns truncation message for payloads over 10KB."""
+        request = MagicMock()
+        request.get_json.return_value = None
+        request.form = MagicMock()
+        request.form.__bool__ = lambda self: False
+        large_data = b"x" * 20000
+        request.get_data.return_value = large_data
+        result = _get_request_body(request)
+        self.assertIn("payload too large", result)
+        self.assertIn("20000", result)
+
+
+class TestExtractErrorFromCallPath(TestCase):
+    """Tests for _extract_error_from_call_path."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+
+    def test_extract_error_with_exception(self):
+        """Exception type name is extracted from the exception object."""
+        state = _ServiceEventsMonitorState.get_instance()
+        state.begin_investigation()
+
+        exc = ValueError("test error")
+        result = _extract_error_from_call_path(exc, "/api/test", "GET")
+
+        self.assertEqual(result["error_type"], "ValueError")
+
+    def test_extract_error_with_call_path(self):
+        """function_name is extracted from investigation call_path."""
+        _state = _ServiceEventsMonitorState.get_instance()
+        _state.begin_investigation()
+        # Directly set call_path data
+        inv_data = _state._investigation_data.get()
+        inv_data["call_path"] = [{"function_name": "my_func_123"}]
+
+        exc = RuntimeError("fail")
+        result = _extract_error_from_call_path(exc, "/api/test", "POST")
+
+        self.assertEqual(result["error_type"], "RuntimeError")
+        self.assertEqual(result["function_name"], "my_func_123")
+
+    def test_extract_error_no_investigation_data(self):
+        """Returns default values when no investigation data exists."""
+        _ServiceEventsMonitorState.get_instance()
+        # No begin_investigation call, so no inv data
+
+        result = _extract_error_from_call_path(None, "/api/test", "GET")
+
+        self.assertEqual(result["error_type"], "UnknownError")
+        self.assertEqual(result["function_name"], "unknown")
+
+    def test_extract_error_prefers_captured_exception_origin(self):
+        """The function the monitor recorded as the thrower wins over call_path[0]."""
+        state = _ServiceEventsMonitorState.get_instance()
+        state.begin_investigation()
+        inv_data = state._investigation_data.get()
+        # call_path[0] is a sibling that did NOT throw; the exception origin is deeper.
+        inv_data["call_path"] = [{"function_name": "sibling_func"}, {"function_name": "thrower_func"}]
+        inv_data["exception"] = {"name": "ValueError", "function_name": "thrower_func"}
+
+        result = _extract_error_from_call_path(ValueError("boom"), "/api/test", "GET")
+
+        self.assertEqual(result["error_type"], "ValueError")
+        self.assertEqual(result["function_name"], "thrower_func")
+
+    def test_extract_error_recovers_type_when_exception_arg_is_none(self):
+        """FastAPI global-handler case: exception arg is None but the monitor captured the
+        real error — recover its type instead of mislabeling it UnknownError."""
+        state = _ServiceEventsMonitorState.get_instance()
+        state.begin_investigation()
+        inv_data = state._investigation_data.get()
+        inv_data["exception"] = {"name": "KeyError", "function_name": "handler_func"}
+
+        result = _extract_error_from_call_path(None, "/api/test", "GET")
+
+        self.assertEqual(result["error_type"], "KeyError")
+        self.assertEqual(result["function_name"], "handler_func")
+
+
+class TestInstallFlaskHooks(TestCase):
+    """Tests for install_flask_hooks."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+        flask_mod._endpoint_collector = None
+        flask_mod._incident_snapshot_collector = None
+        flask_mod._serviceevents_config = None
+
+    def test_install_flask_hooks_stores_collectors(self):
+        """Module globals are set after install_flask_hooks call."""
+        mock_ec = MagicMock()
+        mock_isc = MagicMock()
+        mock_cfg = MagicMock()
+
+        # Use a real class so __init__ can be patched
+        class FakeFlask:
+            def __init__(self, *args, **kwargs):
+                pass
+
+        mock_flask_module = MagicMock()
+        mock_flask_module.Flask = FakeFlask
+        mock_flask_module.g = MagicMock()
+        mock_flask_module.request = MagicMock()
+
+        with patch.dict("sys.modules", {"flask": mock_flask_module}):
+            install_flask_hooks(
+                endpoint_collector=mock_ec,
+                incident_snapshot_collector=mock_isc,
+                config=mock_cfg,
+            )
+
+        self.assertIs(flask_mod._endpoint_collector, mock_ec)
+        self.assertIs(flask_mod._incident_snapshot_collector, mock_isc)
+        self.assertIs(flask_mod._serviceevents_config, mock_cfg)
+
+    def test_install_flask_hooks_patches_flask_init(self):
+        """Flask.__init__ is replaced with instrumented version."""
+
+        class FakeFlask:
+            def __init__(self, *args, **kwargs):
+                pass
+
+        original_init = FakeFlask.__init__
+
+        mock_flask_module = MagicMock()
+        mock_flask_module.Flask = FakeFlask
+
+        with patch.dict("sys.modules", {"flask": mock_flask_module}):
+            install_flask_hooks()
+
+        # Flask.__init__ should have been replaced
+        self.assertIsNot(FakeFlask.__init__, original_init)
+
+    def test_install_flask_hooks_import_error(self):
+        """Gracefully handles missing Flask."""
+        # Remove flask from sys.modules and make import fail
+        import sys
+
+        saved = sys.modules.get("flask")
+        sys.modules["flask"] = None  # Force ImportError
+
+        try:
+            # Should not raise
+            flask_mod._endpoint_collector = None
+            install_flask_hooks(endpoint_collector=MagicMock())
+            # Collectors should remain None since Flask import failed
+            self.assertIsNone(flask_mod._endpoint_collector)
+        finally:
+            if saved is not None:
+                sys.modules["flask"] = saved
+            else:
+                sys.modules.pop("flask", None)
+
+    def test_instrumented_init_registers_hooks_on_app_creation(self):
+        """Creating a Flask app after install runs the wrapped __init__ and registers all hooks."""
+        init_calls = []
+
+        class FakeFlask:
+            def __init__(self, name, *args, **kwargs):
+                init_calls.append(name)
+                self.name = name
+                self.before_request = MagicMock()
+                self.after_request = MagicMock()
+                self.teardown_request = MagicMock()
+
+        mock_flask_module = MagicMock()
+        mock_flask_module.Flask = FakeFlask
+
+        with patch.dict("sys.modules", {"flask": mock_flask_module}):
+            install_flask_hooks()
+            # Instantiating now exercises instrumented_init (original init + hook registration).
+            app = FakeFlask("my_app")
+
+        self.assertEqual(init_calls, ["my_app"])  # original __init__ ran
+        app.before_request.assert_called_once_with(flask_mod._before_request_hook)
+        app.after_request.assert_called_once_with(flask_mod._after_request_hook)
+        app.teardown_request.assert_called_once_with(flask_mod._teardown_request_hook)
+
+
+class TestFlaskHookFunctions(TestCase):
+    """Tests for the Flask hook functions (_before_request_hook, _after_request_hook, _teardown_request_hook)."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+        flask_mod._endpoint_collector = None
+        flask_mod._incident_snapshot_collector = None
+        flask_mod._serviceevents_config = None
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation.set_current_operation")
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation.time")
+    def test_before_request_sets_operation_context(self, mock_time, mock_set_operation):
+        """Before request hook sets the operation via set_current_operation."""
+        mock_time.perf_counter_ns.return_value = 1000000000
+
+        mock_g = MagicMock()
+        mock_request = MagicMock()
+        mock_request.method = "GET"
+        mock_request.path = "/api/users"
+        mock_request.endpoint = "users_list"
+        mock_request.url_rule = MagicMock()
+        mock_request.url_rule.rule = "/api/users"
+
+        with patch(
+            "amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation.g", mock_g, create=True
+        ):
+            with patch(
+                "amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation.request",
+                mock_request,
+                create=True,
+            ):
+                # Need to patch the import inside the function
+                flask_mock = MagicMock()
+                flask_mock.g = mock_g
+                flask_mock.request = mock_request
+                with patch.dict("sys.modules", {"flask": flask_mock}):
+                    _before_request_hook()
+
+        mock_set_operation.assert_called_once()
+        # The operation should be "METHOD /route"
+        call_args = mock_set_operation.call_args[0][0]
+        self.assertEqual(call_args, "GET /api/users")
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation.time")
+    def test_after_request_calculates_duration(self, mock_time):
+        """After request hook calculates request duration and stores it."""
+        mock_time.perf_counter_ns.return_value = 1200000000
+
+        mock_g = MagicMock()
+        mock_g.serviceevents_skip = False
+        mock_g.serviceevents_start_time = 1000000000
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        flask_mock = MagicMock()
+        flask_mock.g = mock_g
+
+        with patch.dict("sys.modules", {"flask": flask_mock}):
+            result = _after_request_hook(mock_response)
+
+        self.assertIs(result, mock_response)
+        # Duration should be stored on g (~200ms)
+        self.assertAlmostEqual(mock_g.serviceevents_duration_ms, 200.0, places=1)
+        self.assertEqual(mock_g.serviceevents_status_code, 200)
+
+    def test_after_request_skips_if_filtered(self):
+        """After request hook returns response immediately if serviceevents_skip is True."""
+        mock_g = MagicMock()
+        mock_g.serviceevents_skip = True
+
+        mock_response = MagicMock()
+
+        flask_mock = MagicMock()
+        flask_mock.g = mock_g
+
+        with patch.dict("sys.modules", {"flask": flask_mock}):
+            result = _after_request_hook(mock_response)
+
+        self.assertIs(result, mock_response)
+        # Duration should NOT be set
+        self.assertFalse(
+            hasattr(mock_g, "serviceevents_duration_ms")
+            and mock_g.serviceevents_duration_ms is not mock_g.serviceevents_duration_ms
+        )
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation.clear_current_operation")
+    def test_teardown_records_endpoint_metric(self, mock_clear):
+        """Teardown hook calls endpoint_collector.record_request."""
+        mock_ec = MagicMock()
+        flask_mod._endpoint_collector = mock_ec
+
+        mock_g = MagicMock()
+        mock_g.serviceevents_skip = False
+        mock_g.serviceevents_start_time = 1000000000
+        mock_g.serviceevents_duration_ms = 150.0
+        mock_g.serviceevents_status_code = 200
+        mock_g.serviceevents_route = "/api/users"
+        mock_g.serviceevents_method = "GET"
+        mock_g.serviceevents_path = "/api/users"
+        mock_g.serviceevents_endpoint = "users_list"
+        # Ensure hasattr returns False for serviceevents_incident_processed
+        del mock_g.serviceevents_incident_processed
+
+        mock_request = MagicMock()
+        mock_request.headers = {}
+        mock_request.args = {}
+        mock_request.view_args = {}
+
+        flask_mock = MagicMock()
+        flask_mock.g = mock_g
+        flask_mock.request = mock_request
+
+        with patch.dict("sys.modules", {"flask": flask_mock}):
+            _teardown_request_hook(exception=None)
+
+        mock_ec.record_request.assert_called_once()
+        call_kwargs = mock_ec.record_request.call_args[1]
+        self.assertEqual(call_kwargs["route"], "/api/users")
+        self.assertEqual(call_kwargs["method"], "GET")
+        self.assertEqual(call_kwargs["status_code"], 200)
+        self.assertIsNone(call_kwargs["error_info"])
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation.clear_current_operation")
+    def test_teardown_processes_incident_on_error(self, mock_clear):
+        """Teardown hook triggers incident processing on 500 status."""
+        mock_ec = MagicMock()
+        mock_isc = MagicMock()
+        flask_mod._endpoint_collector = mock_ec
+        flask_mod._incident_snapshot_collector = mock_isc
+
+        mock_g = MagicMock()
+        mock_g.serviceevents_skip = False
+        mock_g.serviceevents_start_time = 1000000000
+        mock_g.serviceevents_duration_ms = 50.0
+        mock_g.serviceevents_status_code = 500
+        mock_g.serviceevents_route = "/api/orders"
+        mock_g.serviceevents_method = "POST"
+        mock_g.serviceevents_path = "/api/orders"
+        mock_g.serviceevents_endpoint = "create_order"
+        del mock_g.serviceevents_incident_processed
+
+        mock_request = MagicMock()
+        mock_request.headers = {}
+        mock_request.args = {}
+        mock_request.view_args = {}
+
+        flask_mock = MagicMock()
+        flask_mock.g = mock_g
+        flask_mock.request = mock_request
+
+        exc = RuntimeError("DB connection failed")
+
+        with patch.dict("sys.modules", {"flask": flask_mock}):
+            _teardown_request_hook(exception=exc)
+
+        # Incident collector should be called
+        mock_isc.process_potential_incident.assert_called_once()
+        call_kwargs = mock_isc.process_potential_incident.call_args[1]
+        self.assertEqual(call_kwargs["status_code"], 500)
+        self.assertIs(call_kwargs["exception"], exc)
+
+        # Error info should be passed to endpoint collector
+        ec_kwargs = mock_ec.record_request.call_args[1]
+        self.assertIsNotNone(ec_kwargs["error_info"])
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation.clear_current_operation")
+    def test_teardown_clears_operation(self, mock_clear):
+        """Teardown always calls clear_current_operation, even on error."""
+        mock_g = MagicMock()
+        mock_g.serviceevents_skip = False
+        mock_g.serviceevents_start_time = 1000000000
+        mock_g.serviceevents_duration_ms = 10.0
+        mock_g.serviceevents_status_code = 200
+        mock_g.serviceevents_route = "/api/test"
+        mock_g.serviceevents_method = "GET"
+        mock_g.serviceevents_path = "/api/test"
+        mock_g.serviceevents_endpoint = "test"
+        del mock_g.serviceevents_incident_processed
+
+        mock_request = MagicMock()
+        mock_request.headers = {}
+        mock_request.args = {}
+        mock_request.view_args = {}
+
+        flask_mock = MagicMock()
+        flask_mock.g = mock_g
+        flask_mock.request = mock_request
+
+        with patch.dict("sys.modules", {"flask": flask_mock}):
+            _teardown_request_hook(exception=None)
+
+        mock_clear.assert_called_once()
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation.clear_current_operation")
+    def test_teardown_clears_operation_on_exception(self, mock_clear):
+        """clear_current_operation is called even when endpoint_collector raises."""
+        mock_ec = MagicMock()
+        mock_ec.record_request.side_effect = Exception("collector error")
+        flask_mod._endpoint_collector = mock_ec
+
+        mock_g = MagicMock()
+        mock_g.serviceevents_skip = False
+        mock_g.serviceevents_start_time = 1000000000
+        mock_g.serviceevents_duration_ms = 10.0
+        mock_g.serviceevents_status_code = 200
+        mock_g.serviceevents_route = "/api/test"
+        mock_g.serviceevents_method = "GET"
+        mock_g.serviceevents_path = "/api/test"
+        mock_g.serviceevents_endpoint = "test"
+        del mock_g.serviceevents_incident_processed
+
+        mock_request = MagicMock()
+        mock_request.headers = {}
+        mock_request.args = {}
+        mock_request.view_args = {}
+
+        flask_mock = MagicMock()
+        flask_mock.g = mock_g
+        flask_mock.request = mock_request
+
+        with patch.dict("sys.modules", {"flask": flask_mock}):
+            # Should not raise, error is logged internally
+            _teardown_request_hook(exception=None)
+
+        mock_clear.assert_called_once()
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation.clear_current_operation")
+    def test_teardown_skips_if_filtered(self, mock_clear):
+        """Teardown skips processing when g.serviceevents_skip is True."""
+        mock_g = MagicMock()
+        mock_g.serviceevents_skip = True
+
+        flask_mock = MagicMock()
+        flask_mock.g = mock_g
+        flask_mock.request = MagicMock()
+
+        mock_ec = MagicMock()
+        flask_mod._endpoint_collector = mock_ec
+
+        with patch.dict("sys.modules", {"flask": flask_mock}):
+            _teardown_request_hook(exception=None)
+
+        # Should NOT call record_request
+        mock_ec.record_request.assert_not_called()
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation.clear_current_operation")
+    def test_teardown_infers_500_from_exception(self, mock_clear):
+        """When status_code is not set but exception exists, status 500 is inferred."""
+        mock_ec = MagicMock()
+        flask_mod._endpoint_collector = mock_ec
+
+        mock_g = MagicMock()
+        mock_g.serviceevents_skip = False
+        mock_g.serviceevents_start_time = 1000000000
+        # No serviceevents_duration_ms set, so it should calculate
+        del mock_g.serviceevents_duration_ms
+        # No serviceevents_status_code set, so it should infer from exception
+        del mock_g.serviceevents_status_code
+        mock_g.serviceevents_route = "/api/error"
+        mock_g.serviceevents_method = "GET"
+        mock_g.serviceevents_path = "/api/error"
+        mock_g.serviceevents_endpoint = "error_endpoint"
+        del mock_g.serviceevents_incident_processed
+
+        mock_request = MagicMock()
+        mock_request.headers = {}
+        mock_request.args = {}
+        mock_request.view_args = {}
+
+        flask_mock = MagicMock()
+        flask_mock.g = mock_g
+        flask_mock.request = mock_request
+
+        exc = ValueError("bad input")
+
+        with patch("amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation.time") as mock_time:
+            mock_time.perf_counter_ns.return_value = 1050000000
+            with patch.dict("sys.modules", {"flask": flask_mock}):
+                _teardown_request_hook(exception=exc)
+
+        ec_kwargs = mock_ec.record_request.call_args[1]
+        self.assertEqual(ec_kwargs["status_code"], 500)
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation.set_current_operation")
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation.time")
+    def test_before_request_skips_filtered_endpoint(self, mock_time, mock_set_operation):
+        """When config filters out the endpoint, the hook marks skip and stops early."""
+        mock_cfg = MagicMock()
+        mock_cfg.should_track_endpoint.return_value = False
+        flask_mod._serviceevents_config = mock_cfg
+
+        mock_g = MagicMock()
+        mock_request = MagicMock()
+        mock_request.method = "GET"
+        mock_request.path = "/health"
+        mock_request.endpoint = "health"
+        mock_request.url_rule = MagicMock()
+        mock_request.url_rule.rule = "/health"
+
+        flask_mock = MagicMock()
+        flask_mock.g = mock_g
+        flask_mock.request = mock_request
+
+        with patch.dict("sys.modules", {"flask": flask_mock}):
+            _before_request_hook()
+
+        self.assertTrue(mock_g.serviceevents_skip)
+        # Early return: operation context is never established for filtered endpoints.
+        mock_set_operation.assert_not_called()
+        mock_time.perf_counter_ns.assert_not_called()
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation.time")
+    def test_after_request_captures_trace_context(self, mock_time):
+        """After request stores trace_id/span_id when an active span is present."""
+        mock_time.perf_counter_ns.return_value = 1100000000
+
+        mock_g = MagicMock()
+        mock_g.serviceevents_skip = False
+        mock_g.serviceevents_start_time = 1000000000
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        flask_mock = MagicMock()
+        flask_mock.g = mock_g
+
+        mock_span = MagicMock()
+        span_ctx = MagicMock()
+        span_ctx.is_valid = True
+        span_ctx.trace_id = 0xABCD
+        span_ctx.span_id = 0x1234
+        mock_span.get_span_context.return_value = span_ctx
+
+        with patch("opentelemetry.trace.get_current_span", return_value=mock_span):
+            with patch.dict("sys.modules", {"flask": flask_mock}):
+                result = _after_request_hook(mock_response)
+
+        self.assertIs(result, mock_response)
+        self.assertEqual(mock_g.serviceevents_trace_id, 0xABCD)
+        self.assertEqual(mock_g.serviceevents_span_id, 0x1234)
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation.clear_current_operation")
+    def test_teardown_returns_when_no_start_time(self, mock_clear):
+        """Teardown returns early (after clearing) when start_time was never recorded."""
+        mock_ec = MagicMock()
+        flask_mod._endpoint_collector = mock_ec
+
+        mock_g = MagicMock()
+        mock_g.serviceevents_skip = False
+        del mock_g.serviceevents_start_time  # never set (e.g. before_request bailed)
+
+        flask_mock = MagicMock()
+        flask_mock.g = mock_g
+        flask_mock.request = MagicMock()
+
+        with patch.dict("sys.modules", {"flask": flask_mock}):
+            _teardown_request_hook(exception=None)
+
+        mock_ec.record_request.assert_not_called()
+        mock_clear.assert_called_once()
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation.clear_current_operation")
+    def test_teardown_returns_when_incident_already_processed(self, mock_clear):
+        """A second teardown call is a no-op once the incident has been processed."""
+        mock_ec = MagicMock()
+        flask_mod._endpoint_collector = mock_ec
+
+        mock_g = MagicMock()
+        mock_g.serviceevents_skip = False
+        mock_g.serviceevents_start_time = 1000000000
+        mock_g.serviceevents_incident_processed = True  # already handled
+
+        flask_mock = MagicMock()
+        flask_mock.g = mock_g
+        flask_mock.request = MagicMock()
+
+        with patch.dict("sys.modules", {"flask": flask_mock}):
+            _teardown_request_hook(exception=None)
+
+        mock_ec.record_request.assert_not_called()
+        mock_clear.assert_called_once()
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation.clear_current_operation")
+    def test_teardown_defaults_status_to_200_without_exception(self, mock_clear):
+        """When no status was captured and there is no exception, status defaults to 200."""
+        mock_ec = MagicMock()
+        flask_mod._endpoint_collector = mock_ec
+
+        mock_g = MagicMock()
+        mock_g.serviceevents_skip = False
+        mock_g.serviceevents_start_time = 1000000000
+        mock_g.serviceevents_duration_ms = 5.0
+        del mock_g.serviceevents_status_code  # never captured in after_request
+        mock_g.serviceevents_route = "/api/ok"
+        mock_g.serviceevents_method = "GET"
+        mock_g.serviceevents_path = "/api/ok"
+        mock_g.serviceevents_endpoint = "ok"
+        del mock_g.serviceevents_incident_processed
+
+        mock_request = MagicMock()
+        mock_request.headers = {}
+        mock_request.args = {}
+        mock_request.view_args = {}
+
+        flask_mock = MagicMock()
+        flask_mock.g = mock_g
+        flask_mock.request = mock_request
+
+        with patch.dict("sys.modules", {"flask": flask_mock}):
+            _teardown_request_hook(exception=None)
+
+        ec_kwargs = mock_ec.record_request.call_args[1]
+        self.assertEqual(ec_kwargs["status_code"], 200)
+        self.assertIsNone(ec_kwargs["error_info"])
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation.clear_current_operation")
+    def test_teardown_swallows_incident_collector_error(self, mock_clear):
+        """An exception from the incident collector is logged, not propagated."""
+        mock_isc = MagicMock()
+        mock_isc.process_potential_incident.side_effect = RuntimeError("snapshot boom")
+        flask_mod._incident_snapshot_collector = mock_isc
+
+        mock_g = MagicMock()
+        mock_g.serviceevents_skip = False
+        mock_g.serviceevents_start_time = 1000000000
+        mock_g.serviceevents_duration_ms = 5.0
+        mock_g.serviceevents_status_code = 200
+        mock_g.serviceevents_route = "/api/ok"
+        mock_g.serviceevents_method = "GET"
+        mock_g.serviceevents_path = "/api/ok"
+        mock_g.serviceevents_endpoint = "ok"
+        del mock_g.serviceevents_incident_processed
+
+        mock_request = MagicMock()
+        mock_request.headers = {}
+        mock_request.args = {}
+        mock_request.view_args = {}
+
+        flask_mock = MagicMock()
+        flask_mock.g = mock_g
+        flask_mock.request = mock_request
+
+        with patch.dict("sys.modules", {"flask": flask_mock}):
+            # Should not raise even though the collector blows up.
+            _teardown_request_hook(exception=None)
+
+        mock_isc.process_potential_incident.assert_called_once()
+        mock_clear.assert_called_once()
+
+
+class TestFlaskTeardownTraceFallback(TestCase):
+    """When Flask skips after_request (unhandled exception with PROPAGATE_EXCEPTIONS=True),
+    teardown recovers trace correlation from the still-active OTel span so IncidentSnapshot
+    stays joinable on the error path.
+    """
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+        flask_mod._endpoint_collector = None
+        flask_mod._incident_snapshot_collector = None
+        flask_mod._serviceevents_config = None
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation.clear_current_operation")
+    def test_teardown_recovers_trace_when_after_request_skipped(self, mock_clear):
+        """trace_id/span_id come from the active span when not pre-captured in after_request."""
+        mock_isc = MagicMock()
+        flask_mod._incident_snapshot_collector = mock_isc
+
+        # g has no serviceevents_trace_id — after_request was skipped on the error path.
+        mock_g = MagicMock()
+        mock_g.serviceevents_skip = False
+        mock_g.serviceevents_start_time = 1000000000
+        mock_g.serviceevents_duration_ms = 12.0
+        mock_g.serviceevents_route = "/api/orders"
+        mock_g.serviceevents_method = "POST"
+        mock_g.serviceevents_path = "/api/orders"
+        mock_g.serviceevents_endpoint = "create_order"
+        del mock_g.serviceevents_status_code  # infer 500 from exception
+        del mock_g.serviceevents_incident_processed
+        del mock_g.serviceevents_trace_id  # not pre-captured
+        del mock_g.serviceevents_span_id
+
+        mock_request = MagicMock()
+        mock_request.headers = {}
+        mock_request.args = {}
+        mock_request.view_args = {}
+
+        flask_mock = MagicMock()
+        flask_mock.g = mock_g
+        flask_mock.request = mock_request
+
+        mock_span = MagicMock()
+        span_ctx = MagicMock()
+        span_ctx.is_valid = True
+        span_ctx.trace_id = 0x0123456789ABCDEF0123456789ABCDEF
+        span_ctx.span_id = 0x0123456789ABCDEF
+        mock_span.get_span_context.return_value = span_ctx
+
+        exc = ValueError("boom")
+        with patch("opentelemetry.trace.get_current_span", return_value=mock_span):
+            with patch.dict("sys.modules", {"flask": flask_mock}):
+                _teardown_request_hook(exception=exc)
+
+        call_kwargs = mock_isc.process_potential_incident.call_args[1]
+        req_data = call_kwargs["request_data"]
+        self.assertEqual(req_data["trace_id"], 0x0123456789ABCDEF0123456789ABCDEF)
+        self.assertEqual(req_data["span_id"], 0x0123456789ABCDEF)
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation.clear_current_operation")
+    def test_teardown_keeps_precaptured_trace_from_after_request(self, mock_clear):
+        """When after_request already captured trace correlation, teardown leaves it intact."""
+        mock_isc = MagicMock()
+        flask_mod._incident_snapshot_collector = mock_isc
+
+        mock_g = MagicMock()
+        mock_g.serviceevents_skip = False
+        mock_g.serviceevents_start_time = 1000000000
+        mock_g.serviceevents_duration_ms = 12.0
+        mock_g.serviceevents_status_code = 200
+        mock_g.serviceevents_route = "/api/orders"
+        mock_g.serviceevents_method = "GET"
+        mock_g.serviceevents_path = "/api/orders"
+        mock_g.serviceevents_endpoint = "list_orders"
+        del mock_g.serviceevents_incident_processed
+        # Pre-captured in after_request (success path).
+        mock_g.serviceevents_trace_id = 0xAAAA
+        mock_g.serviceevents_span_id = 0xBBBB
+
+        mock_request = MagicMock()
+        mock_request.headers = {}
+        mock_request.args = {}
+        mock_request.view_args = {}
+
+        flask_mock = MagicMock()
+        flask_mock.g = mock_g
+        flask_mock.request = mock_request
+
+        # If the fallback wrongly fired it would overwrite with this span; assert it does NOT.
+        mock_span = MagicMock()
+        span_ctx = MagicMock()
+        span_ctx.is_valid = True
+        span_ctx.trace_id = 0x9999
+        span_ctx.span_id = 0x8888
+        mock_span.get_span_context.return_value = span_ctx
+
+        with patch("opentelemetry.trace.get_current_span", return_value=mock_span):
+            with patch.dict("sys.modules", {"flask": flask_mock}):
+                _teardown_request_hook(exception=None)
+
+        call_kwargs = mock_isc.process_potential_incident.call_args[1]
+        req_data = call_kwargs["request_data"]
+        self.assertEqual(req_data["trace_id"], 0xAAAA)
+        self.assertEqual(req_data["span_id"], 0xBBBB)
+
+
+class TestCaptureActiveTraceContext(TestCase):
+    """Tests for _capture_active_trace_context."""
+
+    def test_returns_ids_for_valid_span(self):
+        """Returns (trace_id, span_id) when an active, valid span exists."""
+        mock_span = MagicMock()
+        span_ctx = MagicMock()
+        span_ctx.is_valid = True
+        span_ctx.trace_id = 0xDEAD
+        span_ctx.span_id = 0xBEEF
+        mock_span.get_span_context.return_value = span_ctx
+
+        with patch("opentelemetry.trace.get_current_span", return_value=mock_span):
+            trace_id, span_id = _capture_active_trace_context()
+
+        self.assertEqual(trace_id, 0xDEAD)
+        self.assertEqual(span_id, 0xBEEF)
+
+    def test_returns_none_when_span_context_invalid(self):
+        """Returns (None, None) when the span context is not valid."""
+        mock_span = MagicMock()
+        span_ctx = MagicMock()
+        span_ctx.is_valid = False
+        mock_span.get_span_context.return_value = span_ctx
+
+        with patch("opentelemetry.trace.get_current_span", return_value=mock_span):
+            self.assertEqual(_capture_active_trace_context(), (None, None))
+
+    def test_returns_none_when_otel_raises(self):
+        """A failure in the OTel API is swallowed and yields (None, None)."""
+        with patch("opentelemetry.trace.get_current_span", side_effect=RuntimeError("otel down")):
+            self.assertEqual(_capture_active_trace_context(), (None, None))
+
+
+class TestFlaskHookCrashSafety(TestCase):
+    """Request-thread hooks must never turn a telemetry failure into a 500."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+        flask_mod._endpoint_collector = None
+        flask_mod._incident_snapshot_collector = None
+        flask_mod._serviceevents_config = None
+
+    @patch(
+        "amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation.set_current_operation",
+        side_effect=RuntimeError("telemetry exploded"),
+    )
+    def test_before_request_swallows_telemetry_failure(self, _mock_set_op):
+        """A failure inside before_request must not propagate (would become a 500)."""
+        mock_g = MagicMock()
+        mock_request = MagicMock()
+        mock_request.method = "GET"
+        mock_request.path = "/api/users"
+        mock_request.endpoint = "users_list"
+        mock_request.url_rule = MagicMock()
+        mock_request.url_rule.rule = "/api/users"
+
+        flask_mock = MagicMock()
+        flask_mock.g = mock_g
+        flask_mock.request = mock_request
+
+        with patch.dict("sys.modules", {"flask": flask_mock}):
+            # Must return normally (None), not raise.
+            self.assertIsNone(_before_request_hook())
+
+    def test_after_request_returns_response_on_telemetry_failure(self):
+        """Even if telemetry fails, the customer's response must pass through unchanged."""
+        mock_g = MagicMock()
+        mock_g.serviceevents_skip = False
+        mock_g.serviceevents_start_time = 1000000000
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        flask_mock = MagicMock()
+        flask_mock.g = mock_g
+
+        # Make the duration math raise by having time.perf_counter_ns blow up.
+        with patch("amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation.time") as mock_time:
+            mock_time.perf_counter_ns.side_effect = RuntimeError("clock exploded")
+            with patch.dict("sys.modules", {"flask": flask_mock}):
+                result = _after_request_hook(mock_response)
+
+        self.assertIs(result, mock_response)

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/instrumentation/test_flask_instrumentation.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/instrumentation/test_flask_instrumentation.py
@@ -5,6 +5,7 @@ from unittest import TestCase
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation as flask_mod
+from amazon.opentelemetry.distro.serviceevents.instrumentation._constants import UNMATCHED_ROUTE
 from amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation import (
     _after_request_hook,
     _before_request_hook,
@@ -37,14 +38,16 @@ class TestGetRoutePattern(TestCase):
         result = _get_route_pattern(request)
         self.assertEqual(result, "/user_detail")
 
-    def test_get_route_pattern_from_path(self):
-        """Falls back to path when both url_rule and endpoint are None."""
+    def test_get_route_pattern_unmatched_uses_sentinel(self):
+        """Unmatched requests (no url_rule, no endpoint) collapse to the <unmatched>
+        sentinel instead of the raw path, to bound metric cardinality for scanner/bot
+        traffic. Parity with the Django/FastAPI instrumentation."""
         request = MagicMock()
         request.url_rule = None
         request.endpoint = None
-        request.path = "/users/42"
+        request.path = "/wp-admin/setup-config.php"
         result = _get_route_pattern(request)
-        self.assertEqual(result, "/users/42")
+        self.assertEqual(result, UNMATCHED_ROUTE)
 
 
 class TestGetRequestBody(TestCase):
@@ -268,6 +271,35 @@ class TestInstallFlaskHooks(TestCase):
         app.after_request.assert_called_once_with(flask_mod._after_request_hook)
         app.teardown_request.assert_called_once_with(flask_mod._teardown_request_hook)
 
+    def test_instrumented_init_swallows_hook_registration_failure(self):
+        """A failure while registering hooks must NOT break Flask app construction.
+
+        Telemetry must never crash the host app: if before_request/after_request/
+        teardown_request registration raises, instrumented_init swallows it and the
+        app is constructed as if uninstrumented (the original __init__ still ran).
+        """
+        init_calls = []
+
+        class FakeFlask:
+            def __init__(self, name, *args, **kwargs):
+                init_calls.append(name)
+                self.name = name
+                # before_request raises -> simulates a hook-registration failure.
+                self.before_request = MagicMock(side_effect=RuntimeError("registration boom"))
+                self.after_request = MagicMock()
+                self.teardown_request = MagicMock()
+
+        mock_flask_module = MagicMock()
+        mock_flask_module.Flask = FakeFlask
+
+        with patch.dict("sys.modules", {"flask": mock_flask_module}):
+            install_flask_hooks()
+            # Must not raise despite before_request blowing up inside instrumented_init.
+            app = FakeFlask("my_app")
+
+        self.assertEqual(init_calls, ["my_app"])  # original __init__ still ran
+        self.assertEqual(app.name, "my_app")  # app fully constructed/usable
+
 
 class TestFlaskHookFunctions(TestCase):
     """Tests for the Flask hook functions (_before_request_hook, _after_request_hook, _teardown_request_hook)."""
@@ -462,6 +494,43 @@ class TestFlaskHookFunctions(TestCase):
             _teardown_request_hook(exception=None)
 
         mock_clear.assert_called_once()
+
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation._ServiceEventsMonitorState")
+    @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation.clear_current_operation")
+    def test_teardown_clears_investigation_data_on_normal_path(self, _mock_clear, mock_state_cls):
+        """Teardown drops investigation data unconditionally (the non-incident leak fix).
+
+        On the normal path no incident is collected, so get_investigation_data() is never
+        called; teardown must still clear it so a stale dict (and any captured traceback)
+        does not linger on a pooled worker thread.
+        """
+        mock_state = MagicMock()
+        mock_state_cls.get_instance.return_value = mock_state
+
+        mock_g = MagicMock()
+        mock_g.serviceevents_skip = False
+        mock_g.serviceevents_start_time = 1000000000
+        mock_g.serviceevents_duration_ms = 10.0
+        mock_g.serviceevents_status_code = 200
+        mock_g.serviceevents_route = "/api/test"
+        mock_g.serviceevents_method = "GET"
+        mock_g.serviceevents_path = "/api/test"
+        mock_g.serviceevents_endpoint = "test"
+        del mock_g.serviceevents_incident_processed
+
+        mock_request = MagicMock()
+        mock_request.headers = {}
+        mock_request.args = {}
+        mock_request.view_args = {}
+
+        flask_mock = MagicMock()
+        flask_mock.g = mock_g
+        flask_mock.request = mock_request
+
+        with patch.dict("sys.modules", {"flask": flask_mock}):
+            _teardown_request_hook(exception=None)
+
+        mock_state.clear_investigation_data.assert_called_once()
 
     @patch("amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation.clear_current_operation")
     def test_teardown_clears_operation_on_exception(self, mock_clear):

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/models/test_models.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/models/test_models.py
@@ -1,0 +1,582 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from unittest import TestCase
+from unittest.mock import patch
+
+from amazon.opentelemetry.distro.serviceevents.models.deployment_telemetry import (
+    DeploymentContext,
+    DeploymentEventTelemetry,
+)
+from amazon.opentelemetry.distro.serviceevents.models.endpoint_telemetry import (
+    EndpointMetricEvent,
+    ErrorBreakdownEntry,
+    ErrorDetail,
+)
+from amazon.opentelemetry.distro.serviceevents.models.function_telemetry import DurationMetrics
+from amazon.opentelemetry.distro.serviceevents.models.incident_telemetry import (
+    CallPathEntry,
+    ExceptionInfo,
+    IncidentSnapshot,
+    RequestContext,
+    TelemetryCorrelation,
+)
+from amazon.opentelemetry.distro.serviceevents.models.resource_attributes import ResourceAttributes
+
+
+class TestDurationMetrics(TestCase):
+    """Test the DurationMetrics dataclass."""
+
+    def test_all_fields_accessible(self):
+        """Test that all fields are accessible."""
+        dm = DurationMetrics(
+            values=[100.0, 200.0],
+            counts=[1, 2],
+            max=200.0,
+            min=100.0,
+            count=3,
+            sum=500.0,
+        )
+
+        self.assertEqual(dm.values, [100.0, 200.0])
+        self.assertEqual(dm.counts, [1, 2])
+        self.assertEqual(dm.max, 200.0)
+        self.assertEqual(dm.min, 100.0)
+        self.assertEqual(dm.count, 3)
+        self.assertEqual(dm.sum, 500.0)
+
+    def test_accepts_float_counts(self):
+        """Test that counts can be floats (from SEH aggregation)."""
+        dm = DurationMetrics(
+            values=[100.0],
+            counts=[1.5],
+            max=100.0,
+            min=100.0,
+            count=1.5,
+            sum=150.0,
+        )
+        self.assertEqual(dm.counts, [1.5])
+
+
+class TestErrorDetail(TestCase):
+    """Test the ErrorDetail dataclass."""
+
+    def test_field_access(self):
+        """Test that ErrorDetail fields are accessible."""
+        detail = ErrorDetail(error_type="ValueError", function_name="func_123")
+        self.assertEqual(detail.error_type, "ValueError")
+        self.assertEqual(detail.function_name, "func_123")
+
+
+class TestErrorBreakdownEntry(TestCase):
+    """Test the ErrorBreakdownEntry dataclass."""
+
+    def test_field_access(self):
+        """Test that ErrorBreakdownEntry fields are accessible."""
+        entry = ErrorBreakdownEntry(
+            errors=[ErrorDetail(error_type="ValueError", function_name="func_1")],
+            count=5,
+            failure_type="500",
+        )
+        self.assertEqual(len(entry.errors), 1)
+        self.assertEqual(entry.count, 5)
+        self.assertEqual(entry.failure_type, "500")
+
+
+class TestEndpointMetricEvent(TestCase):
+    """Test the EndpointMetricEvent dataclass."""
+
+    def test_instantiation(self):
+        """Test basic instantiation."""
+        event = EndpointMetricEvent(
+            environment="production",
+            service_name="api-svc",
+            sdk_version="0.14.2",
+            instance_id="host-1",
+            operation="GET /api/users",
+            pid=100,
+            timestamp="2026-01-01T00:00:00+00:00",
+            count=42,
+            method="GET",
+            route="/api/users",
+        )
+
+        self.assertEqual(event.environment, "production")
+        self.assertEqual(event.operation, "GET /api/users")
+        self.assertEqual(event.method, "GET")
+        self.assertEqual(event.route, "/api/users")
+        self.assertEqual(event.count, 42)
+        self.assertEqual(event.telemetry_type, "EndpointSummary")
+        self.assertEqual(event.error_breakdown, [])
+        self.assertEqual(event.faults, 0)
+        self.assertEqual(event.errors, 0)
+        self.assertIsNone(event.duration)
+
+
+class TestCallPathEntry(TestCase):
+    """Test the CallPathEntry dataclass."""
+
+    def test_error_defaults_to_false(self):
+        """Test that error defaults to False."""
+        entry = CallPathEntry(
+            function_name="func_a",
+            caller_function_name="func_b",
+            duration_ns=1000,
+        )
+        self.assertFalse(entry.error)
+
+    def test_error_can_be_true(self):
+        """Test that error can be set to True."""
+        entry = CallPathEntry(
+            function_name="func_a",
+            caller_function_name=None,
+            duration_ns=5000,
+            error=True,
+        )
+        self.assertTrue(entry.error)
+        self.assertIsNone(entry.caller_function_name)
+
+
+class TestExceptionInfo(TestCase):
+    """Test the ExceptionInfo dataclass."""
+
+    def test_fields_accessible(self):
+        """Test that all ExceptionInfo fields are accessible."""
+        info = ExceptionInfo(
+            exception_type="ValueError",
+            exception_message="invalid value",
+            stack_trace="Traceback...",
+            call_path=[
+                CallPathEntry(function_name="f1", caller_function_name=None, duration_ns=100),
+            ],
+        )
+
+        self.assertEqual(info.exception_type, "ValueError")
+        self.assertEqual(info.exception_message, "invalid value")
+        self.assertEqual(info.stack_trace, "Traceback...")
+        self.assertEqual(len(info.call_path), 1)
+
+
+class TestIncidentSnapshot(TestCase):
+    """Test the IncidentSnapshot dataclass."""
+
+    def test_to_dict_with_all_fields(self):
+        """Test to_dict with all fields populated."""
+        snapshot = IncidentSnapshot(
+            snapshot_id="snap_123",
+            timestamp=1706745600000,
+            severity="critical",
+            trigger_type="exception",
+            service="user-service",
+            environment="production",
+            instance_id="host-1",
+            operation="GET /api/users",
+            sdk_version="0.14.2",
+            pid=12345,
+            duration_ms=150.5,
+            exception_info=[
+                ExceptionInfo(
+                    exception_type="ValueError",
+                    exception_message="bad input",
+                    stack_trace="Traceback...",
+                    call_path=[
+                        CallPathEntry(
+                            function_name="func_a",
+                            caller_function_name=None,
+                            duration_ns=1000,
+                            error=True,
+                        ),
+                    ],
+                ),
+            ],
+            request_context=RequestContext(
+                type="http",
+                timestamp=1706745600000,
+                status_code=500,
+            ),
+            telemetry_correlation=TelemetryCorrelation(
+                trace_id="trace-xyz",
+                request_id="req-123",
+            ),
+        )
+
+        result = snapshot.to_dict()
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["snapshot_id"], "snap_123")
+        self.assertEqual(result["severity"], "critical")
+        self.assertEqual(result["trigger_type"], "exception")
+        self.assertEqual(result["telemetry_type"], "IncidentSnapshot")
+        self.assertEqual(result["sdk_lang"], "python")
+        self.assertEqual(result["duration_ms"], 150.5)
+        self.assertEqual(len(result["exception_info"]), 1)
+        self.assertEqual(result["exception_info"][0]["exception_type"], "ValueError")
+        self.assertEqual(result["request_context"]["type"], "http")
+        self.assertEqual(result["telemetry_correlation"]["trace_id"], "trace-xyz")
+
+    def test_default_telemetry_type(self):
+        """Test that telemetry_type defaults to 'IncidentSnapshot'."""
+        snapshot = IncidentSnapshot(
+            snapshot_id="snap_1",
+            timestamp=0,
+            severity="low",
+            trigger_type="latency",
+            service="svc",
+            environment="dev",
+            instance_id="host",
+            operation="GET /test",
+            sdk_version="0.14.2",
+            pid=1,
+            duration_ms=100.0,
+            exception_info=[],
+            request_context=RequestContext(type="http", timestamp=0, status_code=200),
+            telemetry_correlation=TelemetryCorrelation(),
+        )
+        self.assertEqual(snapshot.telemetry_type, "IncidentSnapshot")
+
+
+class TestRequestContext(TestCase):
+    """Test the RequestContext dataclass."""
+
+    def test_default_fields(self):
+        """Test default field values."""
+        ctx = RequestContext(type="http", timestamp=1000, status_code=200)
+        self.assertEqual(ctx.custom_context, {})
+        self.assertIsNone(ctx.request_body)
+        self.assertIsNone(ctx.query_params)
+        self.assertIsNone(ctx.path_params)
+        self.assertIsNone(ctx.request_headers)
+
+    def test_all_fields_populated(self):
+        """Test with all optional fields populated."""
+        ctx = RequestContext(
+            type="http",
+            timestamp=1000,
+            status_code=500,
+            custom_context={"user_id": "u123"},
+            request_body={"data": "value"},
+            query_params={"page": "1"},
+            path_params={"id": "42"},
+            request_headers={"Content-Type": "application/json"},
+        )
+        self.assertEqual(ctx.custom_context["user_id"], "u123")
+        self.assertEqual(ctx.request_body["data"], "value")
+
+
+class TestTelemetryCorrelation(TestCase):
+    """Test the TelemetryCorrelation dataclass."""
+
+    def test_default_fields(self):
+        """Test default field values."""
+        tc = TelemetryCorrelation()
+        self.assertIsNone(tc.trace_id)
+        self.assertIsNone(tc.session_id)
+        self.assertIsNone(tc.span_id)
+        self.assertIsNone(tc.request_id)
+        self.assertIsNone(tc.correlation_ids)
+
+
+class TestDeploymentEventSimplified(TestCase):
+    """Test that DeploymentEvent has no functions list."""
+
+    def test_no_functions_field(self):
+        """DeploymentEvent should not have a functions field."""
+        from amazon.opentelemetry.distro.serviceevents.models import deployment_telemetry
+
+        self.assertFalse(hasattr(deployment_telemetry, "FunctionInfo"))
+        self.assertFalse(hasattr(deployment_telemetry, "FunctionMappingTelemetry"))
+
+
+class TestDeploymentContext(TestCase):
+    """Test the DeploymentContext dataclass."""
+
+    def test_defaults(self):
+        """Unset fields default to empty (not a sentinel) so emitters omit them."""
+        gm = DeploymentContext()
+        self.assertEqual(gm.git_repo_url, "")
+        self.assertEqual(gm.git_commit_sha, "")
+        self.assertEqual(gm.deployment_url, "")
+        self.assertEqual(gm.deployment_timestamp, "")
+        self.assertEqual(gm.deployment_id, "")
+
+    @patch.dict(
+        "os.environ",
+        {
+            "OTEL_AWS_SERVICE_EVENTS_GIT_REPO_URL": "https://github.com/org/repo",
+            "OTEL_AWS_SERVICE_EVENTS_GIT_COMMIT_SHA": "abc123",
+            "OTEL_AWS_SERVICE_EVENTS_DEPLOYMENT_URL": "https://github.com/org/repo/actions/runs/99",
+            "OTEL_AWS_SERVICE_EVENTS_DEPLOYMENT_TIMESTAMP": "2026-02-04T00:00:00Z",
+            "OTEL_AWS_SERVICE_EVENTS_DEPLOYMENT_ID": "99",
+        },
+    )
+    def test_from_environment(self):
+        """Test creating DeploymentContext from environment variables."""
+        gm = DeploymentContext.from_environment()
+        self.assertEqual(gm.git_repo_url, "https://github.com/org/repo")
+        self.assertEqual(gm.git_commit_sha, "abc123")
+        self.assertEqual(gm.deployment_url, "https://github.com/org/repo/actions/runs/99")
+        self.assertEqual(gm.deployment_timestamp, "2026-02-04T00:00:00Z")
+        self.assertEqual(gm.deployment_id, "99")
+
+    def test_to_dict(self):
+        """Test to_dict conversion."""
+        gm = DeploymentContext(git_repo_url="repo", git_commit_sha="sha")
+        result = gm.to_dict()
+        self.assertEqual(result["git_repo_url"], "repo")
+        self.assertEqual(result["git_commit_sha"], "sha")
+
+
+class TestDeploymentEventTelemetry(TestCase):
+    """Test the DeploymentEventTelemetry dataclass."""
+
+    def test_create(self):
+        """Test creating a DeploymentEventTelemetry instance."""
+        evt = DeploymentEventTelemetry.create(
+            service_name="test-svc",
+            environment="dev",
+            instance_id="host-1",
+            pid=42,
+            include_deployment_context=False,
+        )
+
+        self.assertEqual(evt.service_name, "test-svc")
+        self.assertEqual(evt.telemetry_type, "DeploymentEvent")
+
+    def test_to_dict(self):
+        """Test to_dict conversion."""
+        evt = DeploymentEventTelemetry(
+            service_name="test-svc",
+            environment="dev",
+            instance_id="host-1",
+            sdk_version="0.14.2",
+            pid=42,
+        )
+
+        result = evt.to_dict()
+        self.assertEqual(result["telemetry_type"], "DeploymentEvent")
+        self.assertEqual(result["service_name"], "test-svc")
+        self.assertNotIn("functions", result)
+        self.assertNotIn("total_functions", result)
+        self.assertEqual(result["sdk_lang"], "python")
+        self.assertNotIn("deployment_context", result)
+
+    @patch.dict(
+        "os.environ",
+        {
+            "OTEL_AWS_SERVICE_EVENTS_GIT_REPO_URL": "https://github.com/org/repo",
+            "OTEL_AWS_SERVICE_EVENTS_GIT_COMMIT_SHA": "abc123",
+        },
+    )
+    def test_to_dict_with_deployment_context(self):
+        """Test to_dict includes deployment_context when present."""
+        evt = DeploymentEventTelemetry.create(
+            service_name="test-svc",
+            environment="dev",
+            instance_id="host-1",
+            pid=42,
+            include_deployment_context=True,
+        )
+
+        result = evt.to_dict()
+        self.assertIn("deployment_context", result)
+        self.assertEqual(result["deployment_context"]["git_repo_url"], "https://github.com/org/repo")
+
+    def test_timestamp_auto_set(self):
+        """Test that timestamp is auto-set if not provided."""
+        evt = DeploymentEventTelemetry(
+            service_name="svc",
+            environment="dev",
+            instance_id="host",
+            sdk_version="0.14.2",
+            pid=1,
+        )
+        self.assertTrue(len(evt.timestamp) > 0)
+
+    def test_json_serializable(self):
+        """Test that to_dict output is JSON serializable."""
+        evt = DeploymentEventTelemetry(
+            service_name="test-svc",
+            environment="dev",
+            instance_id="host-1",
+            sdk_version="0.14.2",
+            pid=42,
+        )
+
+        json_str = json.dumps(evt.to_dict())
+        self.assertIsInstance(json_str, str)
+
+
+class TestResourceAttributes(TestCase):
+    """Test the ResourceAttributes dataclass."""
+
+    def test_empty_defaults(self):
+        """Test that all fields default to None."""
+        ra = ResourceAttributes()
+        self.assertIsNone(ra.cloud_provider)
+        self.assertIsNone(ra.cloud_region)
+        self.assertIsNone(ra.host_id)
+        self.assertTrue(ra.is_empty())
+
+    def test_to_dict_sparse(self):
+        """Test that to_dict only includes non-None fields with OTel keys."""
+        ra = ResourceAttributes(
+            cloud_provider="aws",
+            cloud_region="us-east-1",
+            host_id="i-0abc123",
+        )
+        result = ra.to_dict()
+        self.assertEqual(
+            result,
+            {
+                "cloud.provider": "aws",
+                "cloud.region": "us-east-1",
+                "host.id": "i-0abc123",
+            },
+        )
+        # None fields should not appear
+        self.assertNotIn("cloud.platform", result)
+        self.assertNotIn("container.id", result)
+
+    def test_to_dict_empty(self):
+        """Test that empty ResourceAttributes produces empty dict."""
+        ra = ResourceAttributes()
+        self.assertEqual(ra.to_dict(), {})
+
+    def test_is_empty_false_when_set(self):
+        """Test is_empty returns False when any field is set."""
+        ra = ResourceAttributes(cloud_provider="aws")
+        self.assertFalse(ra.is_empty())
+
+    def test_from_otel_resource(self):
+        """Test creating from a mock OTel Resource."""
+
+        class MockResource:
+            attributes = {
+                "cloud.provider": "aws",
+                "cloud.platform": "aws_ec2",
+                "cloud.region": "us-west-2",
+                "host.id": "i-abc123",
+                "host.type": "t3.medium",
+                "telemetry.auto.version": "0.14.2",  # Should be ignored
+                "custom.attr": "value",  # Should be ignored
+            }
+
+        ra = ResourceAttributes.from_otel_resource(MockResource())
+        self.assertEqual(ra.cloud_provider, "aws")
+        self.assertEqual(ra.cloud_platform, "aws_ec2")
+        self.assertEqual(ra.cloud_region, "us-west-2")
+        self.assertEqual(ra.host_id, "i-abc123")
+        self.assertEqual(ra.host_type, "t3.medium")
+        # Unknown attributes should not be included
+        self.assertIsNone(ra.container_id)
+        self.assertIsNone(ra.k8s_cluster_name)
+
+    def test_from_otel_resource_none(self):
+        """Test creating from None resource returns empty."""
+        ra = ResourceAttributes.from_otel_resource(None)
+        self.assertTrue(ra.is_empty())
+
+    def test_from_otel_resource_empty_values_skipped(self):
+        """Test that empty string values are skipped."""
+
+        class MockResource:
+            attributes = {
+                "cloud.provider": "aws",
+                "cloud.region": "",
+                "host.id": "  ",
+            }
+
+        ra = ResourceAttributes.from_otel_resource(MockResource())
+        self.assertEqual(ra.cloud_provider, "aws")
+        self.assertIsNone(ra.cloud_region)
+        self.assertIsNone(ra.host_id)
+
+    def test_all_otel_keys_roundtrip(self):
+        """Test that all 11 attributes roundtrip through to_dict."""
+        ra = ResourceAttributes(
+            cloud_provider="aws",
+            cloud_platform="aws_ecs",
+            cloud_region="eu-west-1",
+            cloud_account_id="123456789012",
+            cloud_availability_zone="eu-west-1a",
+            host_id="i-def456",
+            host_type="m5.xlarge",
+            container_id="abc123container",
+            k8s_cluster_name="prod-cluster",
+            k8s_pod_name="my-pod-xyz",
+            k8s_namespace_name="default",
+        )
+        result = ra.to_dict()
+        self.assertEqual(len(result), 11)
+        self.assertEqual(result["cloud.provider"], "aws")
+        self.assertEqual(result["cloud.platform"], "aws_ecs")
+        self.assertEqual(result["cloud.region"], "eu-west-1")
+        self.assertEqual(result["cloud.account.id"], "123456789012")
+        self.assertEqual(result["cloud.availability_zone"], "eu-west-1a")
+        self.assertEqual(result["host.id"], "i-def456")
+        self.assertEqual(result["host.type"], "m5.xlarge")
+        self.assertEqual(result["container.id"], "abc123container")
+        self.assertEqual(result["k8s.cluster.name"], "prod-cluster")
+        self.assertEqual(result["k8s.pod.name"], "my-pod-xyz")
+        self.assertEqual(result["k8s.namespace.name"], "default")
+
+
+class TestResourceAttributesInModels(TestCase):
+    """Test that resource_attributes integrates correctly in telemetry models."""
+
+    def _make_resource_attrs(self):
+        return ResourceAttributes(
+            cloud_provider="aws",
+            cloud_region="us-east-1",
+            host_id="i-test123",
+        )
+
+    def test_incident_snapshot_with_resource_attributes(self):
+        """Test IncidentSnapshot includes resource_attributes in output."""
+        ra = self._make_resource_attrs()
+        snapshot = IncidentSnapshot(
+            snapshot_id="snap_1",
+            timestamp=0,
+            severity="low",
+            trigger_type="latency",
+            service="svc",
+            environment="dev",
+            instance_id="host",
+            operation="GET /test",
+            sdk_version="0.14.2",
+            pid=1,
+            duration_ms=100.0,
+            exception_info=[],
+            request_context=RequestContext(type="http", timestamp=0, status_code=200),
+            telemetry_correlation=TelemetryCorrelation(),
+            resource_attributes=ra,
+        )
+        result = snapshot.to_dict()
+        self.assertEqual(result["resource_attributes"]["cloud.region"], "us-east-1")
+
+    def test_deployment_event_with_resource_attributes(self):
+        """Test DeploymentEventTelemetry includes resource_attributes when non-empty."""
+        ra = self._make_resource_attrs()
+        evt = DeploymentEventTelemetry.create(
+            service_name="svc",
+            environment="dev",
+            instance_id="host-1",
+            pid=1,
+            include_deployment_context=False,
+            resource_attributes=ra,
+        )
+        result = evt.to_dict()
+        self.assertIn("resource_attributes", result)
+        self.assertEqual(result["resource_attributes"]["cloud.provider"], "aws")
+
+    def test_deployment_event_without_resource_attributes(self):
+        """Test DeploymentEventTelemetry omits resource_attributes when empty."""
+        evt = DeploymentEventTelemetry.create(
+            service_name="svc",
+            environment="dev",
+            instance_id="host-1",
+            pid=1,
+            include_deployment_context=False,
+        )
+        result = evt.to_dict()
+        self.assertNotIn("resource_attributes", result)

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/test_ast_transformation.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/test_ast_transformation.py
@@ -1,0 +1,908 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import ast
+import os
+import sys
+import tempfile
+from importlib.machinery import ModuleSpec, SourceFileLoader
+from unittest import TestCase
+from unittest.mock import patch
+
+from amazon.opentelemetry.distro.serviceevents.ast_transformation import (
+    ServiceEventsASTTransformer,
+    ServiceEventsMetaPathFinder,
+    ServiceEventsSourceLoader,
+    _file_path_to_module_path,
+    build_function_name,
+    clear_function_registry,
+    get_deployment_event_telemetry,
+    get_function_info,
+    get_function_info_unlocked,
+    get_function_registry,
+    get_registry_size,
+    install_ast_hooks,
+    uninstall_ast_hooks,
+)
+
+
+class TestBuildFunctionName(TestCase):
+    """Test composite function name generation."""
+
+    def test_build_function_name_deterministic(self):
+        """Test that function name is deterministic for same inputs."""
+        name1 = build_function_name("my_func", "/path/to/file.py", 10)
+        name2 = build_function_name("my_func", "/path/to/file.py", 10)
+
+        self.assertEqual(name1, name2)
+
+    def test_build_function_name_different_names(self):
+        """Test that different function names produce different identifiers."""
+        name1 = build_function_name("func1", "/path/to/file.py", 10)
+        name2 = build_function_name("func2", "/path/to/file.py", 10)
+
+        self.assertNotEqual(name1, name2)
+
+    def test_build_function_name_different_paths(self):
+        """Test that different file paths produce different identifiers."""
+        name1 = build_function_name("my_func", "/path/to/file1.py", 10)
+        name2 = build_function_name("my_func", "/path/to/file2.py", 10)
+
+        self.assertNotEqual(name1, name2)
+
+    def test_build_function_name_same_for_different_line_numbers(self):
+        """Test that different line numbers produce the same name (line stored in registry, not in name)."""
+        name1 = build_function_name("my_func", "/path/to/file.py", 10)
+        name2 = build_function_name("my_func", "/path/to/file.py", 20)
+
+        self.assertEqual(name1, name2)
+
+    def test_build_function_name_format(self):
+        """Test the composite name format."""
+        name = build_function_name("my_func", "myapp/server.py", 42)
+        self.assertEqual(name, "myapp/server.my_func")
+
+    def test_build_function_name_init_py(self):
+        """Test that __init__.py uses parent directory as module stem."""
+        name = build_function_name("setup", "myapp/utils/__init__.py", 5)
+        self.assertEqual(name, "myapp/utils.setup")
+
+    def test_build_function_name_nested_path(self):
+        """Test composite name with deeply nested relative path."""
+        name = build_function_name("_process", "indico/modules/attachments/controllers/display/base.py", 36)
+        self.assertEqual(name, "indico/modules/attachments/controllers/display/base._process")
+
+
+class TestFilePathToModulePath(TestCase):
+    """Test file path to module path conversion."""
+
+    def test_simple_py_file(self):
+        self.assertEqual(_file_path_to_module_path("myapp/server.py"), "myapp/server")
+
+    def test_init_py(self):
+        self.assertEqual(_file_path_to_module_path("myapp/utils/__init__.py"), "myapp/utils")
+
+    def test_absolute_path(self):
+        self.assertEqual(_file_path_to_module_path("/abs/path/to/module.py"), "/abs/path/to/module")
+
+    def test_no_py_extension(self):
+        self.assertEqual(_file_path_to_module_path("myapp/server"), "myapp/server")
+
+
+class TestToRelativePath(TestCase):
+    """Test relative path derivation from module names."""
+
+    def test_module_file(self):
+        """Test standard module.py path."""
+        result = ServiceEventsSourceLoader._to_relative_path(
+            "indico.modules.attachments.controllers.display.base",
+            "/opt/indico/indico/modules/attachments/controllers/display/base.py",
+        )
+        self.assertEqual(result, "indico/modules/attachments/controllers/display/base.py")
+
+    def test_package_init(self):
+        """Test package __init__.py path."""
+        result = ServiceEventsSourceLoader._to_relative_path(
+            "indico.modules.attachments",
+            "/opt/indico/indico/modules/attachments/__init__.py",
+        )
+        self.assertEqual(result, "indico/modules/attachments/__init__.py")
+
+    def test_top_level_module(self):
+        """Test top-level module path."""
+        result = ServiceEventsSourceLoader._to_relative_path(
+            "myapp.server",
+            "/home/user/projects/myapp/server.py",
+        )
+        self.assertEqual(result, "myapp/server.py")
+
+    def test_fallback_when_no_match(self):
+        """Test fallback to absolute path when suffix doesn't match."""
+        result = ServiceEventsSourceLoader._to_relative_path(
+            "some.module",
+            "/weird/path/not_matching.py",
+        )
+        self.assertEqual(result, "/weird/path/not_matching.py")
+
+
+class TestServiceEventsASTTransformer(TestCase):
+    """Test the AST transformation logic."""
+
+    def test_transform_simple_function(self):
+        """Test transformation of a simple function."""
+        source = """
+def my_function():
+    return 42
+"""
+
+        tree = ast.parse(source)
+        transformer = ServiceEventsASTTransformer("/test/file.py")
+        transformed = transformer.visit(tree)
+
+        # Function should still exist
+        self.assertEqual(len(transformed.body), 1)
+        self.assertIsInstance(transformed.body[0], ast.FunctionDef)
+
+        # Function body should contain a with statement
+        func_def = transformed.body[0]
+        self.assertEqual(len(func_def.body), 1)
+        self.assertIsInstance(func_def.body[0], ast.With)
+
+        # The with statement should call PythonServiceEventsMonitor
+        with_stmt = func_def.body[0]
+        self.assertIsInstance(with_stmt.items[0].context_expr, ast.Call)
+        self.assertEqual(with_stmt.items[0].context_expr.func.id, "PythonServiceEventsMonitor")
+
+    def test_transform_function_with_docstring(self):
+        """Test that docstrings are preserved."""
+        source = '''
+def documented_function():
+    """This is a docstring."""
+    return 42
+'''
+
+        tree = ast.parse(source)
+        transformer = ServiceEventsASTTransformer("/test/file.py")
+        transformed = transformer.visit(tree)
+
+        func_def = transformed.body[0]
+
+        # Should have docstring + with statement
+        self.assertEqual(len(func_def.body), 2)
+        self.assertIsInstance(func_def.body[0], ast.Expr)
+
+        # Verify docstring is preserved
+        if sys.version_info >= (3, 8):
+            self.assertIsInstance(func_def.body[0].value, ast.Constant)
+            self.assertEqual(func_def.body[0].value.value, "This is a docstring.")
+        else:
+            self.assertIsInstance(func_def.body[0].value, ast.Str)
+
+    def test_transform_async_function(self):
+        """Test transformation of async functions and is_async registry flag."""
+        clear_function_registry()
+        source = """
+async def async_function():
+    return await something()
+"""
+
+        tree = ast.parse(source)
+        transformer = ServiceEventsASTTransformer("/test/async_file.py")
+        transformed = transformer.visit(tree)
+
+        # Should still be async function
+        self.assertIsInstance(transformed.body[0], ast.AsyncFunctionDef)
+
+        # Body should contain with statement
+        func_def = transformed.body[0]
+        self.assertIsInstance(func_def.body[0], ast.With)
+
+        # Verify is_async=True in registry
+        registry = get_function_registry()
+        async_entries = [v for v in registry.values() if v["name"] == "async_function"]
+        self.assertEqual(len(async_entries), 1)
+        self.assertTrue(async_entries[0]["is_async"])
+
+    def test_sync_function_registry_is_async_false(self):
+        """Test that sync functions get is_async=False in the registry."""
+        clear_function_registry()
+        source = """
+def sync_function():
+    return 42
+"""
+
+        tree = ast.parse(source)
+        transformer = ServiceEventsASTTransformer("/test/sync_file.py")
+        transformer.visit(tree)
+
+        registry = get_function_registry()
+        sync_entries = [v for v in registry.values() if v["name"] == "sync_function"]
+        self.assertEqual(len(sync_entries), 1)
+        self.assertFalse(sync_entries[0]["is_async"])
+
+    def test_transform_empty_function(self):
+        """Test transformation of empty function (pass statement)."""
+        source = """
+def empty_function():
+    pass
+"""
+
+        tree = ast.parse(source)
+        transformer = ServiceEventsASTTransformer("/test/file.py")
+        transformed = transformer.visit(tree)
+
+        func_def = transformed.body[0]
+        with_stmt = func_def.body[0]
+
+        # With statement should contain pass
+        self.assertEqual(len(with_stmt.body), 1)
+        self.assertIsInstance(with_stmt.body[0], ast.Pass)
+
+    def test_transform_nested_functions(self):
+        """Test transformation of nested function definitions."""
+        source = """
+def outer():
+    def inner():
+        return 42
+    return inner()
+"""
+
+        tree = ast.parse(source)
+        transformer = ServiceEventsASTTransformer("/test/file.py")
+        transformer.visit(tree)
+
+        # Both functions should be instrumented
+        self.assertEqual(transformer.instrumented_functions, 2)
+
+    def test_function_names_differ_by_name_not_line(self):
+        """Test that different function names produce different composite names."""
+        source = """
+def func1():
+    pass
+
+def func2():
+    pass
+"""
+
+        tree = ast.parse(source)
+        transformer = ServiceEventsASTTransformer("/test/file.py")
+        transformed = transformer.visit(tree)
+
+        # Extract the function names from the transformed AST
+        func1_with = transformed.body[0].body[0]
+        func2_with = transformed.body[1].body[0]
+
+        func1_name = func1_with.items[0].context_expr.args[0].value
+        func2_name = func2_with.items[0].context_expr.args[0].value
+
+        # Names should be different (by function name, not line number)
+        self.assertNotEqual(func1_name, func2_name)
+        self.assertNotIn("@line:", func1_name)
+        self.assertIn("func1", func1_name)
+        self.assertIn("func2", func2_name)
+
+    def test_transform_future_imports(self):
+        """Test handling of __future__ imports."""
+        source = """
+from __future__ import annotations
+
+def my_function():
+    pass
+"""
+
+        tree = ast.parse(source)
+        transformer = ServiceEventsASTTransformer("/test/file.py")
+        transformed = transformer.visit(tree)
+
+        # __future__ import should be removed from AST
+        # (it's processed for compiler flags but not kept)
+        import_nodes = [node for node in ast.walk(transformed) if isinstance(node, ast.ImportFrom)]
+        future_imports = [node for node in import_nodes if node.module == "__future__"]
+
+        self.assertEqual(len(future_imports), 0)
+
+    def test_transform_stores_relative_file_path_in_registry(self):
+        """Test that the registry stores relative paths when using ServiceEventsSourceLoader."""
+        clear_function_registry()
+        source = """
+def my_function():
+    return 42
+"""
+
+        tree = ast.parse(source)
+        # Simulate an absolute runtime path with a relative path derived from module name
+        relative_path = ServiceEventsSourceLoader._to_relative_path(
+            "indico.modules.foo.bar", "/opt/indico/indico/modules/foo/bar.py"
+        )
+        transformer = ServiceEventsASTTransformer(relative_path)
+        transformer.visit(tree)
+
+        registry = get_function_registry()
+        entries = [v for v in registry.values() if v["name"] == "my_function"]
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["file_path"], "indico/modules/foo/bar.py")
+
+    def test_instrumented_functions_counter(self):
+        """Test that instrumented_functions counter is accurate."""
+        source = """
+def func1():
+    pass
+
+def func2():
+    pass
+
+def func3():
+    pass
+"""
+
+        tree = ast.parse(source)
+        transformer = ServiceEventsASTTransformer("/test/file.py")
+        transformer.visit(tree)
+
+        self.assertEqual(transformer.instrumented_functions, 3)
+
+
+class TestGeneratorSkipping(TestCase):
+    """Generators/async-generators must not be wrapped in a monitor `with` block."""
+
+    @staticmethod
+    def _transform(source):
+        tree = ast.parse(source)
+        transformer = ServiceEventsASTTransformer("/test/gen.py")
+        transformed = transformer.visit(tree)
+        return transformed, transformer
+
+    def test_yield_generator_not_wrapped(self):
+        """A function containing `yield` is left un-instrumented."""
+        source = """
+def gen():
+    yield 1
+    yield 2
+"""
+        transformed, transformer = self._transform(source)
+        func_def = transformed.body[0]
+        # Body unchanged: no injected `with` statement.
+        self.assertNotIsInstance(func_def.body[0], ast.With)
+        self.assertEqual(transformer.instrumented_functions, 0)
+
+    def test_yield_from_generator_not_wrapped(self):
+        """`yield from` also marks a generator."""
+        source = """
+def gen():
+    yield from range(3)
+"""
+        transformed, transformer = self._transform(source)
+        self.assertNotIsInstance(transformed.body[0].body[0], ast.With)
+        self.assertEqual(transformer.instrumented_functions, 0)
+
+    def test_async_generator_not_wrapped(self):
+        """An async function with `yield` is an async generator — not wrapped."""
+        source = """
+async def agen():
+    async for x in source():
+        yield x
+"""
+        transformed, transformer = self._transform(source)
+        self.assertIsInstance(transformed.body[0], ast.AsyncFunctionDef)
+        # No `with` injected at the top of the body.
+        self.assertFalse(any(isinstance(stmt, ast.With) for stmt in transformed.body[0].body))
+        self.assertEqual(transformer.instrumented_functions, 0)
+
+    def test_function_with_nested_generator_is_still_wrapped(self):
+        """A `yield` in a NESTED function belongs to that inner scope; the outer
+        non-generator function is still instrumented (and the inner generator is not)."""
+        source = """
+def outer():
+    def inner():
+        yield 1
+    return inner
+"""
+        transformed, transformer = self._transform(source)
+        outer = transformed.body[0]
+        # Outer is a normal function → wrapped.
+        self.assertIsInstance(outer.body[0], ast.With)
+        # Inner generator (now nested under the with) is NOT wrapped.
+        inner = outer.body[0].body[0]
+        self.assertIsInstance(inner, ast.FunctionDef)
+        self.assertEqual(inner.name, "inner")
+        self.assertNotIsInstance(inner.body[0], ast.With)
+        # Only the outer function counted as instrumented.
+        self.assertEqual(transformer.instrumented_functions, 1)
+
+    def test_function_with_yield_in_lambda_is_not_treated_as_generator(self):
+        """A generator expression / lambda nested in the body does not make the
+        enclosing function a generator (genexps open their own scope)."""
+        source = """
+def normal():
+    data = (x for x in range(3))
+    return list(data)
+"""
+        transformed, transformer = self._transform(source)
+        # genexp has its own scope; `normal` is an ordinary function → wrapped.
+        self.assertIsInstance(transformed.body[0].body[0], ast.With)
+        self.assertEqual(transformer.instrumented_functions, 1)
+
+
+class TestScopePrecedence(TestCase):
+    """Exercise the scope rule in `ServiceEventsMetaPathFinder.should_instrument_module`.
+
+    There is no implicit default scope: PACKAGES_INCLUDE is the only opt-in and
+    PACKAGES_EXCLUDE the only way to subtract. Decision (highest priority first):
+      0. Matches SDK_SELF_EXCLUDE (non-configurable) → drop
+      1. PACKAGES_INCLUDE empty → drop
+      2. Matches PACKAGES_EXCLUDE → drop
+      3. Matches PACKAGES_INCLUDE → instrument
+      4. Otherwise → drop
+
+    Each test builds a finder with a known include/exclude config and a minimal
+    ModuleSpec with a source origin. These rules are only reachable when
+    FUNCTION_INSTRUMENT_ENABLED=true (the finder isn't installed otherwise) — the
+    finder itself doesn't re-check that flag, so these tests assume it.
+    """
+
+    def _spec(self, origin: str = "/app/app.py"):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(origin=origin)
+
+    def _finder(self, packages_include=None, packages_exclude=None):
+        from amazon.opentelemetry.distro.serviceevents.ast_transformation import ServiceEventsMetaPathFinder
+
+        return ServiceEventsMetaPathFinder(set(packages_include or []), packages_exclude or [])
+
+    # --- Baseline rules 0–4 ---
+
+    def test_empty_include_drops_all(self):
+        """Rule 1: empty PACKAGES_INCLUDE → instrument nothing (no implicit default scope)."""
+        finder = self._finder()
+        self.assertFalse(finder.should_instrument_module("myapp.handler", self._spec()))
+
+    def test_include_match_instruments(self):
+        """Rule 3: include match → instrument."""
+        finder = self._finder(packages_include=["myapp.*"])
+        self.assertTrue(finder.should_instrument_module("myapp.foo", self._spec()))
+
+    def test_include_no_match_drops(self):
+        """Rule 4: PACKAGES_INCLUDE set but class doesn't match → drop."""
+        finder = self._finder(packages_include=["myapp.*"])
+        self.assertFalse(finder.should_instrument_module("other.bar", self._spec()))
+
+    def test_exclude_beats_include(self):
+        """Rule 2 wins over rule 3 — PACKAGES_EXCLUDE always wins."""
+        finder = self._finder(packages_include=["myapp.*"], packages_exclude=["myapp.internal.*"])
+        self.assertFalse(finder.should_instrument_module("myapp.internal.foo", self._spec()))
+
+    def test_self_exclude_holds_under_wildcard_include(self):
+        """Rule 0: SDK_SELF_EXCLUDE is non-configurable, even under a wildcard include.
+
+        Uses ``*.*`` (a fnmatch wildcard that survives the validator — bare ``*`` is
+        stripped in the config layer, ``*.*`` is not) to prove the self-exclude gate
+        runs before include matching.
+        """
+        finder = self._finder(packages_include=["*.*"])
+        self.assertFalse(finder.should_instrument_module("opentelemetry.sdk.trace", self._spec()))
+        self.assertFalse(finder.should_instrument_module("amazon.opentelemetry.distro.foo", self._spec()))
+
+    # --- INCLUDE coverage gaps ---
+
+    def test_include_multi_pattern_union(self):
+        """Any pattern matching = include."""
+        finder = self._finder(packages_include=["myapp.*", "otherapp.*"])
+        self.assertTrue(finder.should_instrument_module("otherapp.foo", self._spec()))
+
+    def test_include_with_unrelated_exclude_still_instruments(self):
+        """A non-empty exclude that doesn't match must not poison the include."""
+        finder = self._finder(packages_include=["myapp.*"], packages_exclude=["otherapp.*"])
+        self.assertTrue(finder.should_instrument_module("myapp.foo", self._spec()))
+
+    def test_include_glob_depth_pinning(self):
+        """Python fnmatch: ``myapp.*`` matches multi-segment names (``.`` is an ordinary char)."""
+        finder = self._finder(packages_include=["myapp.*"])
+        self.assertTrue(finder.should_instrument_module("myapp.sub.bar", self._spec()))
+
+    # --- EXCLUDE coverage gaps ---
+
+    def test_empty_include_with_nonempty_exclude_still_drops(self):
+        """Rule 1 fires before rule 2 — EXCLUDE alone never opens the gate."""
+        finder = self._finder(packages_exclude=["myapp.*"])
+        self.assertFalse(finder.should_instrument_module("other.bar", self._spec()))
+
+    def test_exclude_multi_pattern_union(self):
+        finder = self._finder(packages_include=["myapp.*"], packages_exclude=["myapp.internal.*", "myapp.legacy.*"])
+        self.assertFalse(finder.should_instrument_module("myapp.legacy.bar", self._spec()))
+
+    def test_exclude_multi_pattern_unmatched_still_includes(self):
+        finder = self._finder(packages_include=["myapp.*"], packages_exclude=["myapp.internal.*", "myapp.legacy.*"])
+        self.assertTrue(finder.should_instrument_module("myapp.public.baz", self._spec()))
+
+    def test_exclude_no_match_falls_through_to_include(self):
+        """A non-empty exclude that doesn't match must not drop the class."""
+        finder = self._finder(packages_include=["myapp.*"], packages_exclude=["otherapp.*"])
+        self.assertTrue(finder.should_instrument_module("myapp.foo", self._spec()))
+
+    def test_exclude_wins_when_collides_with_include(self):
+        """Identical include/exclude patterns → exclude wins (rule 2 beats rule 3)."""
+        finder = self._finder(packages_include=["myapp.*"], packages_exclude=["myapp.*"])
+        self.assertFalse(finder.should_instrument_module("myapp.foo", self._spec()))
+
+    def test_self_exclude_wins_over_redundant_exclude(self):
+        """Rule 0 fires regardless of EXCLUDE — a customer can't 'cover' the SDK via EXCLUDE."""
+        finder = self._finder(packages_include=["myapp.*"], packages_exclude=["opentelemetry.*"])
+        self.assertFalse(finder.should_instrument_module("opentelemetry.sdk.trace", self._spec()))
+
+    def test_exclude_glob_depth_pinning(self):
+        """Python fnmatch: ``myapp.secret.*`` catches multi-segment names below it."""
+        finder = self._finder(packages_include=["myapp.*"], packages_exclude=["myapp.secret.*"])
+        self.assertFalse(finder.should_instrument_module("myapp.secret.sub.leak", self._spec()))
+
+    # --- Validator/lifecycle gaps ---
+
+    def test_double_star_passes_through_python(self):
+        """Python validator strips only exact ``*``, not ``**``; ``**`` reaches fnmatch.
+
+        ``fnmatch('myapp.foo', '**')`` is True (``*`` matches everything including dots),
+        so a ``**`` include behaves as match-all here — pins the JS-vs-Python asymmetry.
+        """
+        finder = self._finder(packages_include=["**"])
+        self.assertTrue(finder.should_instrument_module("myapp.foo", self._spec()))
+        # ...but rule 0 still wins over the wildcard.
+        self.assertFalse(finder.should_instrument_module("opentelemetry.sdk.trace", self._spec()))
+
+    def test_structural_gate_drops_specless_module(self):
+        """No spec / no origin / built-in / frozen → drop before any rule runs."""
+        from types import SimpleNamespace
+
+        finder = self._finder(packages_include=["*.*"])
+        self.assertFalse(finder.should_instrument_module("myapp.foo", None))
+        self.assertFalse(finder.should_instrument_module("myapp.foo", SimpleNamespace(origin=None)))
+        self.assertFalse(finder.should_instrument_module("sys", SimpleNamespace(origin="built-in")))
+
+
+class TestFindSpecCrashSafety(TestCase):
+    """find_spec runs inside the customer's import machinery; a failure deciding
+    whether to instrument a module must never break the customer's import."""
+
+    def _finder(self, packages_include=None, packages_exclude=None):
+        from amazon.opentelemetry.distro.serviceevents.ast_transformation import ServiceEventsMetaPathFinder
+
+        return ServiceEventsMetaPathFinder(set(packages_include or ["myapp.*"]), packages_exclude or [])
+
+    def test_find_spec_returns_none_when_should_instrument_raises(self):
+        """If should_instrument_module raises, find_spec returns None (defers to default import)."""
+        from unittest.mock import patch
+
+        finder = self._finder()
+        with patch.object(finder, "should_instrument_module", side_effect=RuntimeError("boom")):
+            # Must not raise — returns None so the default machinery loads the module uninstrumented.
+            self.assertIsNone(finder.find_spec("myapp.foo", None, None))
+        # The recursion-guard set must be cleaned up even on failure.
+        self.assertNotIn("myapp.foo", finder._currently_loading)
+
+    def test_find_spec_returns_none_when_find_spec_raises(self):
+        """If importlib.util.find_spec raises, our find_spec swallows it and returns None."""
+        from unittest.mock import patch
+
+        finder = self._finder()
+        with patch("importlib.util.find_spec", side_effect=RuntimeError("import machinery boom")):
+            self.assertIsNone(finder.find_spec("myapp.foo", None, None))
+        self.assertNotIn("myapp.foo", finder._currently_loading)
+
+
+class TestRegistryAccessors(TestCase):
+    """Cover the registry read accessors that aren't exercised elsewhere."""
+
+    def setUp(self):
+        clear_function_registry()
+
+    def tearDown(self):
+        clear_function_registry()
+
+    def test_get_function_info_returns_metadata(self):
+        """get_function_info returns the stored metadata dict for a known function."""
+        name = build_function_name("widget", "pkg/mod.py", 7, is_async=False)
+        info = get_function_info(name)
+        self.assertIsNotNone(info)
+        self.assertEqual(info["name"], "widget")
+        self.assertEqual(info["file_path"], "pkg/mod.py")
+        self.assertEqual(info["line"], 7)
+
+    def test_get_function_info_missing_returns_none(self):
+        """get_function_info returns None for an unknown function name."""
+        self.assertIsNone(get_function_info("does/not.exist"))
+
+    def test_get_function_info_unlocked_matches_locked(self):
+        """The lock-free read returns the same metadata as the locked read."""
+        name = build_function_name("gizmo", "pkg/other.py", 3)
+        self.assertEqual(get_function_info_unlocked(name), get_function_info(name))
+        self.assertIsNone(get_function_info_unlocked("unknown/name"))
+
+    def test_get_registry_size_tracks_entries(self):
+        """get_registry_size reflects the number of registered functions."""
+        self.assertEqual(get_registry_size(), 0)
+        build_function_name("a", "pkg/m.py", 1)
+        build_function_name("b", "pkg/m.py", 2)
+        self.assertEqual(get_registry_size(), 2)
+
+
+class TestDeploymentEventTelemetry(TestCase):
+    """Cover the get_deployment_event_telemetry convenience wrapper."""
+
+    def test_returns_deployment_event_dict(self):
+        """The wrapper returns a DeploymentEvent telemetry dict with the supplied metadata."""
+        result = get_deployment_event_telemetry(
+            service_name="my-service",
+            environment="test",
+            sdk_version="9.9.9",
+            pid=4242,
+        )
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["telemetry_type"], "DeploymentEvent")
+        self.assertEqual(result["service_name"], "my-service")
+        self.assertEqual(result["environment"], "test")
+        self.assertEqual(result["sdk_version"], "9.9.9")
+        self.assertEqual(result["pid"], 4242)
+
+
+class TestTransformerEdgeCases(TestCase):
+    """Cover branches in the transformer not hit by the main transform tests."""
+
+    def setUp(self):
+        clear_function_registry()
+
+    def tearDown(self):
+        clear_function_registry()
+
+    def test_get_and_remove_docstring_empty_body_returns_none(self):
+        """get_and_remove_docstring returns None when the function body is empty."""
+        node = ast.FunctionDef(
+            name="empty",
+            args=ast.arguments(
+                posonlyargs=[], args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=None, defaults=[]
+            ),
+            body=[],
+            decorator_list=[],
+            returns=None,
+            type_comment=None,
+        )
+        self.assertIsNone(ServiceEventsASTTransformer.get_and_remove_docstring(node))
+
+    def test_get_with_location_from_empty_body_uses_node_location(self):
+        """With an empty body, the with-location falls back to the node's own position."""
+        node = ast.FunctionDef(
+            name="empty",
+            args=ast.arguments(
+                posonlyargs=[], args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=None, defaults=[]
+            ),
+            body=[],
+            decorator_list=[],
+            returns=None,
+            type_comment=None,
+            lineno=11,
+            col_offset=4,
+        )
+        loc = ServiceEventsASTTransformer.get_with_location_from_node(node)
+        self.assertEqual(loc["lineno"], 11)
+        self.assertEqual(loc["col_offset"], 4)
+
+    def test_docstring_only_function_gets_pass_body(self):
+        """A function whose only statement is a docstring keeps the docstring and gets a `pass` body.
+
+        Exercises the empty-body branch: after the docstring is removed, the
+        `with` wraps an injected `ast.Pass` and the location falls back to the node.
+        """
+        source = '''
+def doc_only():
+    """just a docstring"""
+'''
+        tree = ast.parse(source)
+        transformer = ServiceEventsASTTransformer("/test/doc_only.py")
+        transformed = transformer.visit(tree)
+
+        func_def = transformed.body[0]
+        # Docstring preserved as first statement, with-statement second.
+        self.assertEqual(len(func_def.body), 2)
+        self.assertIsInstance(func_def.body[0], ast.Expr)
+        with_stmt = func_def.body[1]
+        self.assertIsInstance(with_stmt, ast.With)
+        # Empty body was replaced by a single `pass`.
+        self.assertEqual(len(with_stmt.body), 1)
+        self.assertIsInstance(with_stmt.body[0], ast.Pass)
+        self.assertEqual(transformer.instrumented_functions, 1)
+
+    def test_non_future_import_from_is_preserved(self):
+        """A non-__future__ ImportFrom is recursed into and kept in the tree."""
+        source = """
+from os import path
+"""
+        tree = ast.parse(source)
+        transformer = ServiceEventsASTTransformer("/test/imp.py")
+        transformed = transformer.visit(tree)
+
+        import_nodes = [node for node in transformed.body if isinstance(node, ast.ImportFrom)]
+        self.assertEqual(len(import_nodes), 1)
+        self.assertEqual(import_nodes[0].module, "os")
+        # No compiler flags set for a non-__future__ import.
+        self.assertEqual(transformer.compiler_flags, 0)
+
+    def test_future_import_sets_compiler_flags(self):
+        """A __future__ import sets the transformer's compiler_flags and is dropped."""
+        source = """
+from __future__ import annotations
+"""
+        tree = ast.parse(source)
+        transformer = ServiceEventsASTTransformer("/test/fut.py")
+        transformer.visit(tree)
+        self.assertNotEqual(transformer.compiler_flags, 0)
+
+
+class TestSourceLoaderGetCode(TestCase):
+    """Cover ServiceEventsSourceLoader.get_code transformation and fallbacks."""
+
+    def setUp(self):
+        clear_function_registry()
+        self._tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        clear_function_registry()
+
+    def _write(self, name, source):
+        path = os.path.join(self._tmpdir, name)
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(source)
+        return path
+
+    def test_get_code_transforms_and_compiles(self):
+        """A valid source file is parsed, transformed and compiled to a code object."""
+        path = self._write("good.py", "def foo():\n    return 1\n")
+        loader = ServiceEventsSourceLoader("good", path)
+        code = loader.get_code("good")
+        self.assertIsNotNone(code)
+        # The injected monitor import surfaces in the compiled code's constants/names.
+        self.assertIn("PythonServiceEventsMonitor", code.co_names)
+        # The function was registered during transformation.
+        registry = get_function_registry()
+        self.assertTrue(any(entry["name"] == "foo" for entry in registry.values()))
+
+    def test_get_code_syntax_error_falls_back_to_super(self):
+        """On a SyntaxError during parse, get_code defers to the default loader."""
+        path = self._write("ok.py", "def foo():\n    return 1\n")
+        loader = ServiceEventsSourceLoader("ok", path)
+        sentinel = object()
+        with patch.object(SourceFileLoader, "get_code", return_value=sentinel):
+            with patch(
+                "amazon.opentelemetry.distro.serviceevents.ast_transformation.ast.parse",
+                side_effect=SyntaxError("bad"),
+            ):
+                self.assertIs(loader.get_code("ok"), sentinel)
+
+    def test_get_code_unexpected_error_falls_back_to_super(self):
+        """Any non-syntax transformation failure also defers to the default loader."""
+        path = self._write("ok2.py", "def foo():\n    return 1\n")
+        loader = ServiceEventsSourceLoader("ok2", path)
+        sentinel = object()
+        with patch.object(SourceFileLoader, "get_code", return_value=sentinel):
+            with patch(
+                "amazon.opentelemetry.distro.serviceevents.ast_transformation.ast.parse",
+                side_effect=RuntimeError("boom"),
+            ):
+                self.assertIs(loader.get_code("ok2"), sentinel)
+
+
+class TestNameCouldMatch(TestCase):
+    """Cover the cheap name-only pre-filter _name_could_match."""
+
+    def _finder(self, packages_include=None, packages_exclude=None):
+        return ServiceEventsMetaPathFinder(set(packages_include or []), packages_exclude or [])
+
+    def test_empty_include_returns_false(self):
+        """Rule 1: empty include → never a candidate."""
+        self.assertFalse(self._finder()._name_could_match("myapp.foo"))
+
+    def test_self_exclude_returns_false(self):
+        """Rule 0: SDK self-exclusion drops candidates by name alone."""
+        finder = self._finder(packages_include=["*.*"])
+        self.assertFalse(finder._name_could_match("opentelemetry.sdk.trace"))
+        self.assertFalse(finder._name_could_match("amazon.opentelemetry.distro.foo"))
+
+    def test_include_match_returns_true(self):
+        """Rule 3 (name part): a matching include pattern makes it a candidate."""
+        finder = self._finder(packages_include=["myapp.*"])
+        self.assertTrue(finder._name_could_match("myapp.foo"))
+
+    def test_no_include_match_returns_false(self):
+        """No include pattern matches the name → not a candidate."""
+        finder = self._finder(packages_include=["myapp.*"])
+        self.assertFalse(finder._name_could_match("other.bar"))
+
+
+class TestFindSpecMainPath(TestCase):
+    """Cover the happy-path and structural-skip branches of find_spec."""
+
+    def _finder(self, packages_include=None, packages_exclude=None):
+        return ServiceEventsMetaPathFinder(set(packages_include or ["myapp.*"]), packages_exclude or [])
+
+    def test_find_spec_replaces_loader_for_py_module(self):
+        """A matching .py module gets its loader swapped for ServiceEventsSourceLoader."""
+        finder = self._finder()
+        fake_spec = ModuleSpec("myapp.foo", loader=None, origin="/app/myapp/foo.py")
+        with patch("importlib.util.find_spec", return_value=fake_spec):
+            result = finder.find_spec("myapp.foo", None, None)
+        self.assertIs(result, fake_spec)
+        self.assertIsInstance(result.loader, ServiceEventsSourceLoader)
+        self.assertNotIn("myapp.foo", finder._currently_loading)
+
+    def test_find_spec_returns_none_when_spec_is_none(self):
+        """If the default machinery yields no spec, find_spec returns None."""
+        finder = self._finder()
+        with patch("importlib.util.find_spec", return_value=None):
+            self.assertIsNone(finder.find_spec("myapp.missing", None, None))
+        self.assertNotIn("myapp.missing", finder._currently_loading)
+
+    def test_find_spec_skips_non_python_origin(self):
+        """A non-.py origin (e.g. extension module) is left to the default loader."""
+        finder = self._finder()
+        fake_spec = ModuleSpec("myapp.ext", loader=None, origin="/app/myapp/ext.so")
+        with patch("importlib.util.find_spec", return_value=fake_spec):
+            self.assertIsNone(finder.find_spec("myapp.ext", None, None))
+
+    def test_find_spec_skips_module_excluded_by_should_instrument(self):
+        """A name candidate that should_instrument_module rejects returns None."""
+        finder = self._finder(packages_include=["myapp.*"], packages_exclude=["myapp.foo"])
+        fake_spec = ModuleSpec("myapp.foo", loader=None, origin="/app/myapp/foo.py")
+        with patch("importlib.util.find_spec", return_value=fake_spec):
+            self.assertIsNone(finder.find_spec("myapp.foo", None, None))
+
+    def test_find_spec_recursion_guard_returns_none(self):
+        """A module already mid-load short-circuits to None (recursion guard)."""
+        finder = self._finder()
+        finder._currently_loading.add("myapp.loop")
+        try:
+            self.assertIsNone(finder.find_spec("myapp.loop", None, None))
+        finally:
+            finder._currently_loading.discard("myapp.loop")
+
+    def test_find_spec_name_prefilter_skips_unmatched(self):
+        """A name that can't match the include is dropped before spec resolution."""
+        finder = self._finder()
+        with patch("importlib.util.find_spec", side_effect=AssertionError("should not resolve")):
+            self.assertIsNone(finder.find_spec("stdlib.thing", None, None))
+
+
+class TestInstallUninstallHooks(TestCase):
+    """Cover install_ast_hooks / uninstall_ast_hooks, restoring sys.meta_path."""
+
+    def setUp(self):
+        self._saved_meta_path = list(sys.meta_path)
+
+    def tearDown(self):
+        sys.meta_path[:] = self._saved_meta_path
+
+    def test_install_inserts_finder_at_front(self):
+        """install_ast_hooks inserts a finder at position 0 with the given config."""
+        install_ast_hooks({"myapp.*"}, ["myapp.internal.*"])
+        finder = sys.meta_path[0]
+        self.assertIsInstance(finder, ServiceEventsMetaPathFinder)
+        self.assertEqual(finder.packages_include, {"myapp.*"})
+        self.assertEqual(finder.packages_exclude, ["myapp.internal.*"])
+
+    def test_install_defaults_to_empty_config(self):
+        """With no args, the installed finder gets an empty include set and exclude list."""
+        install_ast_hooks()
+        finder = sys.meta_path[0]
+        self.assertIsInstance(finder, ServiceEventsMetaPathFinder)
+        self.assertEqual(finder.packages_include, set())
+        self.assertEqual(finder.packages_exclude, [])
+
+    def test_uninstall_removes_all_finders(self):
+        """uninstall_ast_hooks removes every ServiceEventsMetaPathFinder from sys.meta_path."""
+        install_ast_hooks({"a.*"})
+        install_ast_hooks({"b.*"})
+        self.assertTrue(any(isinstance(f, ServiceEventsMetaPathFinder) for f in sys.meta_path))
+        uninstall_ast_hooks()
+        self.assertFalse(any(isinstance(f, ServiceEventsMetaPathFinder) for f in sys.meta_path))
+
+    def test_uninstall_is_idempotent(self):
+        """Calling uninstall when no finder is installed is a no-op."""
+        uninstall_ast_hooks()
+        uninstall_ast_hooks()
+        self.assertFalse(any(isinstance(f, ServiceEventsMetaPathFinder) for f in sys.meta_path))

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/test_direct_cw_otlp.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/test_direct_cw_otlp.py
@@ -42,40 +42,59 @@ class TestBuildLogOtlpExporter(TestCase):
         self.assertIs(type(exp), OTLPLogExporter)
 
     def test_cloudwatch_endpoint_routes_to_sigv4_exporter(self):
-        """Mock the SigV4 exporter to avoid AWS credential resolution in CI.
+        """The CloudWatch endpoint builds the SigV4 exporter via a botocore session.
 
-        Both ``boto3`` and the AWS log-record exporter module are stubbed via
-        ``sys.modules`` rather than ``mock.patch("dotted.path")``. That
-        matters because ``mock.patch`` resolves its target by dotted-name
-        lookup, which walks ``sys.meta_path`` finders. Other tests in this
-        suite (``TestServiceEventsModes``) install the ServiceEvents AST import hook
-        and never uninstall it, so accumulated finders turn that lookup
-        into pathological recursion. Pre-populating ``sys.modules`` sidesteps
-        meta_path entirely — the lazy ``import`` inside the function under
-        test resolves directly from the cache.
+        Regression guard for the boto3-vs-botocore finding: the SigV4 path must
+        obtain its session from ``get_aws_session()`` (which returns a
+        ``botocore.session.Session``) and must NOT ``import boto3``. ``boto3`` is
+        not a declared distro dependency, so we assert it stays absent from
+        ``sys.modules`` throughout — if the production code reintroduced
+        ``import boto3`` this would fail in a botocore-only environment.
+
+        The AWS log-record exporter module is stubbed via ``sys.modules`` rather
+        than ``mock.patch("dotted.path")``. That matters because ``mock.patch``
+        resolves its target by dotted-name lookup, which walks
+        ``sys.meta_path`` finders. Other tests in this suite
+        (``TestServiceEventsModes``) install the ServiceEvents AST import hook
+        and never uninstall it, so accumulated finders turn that lookup into
+        pathological recursion. Pre-populating ``sys.modules`` sidesteps
+        meta_path entirely — the lazy ``import`` inside the function under test
+        resolves directly from the cache. ``get_aws_session`` is patched at its
+        source module so the function picks up the stub on its lazy import.
         """
         from amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation import _build_log_otlp_exporter
         from opentelemetry.exporter.otlp.proto.http import Compression
 
-        stub_boto3 = types.ModuleType("boto3")
-        stub_boto3.Session = MagicMock(return_value=MagicMock(name="stub-boto3-session"))
+        stub_session = MagicMock(name="stub-botocore-session")
 
         exporter_module_path = "amazon.opentelemetry.distro.exporter.otlp.aws.logs.otlp_aws_log_record_exporter"
         stub_exporter_module = types.ModuleType(exporter_module_path)
         mock_ctor = MagicMock(name="OTLPAwsLogRecordExporter")
         stub_exporter_module.OTLPAwsLogRecordExporter = mock_ctor
 
-        with patch.dict(
-            sys.modules,
-            {"boto3": stub_boto3, exporter_module_path: stub_exporter_module},
+        # Guard: boto3 must never be imported by the SigV4 path.
+        had_boto3 = "boto3" in sys.modules
+        if had_boto3:
+            self.addCleanup(lambda saved=sys.modules["boto3"]: sys.modules.__setitem__("boto3", saved))
+            del sys.modules["boto3"]
+
+        with patch.dict(sys.modules, {exporter_module_path: stub_exporter_module}), patch(
+            "amazon.opentelemetry.distro._utils.get_aws_session", return_value=stub_session
         ):
             _build_log_otlp_exporter(
                 "https://logs.us-east-2.amazonaws.com/v1/logs",
                 {"x-aws-log-group": "/my/group", "x-aws-log-stream": "my-stream"},
                 Compression.Gzip,
             )
+
+        # boto3 must not have been imported as a side effect of the SigV4 build.
+        self.assertNotIn("boto3", sys.modules)
+
         mock_ctor.assert_called_once()
         kwargs = mock_ctor.call_args.kwargs
+        # The exporter receives the botocore session from get_aws_session(),
+        # not a boto3.Session().
+        self.assertIs(kwargs["session"], stub_session)
         # Region was extracted from the endpoint hostname.
         self.assertEqual(kwargs["aws_region"], "us-east-2")
         self.assertEqual(kwargs["endpoint"], "https://logs.us-east-2.amazonaws.com/v1/logs")
@@ -83,3 +102,30 @@ class TestBuildLogOtlpExporter(TestCase):
             kwargs["headers"],
             {"x-aws-log-group": "/my/group", "x-aws-log-stream": "my-stream"},
         )
+
+    def test_cloudwatch_endpoint_without_botocore_falls_back_to_plain_exporter(self):
+        """When botocore is unavailable the CloudWatch path must degrade gracefully.
+
+        ``get_aws_session()`` returns ``None`` when botocore is not installed.
+        The SigV4 path must then fall back to a plain (unsigned) ``OTLPLogExporter``
+        against the same endpoint — never return ``None`` (the caller does not
+        handle it) and never raise into the host app. This is the core
+        regression: previously the path did ``import boto3`` and an
+        ``ImportError`` was swallowed by ``initialize()``'s broad-except,
+        silently disabling all ServiceEvents telemetry.
+        """
+        from amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation import _build_log_otlp_exporter
+        from opentelemetry.exporter.otlp.proto.http import Compression
+        from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+
+        with patch("amazon.opentelemetry.distro._utils.get_aws_session", return_value=None):
+            exp = _build_log_otlp_exporter(
+                "https://logs.us-east-2.amazonaws.com/v1/logs",
+                {"x-aws-log-group": "/my/group", "x-aws-log-stream": "my-stream"},
+                Compression.Gzip,
+            )
+
+        # Falls back to the plain upstream exporter (not the SigV4 subclass),
+        # and crucially is not None.
+        self.assertIsNotNone(exp)
+        self.assertIs(type(exp), OTLPLogExporter)

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/test_direct_cw_otlp.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/test_direct_cw_otlp.py
@@ -1,0 +1,85 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the _build_log_otlp_exporter helper in serviceevents_instrumentation.
+
+Kept in a separate file to avoid interactions with the stateful
+ServiceEventsInstrumentation lifecycle tests (which initialize real collectors).
+"""
+
+import sys
+import types
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+
+class TestBuildLogOtlpExporter(TestCase):
+    """Verify _build_log_otlp_exporter routes correctly based on endpoint shape."""
+
+    def test_collector_proxied_endpoint_returns_plain_exporter(self):
+        from amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation import _build_log_otlp_exporter
+        from opentelemetry.exporter.otlp.proto.http import Compression
+        from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+
+        exp = _build_log_otlp_exporter(
+            "http://localhost:4316/v1/logs",
+            {"x-aws-log-group": "g", "x-aws-log-stream": "s"},
+            Compression.NoCompression,
+        )
+        # OTLPAwsLogRecordExporter subclasses OTLPLogExporter, so use `type is`
+        # rather than `isinstance` to distinguish the plain upstream class.
+        self.assertIs(type(exp), OTLPLogExporter)
+
+    def test_arbitrary_https_endpoint_returns_plain_exporter(self):
+        from amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation import _build_log_otlp_exporter
+        from opentelemetry.exporter.otlp.proto.http import Compression
+        from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+
+        exp = _build_log_otlp_exporter(
+            "https://my-collector.example.com/v1/logs",
+            {},
+            Compression.Gzip,
+        )
+        self.assertIs(type(exp), OTLPLogExporter)
+
+    def test_cloudwatch_endpoint_routes_to_sigv4_exporter(self):
+        """Mock the SigV4 exporter to avoid AWS credential resolution in CI.
+
+        Both ``boto3`` and the AWS log-record exporter module are stubbed via
+        ``sys.modules`` rather than ``mock.patch("dotted.path")``. That
+        matters because ``mock.patch`` resolves its target by dotted-name
+        lookup, which walks ``sys.meta_path`` finders. Other tests in this
+        suite (``TestServiceEventsModes``) install the ServiceEvents AST import hook
+        and never uninstall it, so accumulated finders turn that lookup
+        into pathological recursion. Pre-populating ``sys.modules`` sidesteps
+        meta_path entirely — the lazy ``import`` inside the function under
+        test resolves directly from the cache.
+        """
+        from amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation import _build_log_otlp_exporter
+        from opentelemetry.exporter.otlp.proto.http import Compression
+
+        stub_boto3 = types.ModuleType("boto3")
+        stub_boto3.Session = MagicMock(return_value=MagicMock(name="stub-boto3-session"))
+
+        exporter_module_path = "amazon.opentelemetry.distro.exporter.otlp.aws.logs.otlp_aws_log_record_exporter"
+        stub_exporter_module = types.ModuleType(exporter_module_path)
+        mock_ctor = MagicMock(name="OTLPAwsLogRecordExporter")
+        stub_exporter_module.OTLPAwsLogRecordExporter = mock_ctor
+
+        with patch.dict(
+            sys.modules,
+            {"boto3": stub_boto3, exporter_module_path: stub_exporter_module},
+        ):
+            _build_log_otlp_exporter(
+                "https://logs.us-east-2.amazonaws.com/v1/logs",
+                {"x-aws-log-group": "/my/group", "x-aws-log-stream": "my-stream"},
+                Compression.Gzip,
+            )
+        mock_ctor.assert_called_once()
+        kwargs = mock_ctor.call_args.kwargs
+        # Region was extracted from the endpoint hostname.
+        self.assertEqual(kwargs["aws_region"], "us-east-2")
+        self.assertEqual(kwargs["endpoint"], "https://logs.us-east-2.amazonaws.com/v1/logs")
+        self.assertEqual(
+            kwargs["headers"],
+            {"x-aws-log-group": "/my/group", "x-aws-log-stream": "my-stream"},
+        )

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/test_python_monitor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/test_python_monitor.py
@@ -1,0 +1,1213 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import threading
+import time
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from amazon.opentelemetry.distro.serviceevents.python_monitor import (
+    PythonServiceEventsMonitor,
+    _ServiceEventsMonitorState,
+)
+from amazon.opentelemetry.distro.serviceevents.python_monitor_impl import (
+    _adaptive_sample_cache,
+    _call_counters,
+    _call_counters_lock,
+    _call_stack,
+    _current_operation,
+    _hot_operations,
+    _hot_operations_lock,
+    _increment_call_counter,
+    _should_sample,
+    get_call_stack,
+    get_current_operation,
+    get_sampling_mode,
+    mark_operation_hot,
+    reset_after_fork,
+    set_current_operation,
+    set_sampling_mode,
+    set_sampling_thresholds,
+    tick_hot_operations,
+)
+
+
+class TestServiceEventsMonitorState(TestCase):
+    """Test the _ServiceEventsMonitorState singleton class."""
+
+    def setUp(self):
+        """Reset the singleton instance before each test."""
+        _ServiceEventsMonitorState._instance = None
+
+    def test_singleton_pattern(self):
+        """Test that get_instance returns the same instance."""
+        instance1 = _ServiceEventsMonitorState.get_instance()
+        instance2 = _ServiceEventsMonitorState.get_instance()
+
+        self.assertIs(instance1, instance2)
+
+    def test_singleton_thread_safe(self):
+        """Test that singleton is thread-safe."""
+        instances = []
+
+        def get_instance():
+            instances.append(_ServiceEventsMonitorState.get_instance())
+
+        threads = [threading.Thread(target=get_instance) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # All instances should be the same
+        self.assertEqual(len(set(id(i) for i in instances)), 1)
+
+    def test_begin_investigation(self):
+        """Test beginning an investigation."""
+        state = _ServiceEventsMonitorState.get_instance()
+
+        state.begin_investigation()
+
+        inv_data = state._investigation_data.get()
+        self.assertIsNotNone(inv_data)
+        self.assertIn("call_path", inv_data)
+        self.assertIn("exception", inv_data)
+        self.assertIn("start_time", inv_data)
+
+    def test_get_investigation_data(self):
+        """Test getting and clearing investigation data."""
+        state = _ServiceEventsMonitorState.get_instance()
+
+        state.begin_investigation()
+        state.record_execution_flow(None, "func1")
+        state.record_execution_flow("func1", "func2")
+
+        inv_data = state.get_investigation_data()
+
+        self.assertIsNotNone(inv_data)
+        self.assertEqual(len(inv_data["call_path"]), 2)
+        self.assertEqual(inv_data["call_path"][0], (None, "func1"))
+        self.assertEqual(inv_data["call_path"][1], ("func1", "func2"))
+
+        # Should be cleared after get
+        inv_data2 = state.get_investigation_data()
+        self.assertIsNone(inv_data2)
+
+
+class TestPythonServiceEventsMonitor(TestCase):
+    """Test the PythonServiceEventsMonitor context manager."""
+
+    def setUp(self):
+        """Reset state before each test."""
+        _ServiceEventsMonitorState._instance = None
+        _call_stack.set([])
+        set_sampling_mode("always")  # Ensure timing is collected for monitor tests
+
+    @patch("amazon.opentelemetry.distro.serviceevents.python_monitor_impl.time.perf_counter_ns")
+    def test_basic_context_manager(self, mock_time):
+        """Test basic enter/exit of context manager records a timed call-path entry."""
+        mock_time.side_effect = [1000000000, 1100000000]  # 100ms difference
+
+        state = _ServiceEventsMonitorState.get_instance()
+        state.begin_investigation()
+
+        with PythonServiceEventsMonitor("test_func"):
+            pass
+
+        inv_data = state.get_investigation_data()
+        self.assertIsNotNone(inv_data)
+        self.assertEqual(len(inv_data["call_path"]), 1)
+        entry = inv_data["call_path"][0]
+        self.assertEqual(entry["function_name"], "test_func")
+        self.assertIsNone(entry["caller_function_name"])
+        # Duration is in nanoseconds (100ms = 100_000_000ns)
+        self.assertEqual(entry["duration_ns"], 100_000_000)
+
+    @patch("amazon.opentelemetry.distro.serviceevents.python_monitor_impl.time.perf_counter_ns")
+    def test_nested_calls(self, mock_time):
+        """Test nested function calls capture the caller relationship in the call path."""
+        mock_time.side_effect = [
+            1000000000,
+            2000000000,  # inner enter
+            2500000000,  # inner exit
+            3000000000,  # outer exit
+        ]
+
+        state = _ServiceEventsMonitorState.get_instance()
+        state.begin_investigation()
+
+        with PythonServiceEventsMonitor("outer_func"):
+            with PythonServiceEventsMonitor("inner_func"):
+                pass
+
+        inv_data = state.get_investigation_data()
+        self.assertIsNotNone(inv_data)
+
+        # Both functions are recorded; the inner one exits (and records) first.
+        by_name = {e["function_name"]: e for e in inv_data["call_path"]}
+        self.assertIn("outer_func", by_name)
+        self.assertIn("inner_func", by_name)
+
+        # Inner function should have outer_func as caller; outer is an entry point.
+        self.assertEqual(by_name["inner_func"]["caller_function_name"], "outer_func")
+        self.assertIsNone(by_name["outer_func"]["caller_function_name"])
+
+    @patch("amazon.opentelemetry.distro.serviceevents.python_monitor_impl.time.perf_counter_ns")
+    def test_exception_handling(self, mock_time):
+        """Test that exceptions are captured in investigation data but not suppressed."""
+        mock_time.side_effect = [1000000000, 1100000000]
+
+        state = _ServiceEventsMonitorState.get_instance()
+        state.begin_investigation()
+
+        with self.assertRaises(ValueError):
+            with PythonServiceEventsMonitor("error_func"):
+                raise ValueError("Test error")
+
+        inv_data = state.get_investigation_data()
+        self.assertIsNotNone(inv_data)
+        # The call is still recorded in the call path...
+        self.assertEqual(len(inv_data["call_path"]), 1)
+        self.assertEqual(inv_data["call_path"][0]["function_name"], "error_func")
+        # ...and the raised exception is captured (without being suppressed).
+        self.assertIsNotNone(inv_data["exception"])
+        self.assertEqual(inv_data["exception"]["name"], "ValueError")
+        self.assertEqual(inv_data["exception"]["function_name"], "error_func")
+
+    @patch("amazon.opentelemetry.distro.serviceevents.python_monitor_impl.time.perf_counter_ns")
+    def test_multiple_invocations(self, mock_time):
+        """Test multiple invocations of the same function each record a call-path entry."""
+        mock_time.side_effect = [
+            1000000000,
+            1100000000,  # First call: 100ms
+            2000000000,
+            2300000000,  # Second call: 300ms
+            3000000000,
+            3150000000,  # Third call: 150ms
+        ]
+
+        state = _ServiceEventsMonitorState.get_instance()
+        state.begin_investigation()
+
+        for _ in range(3):
+            with PythonServiceEventsMonitor("repeated_func"):
+                pass
+
+        inv_data = state.get_investigation_data()
+        self.assertIsNotNone(inv_data)
+        entries = [e for e in inv_data["call_path"] if e["function_name"] == "repeated_func"]
+        self.assertEqual(len(entries), 3)
+        # Durations in nanoseconds: 100ms + 300ms + 150ms = 550_000_000ns
+        self.assertEqual(sum(e["duration_ns"] for e in entries), 550_000_000)
+
+    def test_call_stack_isolation(self):
+        """Test that call stack is properly isolated per context."""
+        # Each context should have its own call stack
+        _call_stack.set(["initial"])
+
+        with PythonServiceEventsMonitor("func1"):
+            stack = _call_stack.get()
+            self.assertIn("func1", stack)
+
+        # After exiting, stack should be restored
+        stack = _call_stack.get()
+        self.assertNotIn("func1", stack)
+
+    @patch("amazon.opentelemetry.distro.serviceevents.python_monitor_impl.time.perf_counter_ns")
+    def test_concurrent_monitoring(self, mock_time):
+        """Test thread-safe concurrent monitoring of the shared call counters.
+
+        The per-function counter only drives AUTO-mode tiered sampling, so it is only
+        maintained in that mode — drive AUTO here to exercise the locked increment path.
+        """
+        mock_time.return_value = 1000000000
+
+        set_sampling_mode("auto")
+        with _call_counters_lock:
+            _call_counters.clear()
+
+        def monitor_function(func_id):
+            with PythonServiceEventsMonitor(func_id):
+                time.sleep(0.001)  # Small delay
+
+        threads = [threading.Thread(target=monitor_function, args=(f"func_{i}",)) for i in range(10)]
+
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # All 10 functions should be counted exactly once in the shared counter.
+        with _call_counters_lock:
+            for i in range(10):
+                self.assertEqual(_call_counters.get(f"func_{i}"), 1)
+
+    def test_counter_skipped_outside_auto_mode(self):
+        """In non-AUTO modes the call counter is not maintained (hot-path optimization)."""
+        with _call_counters_lock:
+            _call_counters.clear()
+
+        for mode in ("always", "never", "adaptive"):
+            set_sampling_mode(mode)
+            with PythonServiceEventsMonitor(f"skip_func_{mode}"):
+                pass
+
+        with _call_counters_lock:
+            self.assertEqual(_call_counters, {}, "counter must stay empty outside AUTO mode")
+
+    def test_get_instance_class_method(self):
+        """Test that get_instance on PythonServiceEventsMonitor returns state."""
+        state = PythonServiceEventsMonitor.get_instance()
+        self.assertIsInstance(state, _ServiceEventsMonitorState)
+
+
+class TestCrashSafety(TestCase):
+    """The monitor wraps the entire body of every instrumented customer function,
+    so __enter__/__exit__ must NEVER propagate a telemetry exception into customer
+    control flow (it would crash the function, or worse, mask the customer's own
+    in-flight exception)."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+        _call_stack.set([])
+        set_sampling_mode("always")
+
+    def test_exit_telemetry_failure_does_not_break_successful_call(self):
+        """If a recording call raises in __exit__, the customer's normal return is preserved."""
+        state = _ServiceEventsMonitorState.get_instance()
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("histogram exploded")
+
+        ran = []
+        with patch.object(state, "record_function_call_metrics", side_effect=boom):
+            with PythonServiceEventsMonitor("ok_func"):
+                ran.append(True)
+
+        # The body ran and no telemetry exception escaped the with-block.
+        self.assertEqual(ran, [True])
+
+    def test_exit_telemetry_failure_does_not_mask_customer_exception(self):
+        """A telemetry failure in __exit__ must not replace the customer's in-flight exception."""
+        state = _ServiceEventsMonitorState.get_instance()
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("telemetry error that must not surface")
+
+        with patch.object(state, "record_call_path_entry", side_effect=boom):
+            with patch.object(state, "record_function_call_metrics", side_effect=boom):
+                # The ValueError the customer raised must be what propagates,
+                # NOT the telemetry RuntimeError.
+                with self.assertRaises(ValueError) as ctx:
+                    with PythonServiceEventsMonitor("error_func"):
+                        raise ValueError("customer error")
+        self.assertEqual(str(ctx.exception), "customer error")
+
+    def test_exit_survives_exception_with_misbehaving_str(self):
+        """A customer exception whose __str__ raises must not crash __exit__.
+
+        Requires an active investigation so __exit__ actually reaches the
+        ``str(exc_value)`` branch (otherwise the test is vacuous).
+        """
+        # Activate investigation capture so the str(exc_value) path is exercised.
+        state = _ServiceEventsMonitorState.get_instance()
+        state.begin_investigation()
+        self.assertIsNotNone(state.peek_investigation_data())
+
+        called = {"str": False}
+
+        class EvilError(Exception):
+            def __str__(self):
+                called["str"] = True
+                raise RuntimeError("__str__ exploded")
+
+        # __exit__ calls str(exc_value); the original EvilError must still propagate.
+        with self.assertRaises(EvilError):
+            with PythonServiceEventsMonitor("evil_func"):
+                raise EvilError()
+
+        # Prove the guarded str(exc_value) line was actually hit.
+        self.assertTrue(called["str"], "test did not exercise the str(exc_value) branch")
+
+    def test_enter_telemetry_failure_still_runs_customer_body(self):
+        """If __enter__ setup raises, the customer body must still execute."""
+        ran = []
+        # AUTO mode is the only one that calls _increment_call_counter in __enter__, so
+        # drive AUTO to make the injected failure actually fire on the setup path.
+        set_sampling_mode("auto")
+        with patch(
+            "amazon.opentelemetry.distro.serviceevents.python_monitor_impl._increment_call_counter",
+            side_effect=RuntimeError("counter exploded"),
+        ):
+            with PythonServiceEventsMonitor("enter_fail_func"):
+                ran.append(True)
+        self.assertEqual(ran, [True])
+
+    def test_exit_recorder_failure_keeps_call_stack_balanced(self):
+        """A recording failure in __exit__ must not leak this frame on the stack."""
+        state = _ServiceEventsMonitorState.get_instance()
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("recorder exploded")
+
+        _call_stack.set([])
+        with patch.object(state, "record_call_path_entry", side_effect=boom):
+            with PythonServiceEventsMonitor("solo_func"):
+                pass
+
+        # The frame pushed in __enter__ must be popped even though recording failed.
+        self.assertEqual(_call_stack.get(), [])
+
+    def test_enter_failure_does_not_pop_parent_frame(self):
+        """If a nested __enter__ fails before pushing, its __exit__ must not pop the parent."""
+        # AUTO mode is the only one that calls _increment_call_counter in __enter__, which is
+        # where this test injects the inner-frame failure.
+        set_sampling_mode("auto")
+        # Seed a parent frame, then make only the inner monitor's __enter__ fail.
+        original = _increment_call_counter
+
+        def selective(function_name):
+            if function_name == "inner":
+                raise RuntimeError("counter exploded for inner")
+            return original(function_name)
+
+        with patch(
+            "amazon.opentelemetry.distro.serviceevents.python_monitor_impl._increment_call_counter",
+            side_effect=selective,
+        ):
+            with PythonServiceEventsMonitor("outer"):
+                self.assertEqual(_call_stack.get(), ["outer"])
+                with PythonServiceEventsMonitor("inner"):
+                    # inner.__enter__ failed before pushing, so the stack is unchanged.
+                    self.assertEqual(_call_stack.get(), ["outer"])
+                # inner.__exit__ must NOT have popped the parent's frame.
+                self.assertEqual(_call_stack.get(), ["outer"])
+        # After outer exits, the stack is balanced.
+        self.assertEqual(_call_stack.get(), [])
+
+
+class TestAdaptiveSampling(TestCase):
+    """Test the adaptive sampling mode and hot operation tracking."""
+
+    def setUp(self):
+        """Reset state before each test."""
+        _ServiceEventsMonitorState._instance = None
+        _call_stack.set([])
+        _current_operation.set(None)
+        _adaptive_sample_cache.set(None)
+        with _hot_operations_lock:
+            _hot_operations.clear()
+        set_sampling_mode("always")
+
+    def tearDown(self):
+        """Restore sampling mode after each test."""
+        set_sampling_mode("always")
+        _current_operation.set(None)
+        _adaptive_sample_cache.set(None)
+        with _hot_operations_lock:
+            _hot_operations.clear()
+
+    def test_adaptive_no_sampling_for_cold_operation(self):
+        """In adaptive mode, non-hot operations should not be sampled."""
+        set_sampling_mode("adaptive")
+        _current_operation.set("endpoint-123")
+
+        self.assertFalse(_should_sample(1))
+
+    def test_adaptive_samples_hot_operation(self):
+        """In adaptive mode, hot operations should be sampled."""
+        set_sampling_mode("adaptive")
+        _current_operation.set("endpoint-123")
+        mark_operation_hot("endpoint-123")
+
+        self.assertTrue(_should_sample(1))
+
+    def test_adaptive_does_not_sample_different_operation(self):
+        """In adaptive mode, only the hot operation gets sampled."""
+        set_sampling_mode("adaptive")
+        mark_operation_hot("endpoint-123")
+        _current_operation.set("endpoint-456")
+
+        self.assertFalse(_should_sample(1))
+
+    def test_adaptive_caches_result_per_request(self):
+        """Second call should use cached result without checking hot operations."""
+        set_sampling_mode("adaptive")
+        _current_operation.set("endpoint-123")
+        mark_operation_hot("endpoint-123")
+
+        # First call: checks hot operations, caches True
+        self.assertTrue(_should_sample(1))
+
+        # Remove from hot operations (simulating expiry between calls)
+        with _hot_operations_lock:
+            _hot_operations.clear()
+
+        # Second call: returns cached True despite operation no longer being hot
+        self.assertTrue(_should_sample(2))
+
+    def test_adaptive_cache_cleared_with_operation(self):
+        """Cache should be cleared when operation context is cleared."""
+        set_sampling_mode("adaptive")
+        _current_operation.set("endpoint-123")
+        mark_operation_hot("endpoint-123")
+
+        self.assertTrue(_should_sample(1))
+
+        # Clear operation (simulating end of request)
+        from amazon.opentelemetry.distro.serviceevents.python_monitor_impl import clear_current_operation
+
+        clear_current_operation()
+
+        # Set new operation context (new request)
+        _current_operation.set("endpoint-456")
+        self.assertFalse(_should_sample(2))
+
+    def test_adaptive_no_operation_context(self):
+        """Without operation context, adaptive mode should not sample."""
+        set_sampling_mode("adaptive")
+        # No operation set
+        self.assertFalse(_should_sample(1))
+
+    def test_mark_operation_hot(self):
+        """Marking an operation hot should add it to the hot operations dict."""
+        mark_operation_hot("endpoint-123")
+        self.assertIn("endpoint-123", _hot_operations)
+        self.assertEqual(_hot_operations["endpoint-123"], 100)
+
+    def test_mark_operation_hot_resets_countdown(self):
+        """Re-marking a hot operation should reset the countdown."""
+        mark_operation_hot("endpoint-123")
+        # Simulate some ticks
+        for _ in range(50):
+            tick_hot_operations()
+        self.assertEqual(_hot_operations["endpoint-123"], 50)
+
+        # Re-mark should reset to full
+        mark_operation_hot("endpoint-123")
+        self.assertEqual(_hot_operations["endpoint-123"], 100)
+
+    def test_tick_hot_operations_decrements(self):
+        """Each tick should decrement the countdown."""
+        mark_operation_hot("endpoint-123")
+        tick_hot_operations()
+        self.assertEqual(_hot_operations["endpoint-123"], 99)
+
+    def test_tick_hot_operations_removes_expired(self):
+        """Operations should be removed after countdown reaches 0."""
+        mark_operation_hot("endpoint-123")
+        for _ in range(100):
+            tick_hot_operations()
+        self.assertNotIn("endpoint-123", _hot_operations)
+
+    def test_tick_hot_operations_multiple(self):
+        """Multiple hot operations should be tracked independently."""
+        mark_operation_hot("endpoint-A")
+        for _ in range(50):
+            tick_hot_operations()
+        mark_operation_hot("endpoint-B")
+
+        # A has 50 remaining, B has 100
+        self.assertEqual(_hot_operations["endpoint-A"], 50)
+        self.assertEqual(_hot_operations["endpoint-B"], 100)
+
+        for _ in range(50):
+            tick_hot_operations()
+
+        # A should be removed, B has 50 remaining
+        self.assertNotIn("endpoint-A", _hot_operations)
+        self.assertEqual(_hot_operations["endpoint-B"], 50)
+
+    def test_existing_modes_unchanged(self):
+        """Existing sampling modes should work as before."""
+        _current_operation.set("endpoint-123")
+        mark_operation_hot("endpoint-123")
+
+        set_sampling_mode("always")
+        self.assertTrue(_should_sample(1))
+
+        _adaptive_sample_cache.set(None)  # Clear cache between mode switches
+        set_sampling_mode("never")
+        self.assertFalse(_should_sample(1))
+
+    def test_invalid_sampling_mode_rejected(self):
+        """Invalid sampling mode should raise ValueError."""
+        with self.assertRaises(ValueError):
+            set_sampling_mode("invalid")
+
+    @patch("amazon.opentelemetry.distro.serviceevents.python_monitor_impl.time.perf_counter_ns")
+    def test_adaptive_monitor_records_timing_for_hot_operation(self, mock_time):
+        """In adaptive mode, hot operations should have real duration in call_path."""
+        set_sampling_mode("adaptive")
+        _current_operation.set("endpoint-123")
+        mark_operation_hot("endpoint-123")
+        mock_time.side_effect = [1000000000, 1100000000]  # 100ms
+
+        state = _ServiceEventsMonitorState.get_instance()
+        state.begin_investigation()
+
+        with PythonServiceEventsMonitor("test_func"):
+            pass
+
+        inv_data = state.get_investigation_data()
+        self.assertIsNotNone(inv_data)
+        self.assertEqual(len(inv_data["call_path"]), 1)
+        entry = inv_data["call_path"][0]
+        self.assertEqual(entry["duration_ns"], 100_000_000)
+
+    def test_adaptive_monitor_no_timing_for_cold_operation(self):
+        """In adaptive mode, cold operations should have duration_ns=0 in call_path."""
+        set_sampling_mode("adaptive")
+        _current_operation.set("endpoint-cold")
+
+        state = _ServiceEventsMonitorState.get_instance()
+        state.begin_investigation()
+
+        with PythonServiceEventsMonitor("test_func"):
+            pass
+
+        inv_data = state.get_investigation_data()
+        self.assertIsNotNone(inv_data)
+        self.assertEqual(len(inv_data["call_path"]), 1)
+        entry = inv_data["call_path"][0]
+        self.assertEqual(entry["duration_ns"], 0)
+
+    @patch("amazon.opentelemetry.distro.serviceevents.python_monitor_impl.time.perf_counter_ns")
+    def test_adaptive_cache_reset_on_set_operation(self, mock_time):
+        """Setting operation resets adaptive cache to prevent cache poisoning.
+
+        Regression test: If a monitored function runs before the Flask before_request
+        hook sets the operation (e.g., WSGI middleware), _should_sample() caches
+        False (no operation -> not hot). Without cache reset, all subsequent functions
+        in the same request also get False even after the operation is set.
+        """
+        mock_time.side_effect = [1000, 2000]  # start, end times
+        set_sampling_mode("adaptive")
+        operation = "GET /endpoint-hot"
+        mark_operation_hot(operation)
+
+        # Simulate middleware running BEFORE operation is set
+        # _should_sample() caches False because operation is None
+        self.assertFalse(_should_sample(1))
+        self.assertFalse(_adaptive_sample_cache.get())  # Cache poisoned to False
+
+        # Simulate before_request hook setting operation
+        # This must reset the cache so _should_sample() re-evaluates
+        set_current_operation(operation)
+
+        # Now _should_sample() should re-evaluate and find the hot operation
+        self.assertTrue(_should_sample(1))
+
+
+class TestSamplingThresholds(TestCase):
+    """Test configurable sampling thresholds."""
+
+    def setUp(self):
+        """Reset thresholds to defaults before each test."""
+        set_sampling_thresholds(
+            tier1_threshold=100,
+            tier2_threshold=1000,
+            tier2_rate=10,
+            tier3_rate=100,
+            hot_endpoint_cycles=100,
+        )
+        set_sampling_mode("auto")
+
+    def tearDown(self):
+        """Restore defaults."""
+        set_sampling_thresholds(
+            tier1_threshold=100,
+            tier2_threshold=1000,
+            tier2_rate=10,
+            tier3_rate=100,
+            hot_endpoint_cycles=100,
+        )
+        set_sampling_mode("always")
+
+    def test_set_sampling_thresholds_affects_auto_mode(self):
+        """Test that custom thresholds change auto-mode sampling behavior."""
+        # With default tier1=100, call 50 should be sampled
+        self.assertTrue(_should_sample(50))
+
+        # Set tier1 threshold to 10 — call 50 now falls in tier2
+        set_sampling_thresholds(tier1_threshold=10, tier2_threshold=100)
+        # Call 50 in tier2 (10 < 50 <= 100): sampled only if 50 % tier2_rate == 0
+        self.assertTrue(_should_sample(50))  # 50 % 10 == 0
+        self.assertFalse(_should_sample(51))  # 51 % 10 != 0
+
+    def test_set_sampling_thresholds_tier3_rate(self):
+        """Test that custom tier3 rate is applied."""
+        set_sampling_thresholds(tier1_threshold=10, tier2_threshold=20, tier3_rate=50)
+        # Call 100 is in tier3 (> 20): sampled if 100 % 50 == 0
+        self.assertTrue(_should_sample(100))
+        self.assertFalse(_should_sample(101))
+
+    def test_set_sampling_thresholds_hot_endpoint_cycles(self):
+        """Test that custom hot_endpoint_cycles is applied when marking operations hot."""
+        set_sampling_thresholds(hot_endpoint_cycles=3)
+        mark_operation_hot("ep-123")
+        with _hot_operations_lock:
+            self.assertEqual(_hot_operations["ep-123"], 3)
+
+    def test_default_thresholds_unchanged_without_call(self):
+        """Test that defaults match the original hardcoded values."""
+        from amazon.opentelemetry.distro.serviceevents import python_monitor_impl as impl
+
+        self.assertEqual(impl._sample_tier1_threshold, 100)
+        self.assertEqual(impl._sample_tier2_threshold, 1000)
+        self.assertEqual(impl._sample_tier2_rate, 10)
+        self.assertEqual(impl._sample_tier3_rate, 100)
+        self.assertEqual(impl._HOT_ENDPOINT_CYCLES, 100)
+
+
+class TestHistogramWiringIntegration(TestCase):
+    """Integration tests for the full histogram wiring path:
+
+    1. Create a real MeterProvider + InMemoryMetricReader (mirrors production setup).
+    2. Create a `service.function.duration` histogram on the meter.
+    3. Wire it into _ServiceEventsMonitorState via set_function_duration_histogram().
+    4. Drive PythonServiceEventsMonitor.__exit__ via the context manager.
+    5. Read the metric data back through the in-memory reader and assert
+       attributes, durations, and status values.
+
+    These tests catch wiring regressions that the helper-based contract tests
+    cannot — for example, if __exit__ stops calling record_function_call_metrics(),
+    or set_function_duration_histogram() forgets to store base_attrs.
+    """
+
+    def setUp(self):
+        # Reset singleton + sampling state so tests can't leak across each other.
+        _ServiceEventsMonitorState._instance = None
+        set_sampling_mode("always")
+        _call_stack.set([])
+        _current_operation.set(None)
+
+        # Build a real MeterProvider with an in-memory reader.
+        from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+        from opentelemetry.sdk.metrics.view import ExponentialBucketHistogramAggregation, View
+        from opentelemetry.sdk.resources import Resource
+
+        self._metric_reader = InMemoryMetricReader()
+        view = View(
+            instrument_name="service.function.duration",
+            aggregation=ExponentialBucketHistogramAggregation(),
+        )
+        self._meter_provider = MeterProvider(
+            resource=Resource.create({"service.name": "wiring-test"}),
+            metric_readers=[self._metric_reader],
+            views=[view],
+        )
+
+        # Mirror the production wiring done by ServiceEventsInstrumentation.initialize():
+        # create the histogram once on the meter and store it on monitor state with
+        # the same base attrs the runtime would.
+        meter = self._meter_provider.get_meter("serviceevents", "1.0")
+        histogram = meter.create_histogram(
+            "service.function.duration",
+            unit="Microseconds",
+            description="Function call duration",
+        )
+        # Service identity (service.name, environment, deployment, vcs.*) lives
+        # on the Resource attached to the MeterProvider above. The per-call
+        # base_attrs only carry signal-level identifiers.
+        base_attrs = {
+            "Telemetry.Source": "ServiceEvents",
+        }
+        self._state = _ServiceEventsMonitorState.get_instance()
+        self._state.set_metric_base_attrs(base_attrs)
+        self._state.set_function_duration_histogram(histogram)
+
+    def tearDown(self):
+        self._meter_provider.shutdown()
+        _ServiceEventsMonitorState._instance = None
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _get_duration_metric(self):
+        """Return (metric, scope) for service.function.duration, or (None, None)."""
+        data = self._metric_reader.get_metrics_data()
+        if data is None:
+            return None, None
+        for rm in data.resource_metrics:
+            for sm in rm.scope_metrics:
+                for metric in sm.metrics:
+                    if metric.name == "service.function.duration":
+                        return metric, sm.scope
+        return None, None
+
+    def _data_points_by_function(self, metric, function_name):
+        return [dp for dp in metric.data.data_points if dict(dp.attributes).get("function.name") == function_name]
+
+    # ------------------------------------------------------------------
+    # Tests
+    # ------------------------------------------------------------------
+
+    def test_histogram_wired_into_monitor_state(self):
+        """set_function_duration_histogram populates state used by __exit__."""
+        self.assertIsNotNone(self._state._function_duration_histogram)
+        self.assertEqual(self._state._metric_base_attrs["Telemetry.Source"], "ServiceEvents")
+        # Service identity is on the Resource, not the per-call dimension set.
+        self.assertNotIn("service.name", self._state._metric_base_attrs)
+        self.assertNotIn("environment", self._state._metric_base_attrs)
+
+    def test_exit_records_to_wired_histogram_success(self):
+        """A successful with-block records a data point with status=success."""
+        with PythonServiceEventsMonitor("mod.func_success"):
+            pass
+
+        metric, scope = self._get_duration_metric()
+        self.assertIsNotNone(metric, "Expected service.function.duration metric to be present")
+        self.assertEqual(scope.name, "serviceevents")
+
+        dps = self._data_points_by_function(metric, "mod.func_success")
+        self.assertEqual(len(dps), 1, "Expected exactly one data point for func_success")
+        attrs = dict(dps[0].attributes)
+        self.assertEqual(attrs.get("status"), "success")
+        self.assertEqual(attrs.get("Telemetry.Source"), "ServiceEvents")
+        # service.name + environment ride along on the Resource, not per-call attrs.
+        self.assertNotIn("service.name", attrs)
+        self.assertNotIn("environment", attrs)
+        self.assertNotIn("exception.type", attrs)
+        # Duration should be > 0 even though the body is empty (perf_counter resolution).
+        self.assertGreaterEqual(dps[0].sum, 0)
+        self.assertEqual(dps[0].count, 1)
+
+    def test_exit_records_to_wired_histogram_exception(self):
+        """An exception inside the context propagates and emits status=error."""
+        with self.assertRaises(ValueError):
+            with PythonServiceEventsMonitor("mod.func_error"):
+                raise ValueError("boom")
+
+        metric, _ = self._get_duration_metric()
+        self.assertIsNotNone(metric)
+        dps = self._data_points_by_function(metric, "mod.func_error")
+        self.assertEqual(len(dps), 1)
+        attrs = dict(dps[0].attributes)
+        self.assertEqual(attrs.get("status"), "error")
+        # Exception class name is intentionally NOT a histogram dimension —
+        # it lives on the IncidentSnapshot log signal so cardinality stays bounded.
+        self.assertNotIn("exception.type", attrs)
+
+    def test_exit_records_caller_attribute(self):
+        """Nested with-blocks emit the outer function as the caller of the inner one."""
+        with PythonServiceEventsMonitor("mod.outer"):
+            with PythonServiceEventsMonitor("mod.inner"):
+                pass
+
+        metric, _ = self._get_duration_metric()
+        self.assertIsNotNone(metric)
+
+        inner_dps = self._data_points_by_function(metric, "mod.inner")
+        self.assertEqual(len(inner_dps), 1)
+        self.assertEqual(dict(inner_dps[0].attributes).get("aws.service_events.caller"), "mod.outer")
+
+        outer_dps = self._data_points_by_function(metric, "mod.outer")
+        self.assertEqual(len(outer_dps), 1)
+        self.assertNotIn("aws.service_events.caller", dict(outer_dps[0].attributes))
+
+    def test_exit_aggregates_multiple_calls_into_one_data_point(self):
+        """Same function_name + same status collapses into one data point with count=N."""
+        for _ in range(5):
+            with PythonServiceEventsMonitor("mod.repeated"):
+                pass
+
+        metric, _ = self._get_duration_metric()
+        self.assertIsNotNone(metric)
+        dps = self._data_points_by_function(metric, "mod.repeated")
+        self.assertEqual(len(dps), 1, "Expected the 5 calls to aggregate into one data point")
+        self.assertEqual(dps[0].count, 5)
+
+    def test_exit_no_ops_when_histogram_not_wired(self):
+        """When no histogram is wired, __exit__ records nothing and does not crash.
+
+        There is no SEH/EMF fallback: function-call duration is recorded only into
+        the OTel histogram, so an un-wired instrument simply no-ops.
+        """
+        # Reset so no histogram is wired.
+        _ServiceEventsMonitorState._instance = None
+        state = _ServiceEventsMonitorState.get_instance()
+        self.assertIsNone(state._function_duration_histogram)
+
+        # Must not raise even though no instrument is wired.
+        with PythonServiceEventsMonitor("mod.no_histogram"):
+            pass
+
+        # No metric reader is attached to this un-wired state, and the call simply
+        # no-ops — there is no fallback aggregation store to inspect.
+        self.assertFalse(hasattr(state, "_aggregations"))
+
+
+class TestSamplingAwareHistogramWiring(TestCase):
+    """Verify the sampling contract for ``service.function.duration``.
+
+    The pre-existing TestHistogramWiringIntegration class only exercises the
+    ``always`` sampling mode, so it can't catch a regression where the
+    histogram starts recording zero-duration entries for non-sampled calls
+    again. These tests close that gap.
+    """
+
+    def setUp(self):
+        # Reset singleton + sampling state so tests can't leak across each other.
+        _ServiceEventsMonitorState._instance = None
+        set_sampling_mode("always")
+        _call_stack.set([])
+        _current_operation.set(None)
+        _adaptive_sample_cache.set(None)
+
+        from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+        from opentelemetry.sdk.metrics.view import ExponentialBucketHistogramAggregation, View
+        from opentelemetry.sdk.resources import Resource
+
+        self._metric_reader = InMemoryMetricReader()
+        view = View(
+            instrument_name="service.function.duration",
+            aggregation=ExponentialBucketHistogramAggregation(),
+        )
+        self._meter_provider = MeterProvider(
+            resource=Resource.create({"service.name": "wiring-test"}),
+            metric_readers=[self._metric_reader],
+            views=[view],
+        )
+
+        meter = self._meter_provider.get_meter("serviceevents", "1.0")
+        histogram = meter.create_histogram(
+            "service.function.duration",
+            unit="Microseconds",
+            description="Function call duration",
+        )
+        # Service identity (service.name, environment, deployment, vcs.*) lives
+        # on the Resource attached to the MeterProvider above. The per-call
+        # base_attrs only carry signal-level identifiers.
+        base_attrs = {
+            "Telemetry.Source": "ServiceEvents",
+        }
+        self._state = _ServiceEventsMonitorState.get_instance()
+        self._state.set_metric_base_attrs(base_attrs)
+        self._state.set_function_duration_histogram(histogram)
+
+    def tearDown(self):
+        self._meter_provider.shutdown()
+        _ServiceEventsMonitorState._instance = None
+        set_sampling_mode("always")
+        _adaptive_sample_cache.set(None)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _get_histogram(self):
+        """Return (metric, scope) for service.function.duration, or (None, None)."""
+        data = self._metric_reader.get_metrics_data()
+        if data is None:
+            return None, None
+        for rm in data.resource_metrics:
+            for sm in rm.scope_metrics:
+                for metric in sm.metrics:
+                    if metric.name == "service.function.duration":
+                        return metric, sm.scope
+        return None, None
+
+    def _data_points_by_function(self, metric, function_name):
+        return [dp for dp in metric.data.data_points if dict(dp.attributes).get("function.name") == function_name]
+
+    # ------------------------------------------------------------------
+    # Sampling-aware recording
+    # ------------------------------------------------------------------
+
+    def test_non_sampled_calls_skip_histogram(self):
+        """In 'never' mode the histogram must stay silent.
+
+        This is the core regression guard for the duration-pollution bug:
+        non-sampled calls must NOT produce zero-duration histogram entries.
+        """
+        set_sampling_mode("never")
+
+        for _ in range(7):
+            with PythonServiceEventsMonitor("mod.never_sampled"):
+                pass
+
+        metric, _ = self._get_histogram()
+        if metric is not None:
+            histogram_dps = self._data_points_by_function(metric, "mod.never_sampled")
+            self.assertEqual(
+                len(histogram_dps),
+                0,
+                "Histogram must not record non-sampled calls (would pollute sum/percentiles with zeros)",
+            )
+
+    def test_mixed_sampling_histogram_count_matches_sampled_only(self):
+        """Histogram count tracks the sampled subset, not total invocations."""
+        # 3 sampled calls
+        set_sampling_mode("always")
+        for _ in range(3):
+            with PythonServiceEventsMonitor("mod.mixed"):
+                pass
+
+        # 5 non-sampled calls
+        set_sampling_mode("never")
+        for _ in range(5):
+            with PythonServiceEventsMonitor("mod.mixed"):
+                pass
+
+        metric, _ = self._get_histogram()
+        self.assertIsNotNone(metric)
+        histogram_dps = self._data_points_by_function(metric, "mod.mixed")
+
+        # Histogram only sees the 3 sampled calls.
+        self.assertEqual(sum(dp.count for dp in histogram_dps), 3)
+
+    def test_non_sampled_call_has_no_aggregation_fallback(self):
+        """A non-sampled call must not record anywhere but the (skipped) histogram.
+
+        The legacy SEH/EMF aggregation path has been removed entirely, so there
+        is structurally no second sink that could resurrect the old
+        ``aws.service_events.function_call`` log signal and double-count
+        downstream. This guards that the fallback store stays gone.
+        """
+        set_sampling_mode("never")
+
+        with PythonServiceEventsMonitor("mod.no_double_path"):
+            pass
+
+        # No aggregation store exists, and the histogram skipped the non-sampled call.
+        self.assertFalse(hasattr(self._state, "_aggregations"))
+        metric, _ = self._get_histogram()
+        if metric is not None:
+            self.assertEqual(len(self._data_points_by_function(metric, "mod.no_double_path")), 0)
+
+    def test_sampled_error_lands_on_histogram(self):
+        """A sampled error adds one histogram entry tagged status=error.
+        Exception class name is intentionally not a histogram dimension."""
+        with self.assertRaises(ValueError):
+            with PythonServiceEventsMonitor("mod.err_sampled"):
+                raise ValueError("boom")
+
+        metric, _ = self._get_histogram()
+        self.assertIsNotNone(metric)
+        histogram_dps = self._data_points_by_function(metric, "mod.err_sampled")
+
+        self.assertEqual(len(histogram_dps), 1)
+        attrs = dict(histogram_dps[0].attributes)
+        self.assertEqual(attrs.get("status"), "error")
+        self.assertNotIn("exception.type", attrs)
+
+    def test_non_sampled_error_skipped_on_histogram(self):
+        """An error in 'never' mode must not record a zero-duration error
+        entry on the histogram."""
+        set_sampling_mode("never")
+
+        with self.assertRaises(RuntimeError):
+            with PythonServiceEventsMonitor("mod.err_unsampled"):
+                raise RuntimeError("nope")
+
+        metric, _ = self._get_histogram()
+        if metric is not None:
+            histogram_dps = self._data_points_by_function(metric, "mod.err_unsampled")
+            self.assertEqual(len(histogram_dps), 0)
+
+
+class TestModuleStateFunctions(TestCase):
+    """Test the module-level getters and the after-fork state reset."""
+
+    def setUp(self):
+        """Reset module + singleton state before each test."""
+        _ServiceEventsMonitorState._instance = None
+        _call_stack.set([])
+        _current_operation.set(None)
+        _adaptive_sample_cache.set(None)
+        with _call_counters_lock:
+            _call_counters.clear()
+        with _hot_operations_lock:
+            _hot_operations.clear()
+        set_sampling_mode("always")
+
+    def tearDown(self):
+        """Restore defaults so this class can't leak into other suites."""
+        set_sampling_mode("always")
+        _call_stack.set([])
+        _current_operation.set(None)
+        _adaptive_sample_cache.set(None)
+        with _call_counters_lock:
+            _call_counters.clear()
+        with _hot_operations_lock:
+            _hot_operations.clear()
+
+    def test_get_sampling_mode_returns_current_mode(self):
+        """get_sampling_mode reflects the mode set via set_sampling_mode."""
+        set_sampling_mode("never")
+        self.assertEqual(get_sampling_mode(), "never")
+
+    def test_get_current_operation_returns_set_operation(self):
+        """get_current_operation returns the operation set on the context."""
+        set_current_operation("GET /widgets")
+        self.assertEqual(get_current_operation(), "GET /widgets")
+
+    def test_get_call_stack_returns_copy_of_stack(self):
+        """get_call_stack returns the current frames as a fresh list."""
+        _call_stack.set(["a", "b"])
+
+        stack = get_call_stack()
+
+        self.assertEqual(stack, ["a", "b"])
+        # It must be a copy, not the underlying context-var list.
+        self.assertIsNot(stack, _call_stack.get())
+
+    def test_get_call_stack_handles_none(self):
+        """get_call_stack returns [] when the context var holds None."""
+        _call_stack.set(None)
+        self.assertEqual(get_call_stack(), [])
+
+    def test_reset_after_fork_clears_mutable_state(self):
+        """reset_after_fork restores defaults and clears all mutable state."""
+        # Dirty every piece of mutable state the reset is responsible for.
+        set_sampling_mode("never")
+        with _call_counters_lock:
+            _call_counters["fork_func"] = 7
+        mark_operation_hot("fork-op")
+        _call_stack.set(["frame"])
+        _current_operation.set("GET /forked")
+        _adaptive_sample_cache.set(True)
+
+        state = _ServiceEventsMonitorState.get_instance()
+        state.begin_investigation()
+        self.assertIsNotNone(state.peek_investigation_data())
+
+        reset_after_fork()
+
+        # Sampling mode falls back to the default "always".
+        self.assertEqual(get_sampling_mode(), "always")
+        # Counters and hot operations are emptied.
+        with _call_counters_lock:
+            self.assertEqual(_call_counters, {})
+        with _hot_operations_lock:
+            self.assertEqual(_hot_operations, {})
+        # Thread-local state is reset.
+        self.assertEqual(_call_stack.get(), [])
+        self.assertIsNone(_current_operation.get())
+        self.assertIsNone(_adaptive_sample_cache.get())
+        # The singleton's identity is preserved, only its investigation data cleared.
+        self.assertIs(_ServiceEventsMonitorState.get_instance(), state)
+        self.assertIsNone(state.peek_investigation_data())
+
+    def test_reset_after_fork_without_singleton_is_safe(self):
+        """reset_after_fork no-ops the singleton branch when no instance exists."""
+        _ServiceEventsMonitorState._instance = None
+
+        # Must not raise even though no singleton has been created yet.
+        reset_after_fork()
+
+        self.assertIsNone(_ServiceEventsMonitorState._instance)
+        self.assertEqual(get_sampling_mode(), "always")
+
+
+class TestMonitorEdgeBranches(TestCase):
+    """Cover defensive edge branches in __enter__/__exit__ and metric attribution."""
+
+    def setUp(self):
+        """Reset state before each test."""
+        _ServiceEventsMonitorState._instance = None
+        _call_stack.set([])
+        _current_operation.set(None)
+        _adaptive_sample_cache.set(None)
+        set_sampling_mode("always")
+
+    def tearDown(self):
+        """Restore defaults."""
+        set_sampling_mode("always")
+        _call_stack.set([])
+
+    def test_enter_handles_none_call_stack(self):
+        """__enter__ treats a None call stack as empty and still pushes the frame."""
+        _call_stack.set(None)
+
+        monitor = PythonServiceEventsMonitor("mod.none_stack")
+        monitor.__enter__()
+        try:
+            # With no prior frames, this call is an entry point (no caller).
+            self.assertIsNone(monitor.caller)
+            self.assertEqual(_call_stack.get(), ["mod.none_stack"])
+        finally:
+            monitor.__exit__(None, None, None)
+
+        # Frame popped cleanly on exit.
+        self.assertEqual(_call_stack.get(), [])
+
+    def test_exit_swallows_pop_failure(self):
+        """If reading the stack during the finally pop raises, __exit__ must not propagate."""
+        # Enter normally so _pushed is True and the finally block runs the pop.
+        monitor = PythonServiceEventsMonitor("mod.pop_fail")
+        monitor.__enter__()
+        self.assertTrue(monitor._pushed)
+
+        # Swap the module-level call-stack ContextVar for one whose get() raises.
+        # __exit__'s recording body does not touch _call_stack, so only the
+        # finally-block stack read hits this fault.
+        broken_stack = MagicMock()
+        broken_stack.get.side_effect = RuntimeError("context var read exploded")
+        with patch(
+            "amazon.opentelemetry.distro.serviceevents.python_monitor_impl._call_stack",
+            broken_stack,
+        ):
+            # Must return False (does not suppress) and must not raise the telemetry error.
+            result = monitor.__exit__(None, None, None)
+
+        self.assertFalse(result)
+        broken_stack.get.assert_called_once()
+
+    def test_metrics_attach_function_info_attributes(self):
+        """record_function_call_metrics adds function_at_line + async from the registry."""
+        state = _ServiceEventsMonitorState.get_instance()
+        state.set_metric_base_attrs({"Telemetry.Source": "ServiceEvents"})
+
+        recorded = {}
+
+        histogram = MagicMock()
+        histogram.record.side_effect = lambda value, attrs: recorded.update(attrs)
+        state.set_function_duration_histogram(histogram)
+
+        with patch(
+            "amazon.opentelemetry.distro.serviceevents.python_monitor_impl.get_function_info_unlocked",
+            return_value={"line": 42, "is_async": True},
+        ):
+            state.record_function_call_metrics(
+                function_name="mod.async_func",
+                duration_ns=1000,
+                caller=None,
+                exception_name=None,
+                is_sampled=True,
+            )
+
+        histogram.record.assert_called_once()
+        self.assertEqual(recorded.get("aws.service_events.function_at_line"), 42)
+        self.assertTrue(recorded.get("aws.service_events.async"))
+        self.assertEqual(recorded.get("status"), "success")
+
+    def test_metrics_skip_function_info_when_fields_absent(self):
+        """A registry hit with no line/async info adds neither attribute."""
+        state = _ServiceEventsMonitorState.get_instance()
+        state.set_metric_base_attrs({"Telemetry.Source": "ServiceEvents"})
+
+        recorded = {}
+        histogram = MagicMock()
+        histogram.record.side_effect = lambda value, attrs: recorded.update(attrs)
+        state.set_function_duration_histogram(histogram)
+
+        with patch(
+            "amazon.opentelemetry.distro.serviceevents.python_monitor_impl.get_function_info_unlocked",
+            return_value={"line": None, "is_async": False},
+        ):
+            state.record_function_call_metrics(
+                function_name="mod.plain_func",
+                duration_ns=1000,
+                caller=None,
+                exception_name=None,
+                is_sampled=True,
+            )
+
+        histogram.record.assert_called_once()
+        self.assertNotIn("aws.service_events.function_at_line", recorded)
+        self.assertNotIn("aws.service_events.async", recorded)

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/test_python_monitor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/test_python_monitor.py
@@ -173,6 +173,27 @@ class TestPythonServiceEventsMonitor(TestCase):
         self.assertIsNotNone(inv_data["exception"])
         self.assertEqual(inv_data["exception"]["name"], "ValueError")
         self.assertEqual(inv_data["exception"]["function_name"], "error_func")
+        # The traceback is formatted to a STRING eagerly (not stored as an
+        # (exc_type, exc_value, exc_traceback) tuple) so it cannot pin the frame
+        # chain alive in the ContextVar; the formatted text includes the exception.
+        traceback_info = inv_data["exception"]["traceback_info"]
+        self.assertIsInstance(traceback_info, str)
+        self.assertIn("ValueError", traceback_info)
+        self.assertIn("Test error", traceback_info)
+
+    def test_exception_does_not_set_dead_exception_info_attr(self):
+        """The monitor no longer keeps a self.exception_info attr pinning the traceback."""
+        state = _ServiceEventsMonitorState.get_instance()
+        state.begin_investigation()
+
+        monitor = PythonServiceEventsMonitor("error_func")
+        with self.assertRaises(ValueError):
+            with monitor:
+                raise ValueError("boom")
+
+        # The dead instance attribute was removed; exception data flows only through
+        # the investigation-data dict, so nothing on the monitor pins the traceback.
+        self.assertFalse(hasattr(monitor, "exception_info"))
 
     @patch("amazon.opentelemetry.distro.serviceevents.python_monitor_impl.time.perf_counter_ns")
     def test_multiple_invocations(self, mock_time):

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/test_python_monitor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/test_python_monitor.py
@@ -93,6 +93,27 @@ class TestServiceEventsMonitorState(TestCase):
         inv_data2 = state.get_investigation_data()
         self.assertIsNone(inv_data2)
 
+    def test_clear_investigation_data(self):
+        """clear_investigation_data drops the dict on the normal (non-incident) path."""
+        state = _ServiceEventsMonitorState.get_instance()
+
+        state.begin_investigation()
+        self.assertIsNotNone(state.peek_investigation_data())
+
+        state.clear_investigation_data()
+
+        # Dropped without going through get_investigation_data (the incident-only path).
+        self.assertIsNone(state.peek_investigation_data())
+
+    def test_clear_investigation_data_is_idempotent(self):
+        """Calling clear when there is nothing to clear is a safe no-op."""
+        state = _ServiceEventsMonitorState.get_instance()
+
+        # Already empty (or already consumed by the incident path): must not raise.
+        state.clear_investigation_data()
+        state.clear_investigation_data()
+        self.assertIsNone(state.peek_investigation_data())
+
 
 class TestPythonServiceEventsMonitor(TestCase):
     """Test the PythonServiceEventsMonitor context manager."""

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/test_serviceevents_config.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/test_serviceevents_config.py
@@ -1,0 +1,438 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from unittest import TestCase
+from unittest.mock import patch
+
+from amazon.opentelemetry.distro.serviceevents.config import ServiceEventsConfig
+
+
+class TestServiceEventsConfig(TestCase):
+    """Test the ServiceEventsConfig class."""
+
+    def test_init_with_defaults(self):
+        """Test initialization with default parameters."""
+        config = ServiceEventsConfig()
+
+        # Default false: mirrors unset OTEL_AWS_SERVICE_EVENTS_ENABLED. The outer bundling
+        # gate in the configurator decides whether ServiceEvents actually runs.
+        self.assertFalse(config.enabled)
+        self.assertEqual(config.service_name, "UnknownService")
+        self.assertEqual(config.endpoint_flush_interval, 30000)
+        self.assertEqual(config.incident_snapshot_flush_interval, 10000)
+        self.assertEqual(config.incident_snapshot_max_per_minute, 100)
+        self.assertEqual(config.incident_snapshot_duration_threshold_ms, 5000)
+        self.assertEqual(config.incident_snapshot_max_same_error, 1)
+        # packages_exclude is empty by default. The non-configurable SDK_SELF_EXCLUDE
+        # (in ast_transformation.py) is the only built-in filter.
+        self.assertEqual(config.packages_exclude, [])
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_from_env_with_defaults(self):
+        """Test from_env with no environment variables set."""
+        config = ServiceEventsConfig.from_env()
+
+        # OTEL_AWS_SERVICE_EVENTS_ENABLED is unset by default → config.enabled is False.
+        # The outer bundling gate (see _is_serviceevents_enabled in configurator) is
+        # authoritative for "should ServiceEvents run".
+        self.assertFalse(config.enabled)
+        self.assertEqual(config.service_name, "UnknownService")
+        self.assertEqual(config.endpoint_flush_interval, 30000)
+        # Function instrumentation is on by default (instruments nothing until
+        # packages_include is set, which defaults empty).
+        self.assertTrue(config.function_instrument_enabled)
+
+    @patch.dict(
+        os.environ,
+        {
+            "OTEL_AWS_SERVICE_EVENTS_ENABLED": "false",
+            "OTEL_SERVICE_NAME": "test-service",
+            "OTEL_AWS_SERVICE_EVENTS_INCIDENT_SNAPSHOT_MAX_PER_MINUTE": "10",
+        },
+    )
+    def test_from_env_with_custom_values(self):
+        """Test from_env with custom (release) environment variables."""
+        config = ServiceEventsConfig.from_env()
+
+        self.assertFalse(config.enabled)
+        self.assertEqual(config.service_name, "test-service")
+        self.assertEqual(config.incident_snapshot_max_per_minute, 10)
+
+    @patch.dict(
+        os.environ,
+        {
+            "OTEL_AWS_SERVICE_EVENTS_PACKAGES_EXCLUDE": "test.*,build.*",
+        },
+    )
+    def test_from_env_with_lists(self):
+        """OTEL_AWS_SERVICE_EVENTS_PACKAGES_EXCLUDE binds to the packages_exclude field."""
+        config = ServiceEventsConfig.from_env()
+        self.assertEqual(config.packages_exclude, ["test.*", "build.*"])
+
+    @patch.dict(os.environ, {"OTEL_AWS_SERVICE_EVENTS_PACKAGES_INCLUDE": "myapp,mylib.*"})
+    def test_packages_include_from_env(self):
+        """OTEL_AWS_SERVICE_EVENTS_PACKAGES_INCLUDE binds to the packages_include field."""
+        config = ServiceEventsConfig.from_env()
+        self.assertEqual(config.packages_include, ["myapp", "mylib.*"])
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_packages_include_default_empty(self):
+        """Empty by default — no implicit default scope, so no functions are instrumented."""
+        config = ServiceEventsConfig.from_env()
+        self.assertEqual(config.packages_include, [])
+
+    @patch.dict(os.environ, {"OTEL_AWS_SERVICE_EVENTS_PACKAGES_INCLUDE": "*"})
+    def test_packages_include_bare_star_normalized_away(self):
+        """Bare '*' is invalid input — normalized away to empty list (equivalent to unset)."""
+        config = ServiceEventsConfig.from_env()
+        self.assertEqual(config.packages_include, [])
+
+    @patch.dict(os.environ, {"OTEL_AWS_SERVICE_EVENTS_PACKAGES_INCLUDE": "myapp,*,other"})
+    def test_packages_include_bare_star_stripped_from_mixed_list(self):
+        """Bare '*' entries are stripped; other entries pass through."""
+        config = ServiceEventsConfig.from_env()
+        self.assertEqual(config.packages_include, ["myapp", "other"])
+
+    @patch.dict(os.environ, {"OTEL_AWS_SERVICE_EVENTS_PACKAGES_EXCLUDE": "*"})
+    def test_packages_exclude_bare_star_normalized_away(self):
+        """Same bare-'*' rejection applies to PACKAGES_EXCLUDE."""
+        config = ServiceEventsConfig.from_env()
+        self.assertEqual(config.packages_exclude, [])
+
+    @patch.dict(os.environ, {"OTEL_AWS_SERVICE_EVENTS_INCIDENT_SNAPSHOT_MAX_PER_MINUTE": "invalid"})
+    def test_from_env_with_invalid_int(self):
+        """Test from_env with invalid integer value falls back to default."""
+        config = ServiceEventsConfig.from_env()
+
+        # Should fall back to default
+        self.assertEqual(config.incident_snapshot_max_per_minute, 100)
+
+    @patch.dict(os.environ, {"OTEL_AWS_SERVICE_EVENTS_ENABLED": "TRUE"}, clear=True)
+    def test_from_env_case_insensitive_bool(self):
+        """Test boolean parsing is case-insensitive."""
+        config = ServiceEventsConfig.from_env()
+        self.assertTrue(config.enabled)
+
+    @patch.dict(os.environ, {"OTEL_AWS_SERVICE_EVENTS_ENABLED": "yes"})
+    def test_from_env_non_true_bool_is_false(self):
+        """Test that non-'true' values for booleans are treated as false."""
+        config = ServiceEventsConfig.from_env()
+        self.assertFalse(config.enabled)
+
+    def test_sampling_thresholds_defaults(self):
+        """Test that sampling threshold fields have correct default values."""
+        config = ServiceEventsConfig()
+        self.assertEqual(config.sample_tier1_threshold, 100)
+        self.assertEqual(config.sample_tier2_threshold, 1000)
+        self.assertEqual(config.sample_tier2_rate, 10)
+        self.assertEqual(config.sample_tier3_rate, 100)
+        self.assertEqual(config.hot_endpoint_cycles, 100)
+
+    @patch.dict(
+        os.environ,
+        {
+            "OTEL_AWS_SERVICE_EVENTS_SAMPLE_TIER1_THRESHOLD": "50",
+            "OTEL_AWS_SERVICE_EVENTS_SAMPLE_TIER2_THRESHOLD": "500",
+            "OTEL_AWS_SERVICE_EVENTS_SAMPLE_TIER2_RATE": "5",
+            "OTEL_AWS_SERVICE_EVENTS_SAMPLE_TIER3_RATE": "50",
+            "OTEL_AWS_SERVICE_EVENTS_HOT_ENDPOINT_CYCLES": "200",
+        },
+    )
+    def test_sampling_thresholds_env_is_ignored(self):
+        """Sampling thresholds are internal — the former env vars no longer have any effect."""
+        config = ServiceEventsConfig.from_env()
+        self.assertEqual(config.sample_tier1_threshold, 100)
+        self.assertEqual(config.sample_tier2_threshold, 1000)
+        self.assertEqual(config.sample_tier2_rate, 10)
+        self.assertEqual(config.sample_tier3_rate, 100)
+        self.assertEqual(config.hot_endpoint_cycles, 100)
+
+    # ─── Internal test-config hook (DEBUG_SE_TEST_CONFIG) ──
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_test_config_hook_unset_is_noop(self):
+        """With the hook env unset, internal fields keep their hardcoded defaults."""
+        config = ServiceEventsConfig.from_env()
+        self.assertEqual(config.endpoint_flush_interval, 30000)
+        self.assertEqual(config.sample_tier1_threshold, 100)
+        self.assertEqual(config.log_group, "/aws/serviceevents/telemetry")
+
+    @patch.dict(
+        os.environ,
+        {
+            "DEBUG_SE_TEST_CONFIG": (
+                "ENDPOINT_FLUSH_INTERVAL=2000;"
+                "INCIDENT_SNAPSHOT_FLUSH_INTERVAL=1500;"
+                "SAMPLE_TIER1_THRESHOLD=7;SAMPLE_TIER2_THRESHOLD=70;SAMPLE_TIER2_RATE=3;"
+                "SAMPLE_TIER3_RATE=30;LOG_GROUP=/test/group;"
+                "LOG_STREAM=test-stream"
+            )
+        },
+        clear=True,
+    )
+    def test_test_config_hook_overrides_recognized_keys(self):
+        """The hook overrides exactly the recognized internal fields."""
+        config = ServiceEventsConfig.from_env()
+        self.assertEqual(config.endpoint_flush_interval, 2000)
+        self.assertEqual(config.incident_snapshot_flush_interval, 1500)
+        self.assertEqual(config.sample_tier1_threshold, 7)
+        self.assertEqual(config.sample_tier2_threshold, 70)
+        self.assertEqual(config.sample_tier2_rate, 3)
+        self.assertEqual(config.sample_tier3_rate, 30)
+        self.assertEqual(config.log_group, "/test/group")
+        self.assertEqual(config.log_stream, "test-stream")
+
+    @patch.dict(
+        os.environ,
+        {"DEBUG_SE_TEST_CONFIG": "UNKNOWN_KEY=1;ENDPOINT_FLUSH_INTERVAL=notanint;LOG_GROUP=/ok"},
+        clear=True,
+    )
+    def test_test_config_hook_ignores_unknown_and_garbage(self):
+        """Unknown keys and unparsable values are silently ignored; valid keys still apply."""
+        config = ServiceEventsConfig.from_env()
+        # Unknown key: no crash, no attribute created.
+        self.assertFalse(hasattr(config, "UNKNOWN_KEY"))
+        # Garbage int: field keeps its default.
+        self.assertEqual(config.endpoint_flush_interval, 30000)
+        # Valid string key still applied.
+        self.assertEqual(config.log_group, "/ok")
+
+    # ─── Function-instrument mode flag ──
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_function_instrument_flag_default(self):
+        """Function instrumentation is on by default."""
+        config = ServiceEventsConfig.from_env()
+        self.assertTrue(config.function_instrument_enabled)
+
+    @patch.dict(
+        os.environ,
+        {"OTEL_AWS_SERVICE_EVENTS_FUNCTION_INSTRUMENT_ENABLED": "false"},
+    )
+    def test_function_instrument_can_be_disabled(self):
+        """Function instrumentation turns off when its env flag is set to false."""
+        config = ServiceEventsConfig.from_env()
+        self.assertFalse(config.function_instrument_enabled)
+
+    @patch.dict(
+        os.environ,
+        {"OTEL_AWS_SERVICE_EVENTS_FUNCTION_INSTRUMENT_ENABLED": "true"},
+    )
+    def test_function_instrument_can_be_enabled(self):
+        """Function instrumentation turns on when its env flag is set."""
+        config = ServiceEventsConfig.from_env()
+        self.assertTrue(config.function_instrument_enabled)
+
+    @patch.dict(os.environ, {"OTEL_AWS_APPLICATION_SIGNALS_ENABLED": "true"})
+    def test_application_signals_enabled_from_env(self):
+        """application_signals_enabled mirrors OTEL_AWS_APPLICATION_SIGNALS_ENABLED."""
+        config = ServiceEventsConfig.from_env()
+        self.assertTrue(config.application_signals_enabled)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_application_signals_disabled_by_default(self):
+        config = ServiceEventsConfig.from_env()
+        self.assertFalse(config.application_signals_enabled)
+
+    # ─── service_name resolution from OTEL_RESOURCE_ATTRIBUTES ──
+
+    @patch.dict(
+        os.environ,
+        {"OTEL_RESOURCE_ATTRIBUTES": "service.name=shoppingcart,deployment.environment=production"},
+        clear=True,
+    )
+    def test_service_name_from_resource_attributes(self):
+        """service.name is read from OTEL_RESOURCE_ATTRIBUTES when OTEL_SERVICE_NAME is unset."""
+        config = ServiceEventsConfig.from_env()
+        self.assertEqual(config.service_name, "shoppingcart")
+
+    @patch.dict(
+        os.environ,
+        {
+            "OTEL_SERVICE_NAME": "from-service-name",
+            "OTEL_RESOURCE_ATTRIBUTES": "service.name=from-resource",
+        },
+        clear=True,
+    )
+    def test_service_name_env_var_wins_over_resource_attributes(self):
+        """OTEL_SERVICE_NAME takes priority over OTEL_RESOURCE_ATTRIBUTES[service.name]."""
+        config = ServiceEventsConfig.from_env()
+        self.assertEqual(config.service_name, "from-service-name")
+
+    @patch.dict(
+        os.environ,
+        {"OTEL_RESOURCE_ATTRIBUTES": "deployment.environment=prod,other.key=value"},
+        clear=True,
+    )
+    def test_service_name_falls_back_to_default_when_not_in_resource_attributes(self):
+        """service_name falls back to the default when no service.name pair is present."""
+        config = ServiceEventsConfig.from_env()
+        self.assertEqual(config.service_name, "UnknownService")
+
+    @patch.dict(
+        os.environ,
+        {"OTEL_RESOURCE_ATTRIBUTES": "  service.name = padded-name , k=v"},
+        clear=True,
+    )
+    def test_service_name_strips_whitespace_around_pairs(self):
+        """Whitespace around the key and value in a resource-attribute pair is stripped."""
+        config = ServiceEventsConfig.from_env()
+        self.assertEqual(config.service_name, "padded-name")
+
+    @patch.dict(
+        os.environ,
+        {"OTEL_RESOURCE_ATTRIBUTES": "malformed,service.name=valid"},
+        clear=True,
+    )
+    def test_service_name_skips_pairs_without_equals(self):
+        """Pairs without an '=' are skipped while later valid pairs are still parsed."""
+        config = ServiceEventsConfig.from_env()
+        self.assertEqual(config.service_name, "valid")
+
+    # ─── environment resolution from OTEL_RESOURCE_ATTRIBUTES / ENVIRONMENT ──
+
+    @patch.dict(
+        os.environ,
+        {"OTEL_RESOURCE_ATTRIBUTES": "deployment.environment.name=staging"},
+        clear=True,
+    )
+    def test_environment_from_resource_attributes_name_convention(self):
+        """deployment.environment.name (newer convention) is read from OTEL_RESOURCE_ATTRIBUTES."""
+        config = ServiceEventsConfig.from_env()
+        self.assertEqual(config.environment, "staging")
+
+    @patch.dict(
+        os.environ,
+        {"OTEL_RESOURCE_ATTRIBUTES": "deployment.environment=production"},
+        clear=True,
+    )
+    def test_environment_from_resource_attributes_legacy_convention(self):
+        """deployment.environment (older convention) is read from OTEL_RESOURCE_ATTRIBUTES."""
+        config = ServiceEventsConfig.from_env()
+        self.assertEqual(config.environment, "production")
+
+    @patch.dict(os.environ, {"ENVIRONMENT": "qa"}, clear=True)
+    def test_environment_from_environment_env_var(self):
+        """environment falls back to the ENVIRONMENT env var when resource attributes lack it."""
+        config = ServiceEventsConfig.from_env()
+        self.assertEqual(config.environment, "qa")
+
+    @patch.dict(
+        os.environ,
+        {
+            "OTEL_RESOURCE_ATTRIBUTES": "deployment.environment=from-resource",
+            "ENVIRONMENT": "from-env-var",
+        },
+        clear=True,
+    )
+    def test_environment_resource_attributes_win_over_environment_var(self):
+        """OTEL_RESOURCE_ATTRIBUTES takes priority over the ENVIRONMENT env var."""
+        config = ServiceEventsConfig.from_env()
+        self.assertEqual(config.environment, "from-resource")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_environment_defaults_to_none_when_unset(self):
+        """environment stays None when no resolution source is set (no placeholder sentinel)."""
+        config = ServiceEventsConfig.from_env()
+        self.assertIsNone(config.environment)
+
+    @patch.dict(
+        os.environ,
+        {"OTEL_RESOURCE_ATTRIBUTES": "malformed,deployment.environment=valid"},
+        clear=True,
+    )
+    def test_environment_skips_pairs_without_equals(self):
+        """Pairs without an '=' are skipped while later valid environment pairs are parsed."""
+        config = ServiceEventsConfig.from_env()
+        self.assertEqual(config.environment, "valid")
+
+    # ─── test-config hook entry parsing edge cases ──
+
+    @patch.dict(
+        os.environ,
+        {"DEBUG_SE_TEST_CONFIG": ";;LOG_GROUP=/ok;noequals;  ;LOG_STREAM=stream"},
+        clear=True,
+    )
+    def test_test_config_hook_skips_empty_and_equals_less_entries(self):
+        """Empty entries and entries lacking '=' are skipped; valid entries still apply."""
+        config = ServiceEventsConfig.from_env()
+        self.assertEqual(config.log_group, "/ok")
+        self.assertEqual(config.log_stream, "stream")
+
+    # ─── get_latency_threshold_patterns ──
+
+    def test_latency_threshold_patterns_parses_entries(self):
+        """Well-formed "METHOD /route:threshold" entries parse into (pattern, threshold) tuples."""
+        config = ServiceEventsConfig(latency_thresholds=["POST /api/checkout:500", "get /api/health:50"])
+        self.assertEqual(
+            config.get_latency_threshold_patterns(),
+            [("POST /api/checkout", 500.0), ("GET /api/health", 50.0)],
+        )
+
+    def test_latency_threshold_patterns_route_with_colon(self):
+        """Splitting on the last colon preserves routes that themselves contain colons."""
+        config = ServiceEventsConfig(latency_thresholds=["GET /api/v1:resource:250"])
+        self.assertEqual(
+            config.get_latency_threshold_patterns(),
+            [("GET /api/v1:resource", 250.0)],
+        )
+
+    def test_latency_threshold_patterns_skips_invalid_entries(self):
+        """Entries that are empty, colon-less, leading-colon, non-numeric, or missing the route are skipped."""
+        config = ServiceEventsConfig(
+            latency_thresholds=[
+                "",
+                "  ",
+                "no-colon-here",
+                ":500",
+                "GET /api/users:notanumber",
+                "GET/api/users:100",
+                "GET /api/ok:300",
+            ]
+        )
+        self.assertEqual(
+            config.get_latency_threshold_patterns(),
+            [("GET /api/ok", 300.0)],
+        )
+
+    def test_latency_threshold_patterns_empty_default(self):
+        """An empty latency_thresholds list yields no patterns."""
+        config = ServiceEventsConfig()
+        self.assertEqual(config.get_latency_threshold_patterns(), [])
+
+    # ─── should_track_endpoint ──
+
+    def test_should_track_endpoint_no_patterns_tracks_all(self):
+        """With no include/exclude patterns, every endpoint is tracked."""
+        config = ServiceEventsConfig()
+        self.assertTrue(config.should_track_endpoint("/api/users", "GET"))
+
+    def test_should_track_endpoint_include_match(self):
+        """An endpoint matching an include pattern is tracked."""
+        config = ServiceEventsConfig(endpoint_include_patterns=["GET /api/*"])
+        self.assertTrue(config.should_track_endpoint("/api/users", "get"))
+
+    def test_should_track_endpoint_include_no_match(self):
+        """An endpoint not matching any include pattern is filtered out."""
+        config = ServiceEventsConfig(endpoint_include_patterns=["GET /api/*"])
+        self.assertFalse(config.should_track_endpoint("/health", "GET"))
+
+    def test_should_track_endpoint_exclude_match(self):
+        """An endpoint matching an exclude pattern is filtered out."""
+        config = ServiceEventsConfig(endpoint_exclude_patterns=["* /health"])
+        self.assertFalse(config.should_track_endpoint("/health", "GET"))
+
+    def test_should_track_endpoint_exclude_no_match_tracks(self):
+        """An endpoint not matching any exclude pattern is tracked."""
+        config = ServiceEventsConfig(endpoint_exclude_patterns=["* /health"])
+        self.assertTrue(config.should_track_endpoint("/api/users", "GET"))
+
+    def test_should_track_endpoint_include_then_exclude(self):
+        """Include selects the set, then exclude removes a matching endpoint from it."""
+        config = ServiceEventsConfig(
+            endpoint_include_patterns=["GET /api/*"],
+            endpoint_exclude_patterns=["GET /api/secret"],
+        )
+        self.assertTrue(config.should_track_endpoint("/api/users", "GET"))
+        self.assertFalse(config.should_track_endpoint("/api/secret", "GET"))

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/test_serviceevents_get_code_docstring.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/test_serviceevents_get_code_docstring.py
@@ -11,6 +11,7 @@ pydoc/help()/doctest/__doc__-based tooling). These tests load a transformed modu
 assert the docstring is preserved, while the import is still injected and functional.
 """
 
+import ast
 import os
 import tempfile
 from unittest import TestCase
@@ -79,3 +80,56 @@ class TestGetCodePreservesModuleDocstring(TestCase):
         self.assertEqual(namespace.get("__doc__"), MODULE_DOCSTRING)
         self.assertEqual(namespace["x"], 1)
         self.assertIn("PythonServiceEventsMonitor", namespace)
+
+    def test_docstring_then_future_import_keeps_docstring_and_instruments(self):
+        """A module with a docstring followed by ``from __future__`` stays valid and instrumented.
+
+        End-to-end through get_code, ``from __future__`` is folded into compiler flags by the
+        transformer (visit_ImportFrom), not kept as a body statement, so this asserts the
+        observable contract: the docstring survives and the monitor import is injected. The
+        placement of the injected import relative to a *retained* ``__future__`` node is covered
+        directly in TestPreambleInsertIndex below.
+        """
+        source = (
+            f'"""{MODULE_DOCSTRING}"""\n' "from __future__ import annotations\n" "\n" "def qux():\n" "    return 4\n"
+        )
+        namespace = self._load("doc_then_future", source)
+        self.assertEqual(namespace.get("__doc__"), MODULE_DOCSTRING)
+        self.assertIn("PythonServiceEventsMonitor", namespace)
+        self.assertEqual(namespace["qux"](), 4)
+
+
+class TestPreambleInsertIndex(TestCase):
+    """Direct unit tests for _preamble_insert_index on raw (un-transformed) AST bodies.
+
+    These exercise the helper on bodies that still contain ``from __future__`` nodes — which
+    the real get_code pipeline strips into compiler flags before insertion — so they actually
+    cover the ``__future__``-skipping branch that the end-to-end get_code tests cannot reach.
+    """
+
+    @staticmethod
+    def _index(source):
+        return ServiceEventsSourceLoader._preamble_insert_index(ast.parse(source).body)
+
+    def test_empty_body(self):
+        self.assertEqual(ServiceEventsSourceLoader._preamble_insert_index([]), 0)
+
+    def test_plain_module_inserts_at_zero(self):
+        self.assertEqual(self._index("def f():\n    return 1\n"), 0)
+
+    def test_leading_docstring_inserts_after_it(self):
+        self.assertEqual(self._index('"""doc"""\ndef f():\n    return 1\n'), 1)
+
+    def test_skips_single_future_import(self):
+        self.assertEqual(self._index("from __future__ import annotations\ndef f():\n    return 1\n"), 1)
+
+    def test_skips_docstring_then_future_import(self):
+        self.assertEqual(self._index('"""doc"""\nfrom __future__ import annotations\ndef f():\n    return 1\n'), 2)
+
+    def test_skips_multiple_future_imports(self):
+        source = "from __future__ import annotations\nfrom __future__ import division\ndef f():\n    return 1\n"
+        self.assertEqual(self._index(source), 2)
+
+    def test_non_future_importfrom_is_not_skipped(self):
+        """A regular ``from x import y`` is not preamble; the import goes before it."""
+        self.assertEqual(self._index("from os import path\ndef f():\n    return 1\n"), 0)

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/test_serviceevents_get_code_docstring.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/test_serviceevents_get_code_docstring.py
@@ -1,0 +1,81 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests: get_code must not clobber a module-level docstring.
+
+The AST transform injects a `PythonServiceEventsMonitor` import at the top of every
+instrumented module. A module's __doc__ is populated only when the FIRST statement in
+the body is a string-constant expression, so inserting that import at index 0 would push
+the docstring out of first position and silently make __doc__ None (breaking
+pydoc/help()/doctest/__doc__-based tooling). These tests load a transformed module and
+assert the docstring is preserved, while the import is still injected and functional.
+"""
+
+import os
+import tempfile
+from unittest import TestCase
+
+from amazon.opentelemetry.distro.serviceevents.ast_transformation import (
+    ServiceEventsSourceLoader,
+    clear_function_registry,
+)
+
+MODULE_DOCSTRING = "Top-level module docstring that must survive instrumentation."
+
+
+class TestGetCodePreservesModuleDocstring(TestCase):
+    """get_code injects the monitor import without destroying the module docstring."""
+
+    def setUp(self):
+        clear_function_registry()
+        self._tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        clear_function_registry()
+
+    def _write(self, name, source):
+        path = os.path.join(self._tmpdir, name)
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(source)
+        return path
+
+    def _load(self, name, source):
+        """Transform + compile + exec the source, returning the populated namespace."""
+        path = self._write(f"{name}.py", source)
+        code = ServiceEventsSourceLoader(name, path).get_code(name)
+        self.assertIsNotNone(code)
+        # The injected monitor import must be present in the compiled code's names.
+        self.assertIn("PythonServiceEventsMonitor", code.co_names)
+        namespace = {}
+        # exec runs the (real) injected `from ...python_monitor import PythonServiceEventsMonitor`,
+        # so a green exec proves the import is functional, not just syntactically present.
+        exec(code, namespace)  # pylint: disable=exec-used
+        return namespace
+
+    def test_module_docstring_preserved_with_leading_docstring(self):
+        """A module whose first statement is a docstring keeps __doc__ after transform."""
+        source = f'"""{MODULE_DOCSTRING}"""\n' "\n" "def foo():\n" '    """func doc"""\n' "    return 1\n"
+        namespace = self._load("with_docstring", source)
+        # The bug: __doc__ would be None here. The fix preserves the original docstring.
+        self.assertEqual(namespace.get("__doc__"), MODULE_DOCSTRING)
+        # The injected import is functional and bound in the module namespace.
+        self.assertIn("PythonServiceEventsMonitor", namespace)
+        # The module's own code still works.
+        self.assertEqual(namespace["foo"](), 1)
+
+    def test_no_docstring_still_injects_import_at_index_zero(self):
+        """A module with no docstring: import is still injected; __doc__ stays None."""
+        source = "def bar():\n    return 2\n"
+        namespace = self._load("no_docstring", source)
+        # No docstring originally -> __doc__ is None (unchanged by the fix).
+        self.assertIsNone(namespace.get("__doc__"))
+        self.assertIn("PythonServiceEventsMonitor", namespace)
+        self.assertEqual(namespace["bar"](), 2)
+
+    def test_leading_string_after_real_docstring_is_not_confused(self):
+        """Only the genuine first-statement docstring counts; later strings are unaffected."""
+        source = f'"""{MODULE_DOCSTRING}"""\n' "\n" "x = 1\n" '"a non-docstring string expression"\n'
+        namespace = self._load("doc_then_string", source)
+        self.assertEqual(namespace.get("__doc__"), MODULE_DOCSTRING)
+        self.assertEqual(namespace["x"], 1)
+        self.assertIn("PythonServiceEventsMonitor", namespace)

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/test_serviceevents_instrumentation.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/test_serviceevents_instrumentation.py
@@ -1,0 +1,792 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import os
+import sys
+import tempfile
+import types
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from amazon.opentelemetry.distro.serviceevents.config import ServiceEventsConfig
+from amazon.opentelemetry.distro.serviceevents.models.resource_attributes import ResourceAttributes
+from amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation import ServiceEventsInstrumentation
+
+
+class TestServiceEventsInstrumentation(TestCase):
+    """Test the ServiceEventsInstrumentation class."""
+
+    def setUp(self):
+        # initialize() registers an atexit shutdown hook. These tests construct throwaway
+        # instances and don't always call shutdown(), so neutralize the registration to
+        # avoid leaking hooks that fire (and log) after pytest tears down its streams.
+        # The real atexit wiring is covered explicitly in test_initialize_registers_atexit.
+        patcher = patch("amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation.atexit")
+        self.mock_atexit = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_init(self):
+        """Test initialization with config."""
+        config = ServiceEventsConfig()
+        instrumentation = ServiceEventsInstrumentation(config)
+
+        self.assertEqual(instrumentation.config, config)
+        self.assertIsNone(instrumentation.monitor_state)
+        self.assertEqual(instrumentation.collectors, [])
+        self.assertFalse(instrumentation._initialized)
+
+    @patch("amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation._ServiceEventsMonitorState")
+    @patch("amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation.install_ast_hooks")
+    def test_initialize_success(self, mock_install_hooks, mock_state):
+        """Test successful initialization."""
+        config = ServiceEventsConfig(enabled=True, function_instrument_enabled=True)
+        instrumentation = ServiceEventsInstrumentation(config)
+
+        mock_state.get_instance.return_value = MagicMock()
+
+        instrumentation.initialize()
+
+        # Should get monitor state instance
+        mock_state.get_instance.assert_called_once()
+
+        # Should install AST hooks
+        mock_install_hooks.assert_called_once()
+
+        # Should be marked as initialized
+        self.assertTrue(instrumentation._initialized)
+
+    @patch("amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation._ServiceEventsMonitorState")
+    @patch("amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation.install_ast_hooks")
+    def test_initialize_disabled(self, mock_install_hooks, mock_state):
+        """Test that initialization is skipped when disabled."""
+        config = ServiceEventsConfig(enabled=False)
+        instrumentation = ServiceEventsInstrumentation(config)
+
+        instrumentation.initialize()
+
+        # Should not install hooks or get state when disabled
+        mock_install_hooks.assert_not_called()
+        mock_state.get_instance.assert_not_called()
+        self.assertFalse(instrumentation._initialized)
+
+    @patch("amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation._ServiceEventsMonitorState")
+    @patch("amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation.install_ast_hooks")
+    def test_initialize_idempotent(self, mock_install_hooks, mock_state):
+        """Test that initialize can be called multiple times safely."""
+        config = ServiceEventsConfig(enabled=True, function_instrument_enabled=True)
+        instrumentation = ServiceEventsInstrumentation(config)
+
+        mock_state.get_instance.return_value = MagicMock()
+
+        # Call initialize twice
+        instrumentation.initialize()
+        instrumentation.initialize()
+
+        # Should only initialize once
+        self.assertEqual(mock_state.get_instance.call_count, 1)
+        self.assertEqual(mock_install_hooks.call_count, 1)
+
+    @patch("amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation._ServiceEventsMonitorState")
+    @patch("amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation.install_ast_hooks")
+    def test_initialize_registers_atexit_and_shutdown_unregisters(self, mock_install_hooks, mock_state):
+        """initialize() registers the shutdown atexit hook exactly once; shutdown() removes it."""
+        config = ServiceEventsConfig(enabled=True, function_instrument_enabled=True)
+        instrumentation = ServiceEventsInstrumentation(config)
+        mock_state.get_instance.return_value = MagicMock()
+
+        instrumentation.initialize()
+        # A second initialize() is a no-op (already initialized) — still only one registration.
+        instrumentation.initialize()
+
+        self.mock_atexit.register.assert_called_once_with(instrumentation.shutdown)
+        self.assertTrue(instrumentation._atexit_registered)
+
+        instrumentation.shutdown()
+
+        self.mock_atexit.unregister.assert_called_once_with(instrumentation.shutdown)
+        self.assertFalse(instrumentation._atexit_registered)
+
+    @patch("amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation._ServiceEventsMonitorState")
+    @patch("amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation.install_ast_hooks")
+    def test_initialize_with_exception(self, mock_install_hooks, mock_state):
+        """Test that exceptions during initialization are caught."""
+        config = ServiceEventsConfig(enabled=True)
+        instrumentation = ServiceEventsInstrumentation(config)
+
+        # Make initialization raise an exception
+        mock_state.get_instance.side_effect = RuntimeError("Test error")
+
+        # Should not raise exception
+        instrumentation.initialize()
+
+        # Should not be marked as initialized
+        self.assertFalse(instrumentation._initialized)
+
+    def test_shutdown_not_initialized(self):
+        """Test shutdown when not initialized."""
+        config = ServiceEventsConfig()
+        instrumentation = ServiceEventsInstrumentation(config)
+
+        # Should not raise exception
+        instrumentation.shutdown()
+
+    @patch("amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation._ServiceEventsMonitorState")
+    @patch("amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation.install_ast_hooks")
+    def test_shutdown_with_collectors(self, mock_install_hooks, mock_state):
+        """Test shutdown with collectors."""
+        config = ServiceEventsConfig(enabled=True)
+        instrumentation = ServiceEventsInstrumentation(config)
+
+        mock_state.get_instance.return_value = MagicMock()
+
+        # Initialize
+        instrumentation.initialize()
+
+        # Add mock collectors
+        mock_collector1 = MagicMock()
+        mock_collector2 = MagicMock()
+        instrumentation.collectors = [mock_collector1, mock_collector2]
+
+        # Shutdown
+        instrumentation.shutdown()
+
+        # Should stop all collectors
+        mock_collector1.stop.assert_called_once()
+        mock_collector2.stop.assert_called_once()
+
+        # Should be marked as not initialized
+        self.assertFalse(instrumentation._initialized)
+
+    @patch("amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation._ServiceEventsMonitorState")
+    @patch("amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation.install_ast_hooks")
+    def test_shutdown_collector_exception(self, mock_install_hooks, mock_state):
+        """Test that exceptions during collector shutdown are caught."""
+        config = ServiceEventsConfig(enabled=True)
+        instrumentation = ServiceEventsInstrumentation(config)
+
+        mock_state.get_instance.return_value = MagicMock()
+
+        instrumentation.initialize()
+
+        # Add collector that raises exception on stop
+        mock_collector = MagicMock()
+        mock_collector.stop.side_effect = RuntimeError("Test error")
+        instrumentation.collectors = [mock_collector]
+
+        # Should not raise exception
+        instrumentation.shutdown()
+
+    @patch("amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation._ServiceEventsMonitorState")
+    @patch("amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation.install_ast_hooks")
+    def test_initialize_with_packages_exclude(self, mock_install_hooks, mock_state):
+        """install_ast_hooks receives both packages_include and packages_exclude from config."""
+        config = ServiceEventsConfig(
+            enabled=True,
+            function_instrument_enabled=True,
+            packages_include=["myapp", "mylib.*"],
+            packages_exclude=["test.*", "build.*"],
+        )
+        instrumentation = ServiceEventsInstrumentation(config)
+
+        mock_state.get_instance.return_value = MagicMock()
+
+        instrumentation.initialize()
+
+        call_args = mock_install_hooks.call_args
+        self.assertEqual(call_args[1]["packages_exclude"], ["test.*", "build.*"])
+        self.assertEqual(call_args[1]["packages_include"], {"myapp", "mylib.*"})
+
+    @patch("amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation._ServiceEventsMonitorState")
+    @patch("amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation.install_ast_hooks")
+    def test_no_warn_when_enabled_without_include(self, mock_install_hooks, mock_state):
+        """Empty PACKAGES_INCLUDE installs hooks quietly — no WARNING.
+
+        Function instrumentation is on by default, so an empty allowlist is a normal
+        no-op (instruments nothing) rather than a misconfiguration; warning on it would
+        fire on every default install and just be noise. Hooks still install — endpoint
+        signals are unaffected.
+        """
+        config = ServiceEventsConfig(
+            enabled=True,
+            function_instrument_enabled=True,
+            packages_include=[],
+            packages_exclude=[],
+        )
+        instrumentation = ServiceEventsInstrumentation(config)
+        mock_state.get_instance.return_value = MagicMock()
+
+        logger_name = "amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation"
+        with self.assertLogs(logger_name, level="DEBUG") as captured:
+            instrumentation.initialize()
+
+        warn_records = [r for r in captured.records if r.levelno >= logging.WARNING]
+        self.assertEqual(warn_records, [], "expected no WARNING when include list is empty")
+        # Hooks are still installed (instruments nothing, but endpoint signals flow).
+        mock_install_hooks.assert_called_once()
+
+
+class TestServiceEventsModes(TestCase):
+    """Test function-instrument (AST) vs endpoint-only mode collector wiring.
+
+    Function-level telemetry is controlled by `function_instrument_enabled`; when off,
+    only endpoint metrics and incident snapshots run.
+    """
+
+    def setUp(self):
+        # Neutralize atexit registration (see TestServiceEventsInstrumentation.setUp).
+        patcher = patch("amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation.atexit")
+        self.mock_atexit = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _init_and_get_collector_names(self, function_instrument_enabled=False, logs_endpoint=""):
+        config = ServiceEventsConfig(
+            enabled=True,
+            function_instrument_enabled=function_instrument_enabled,
+            logs_endpoint=logs_endpoint,
+            sampling_mode="always",
+        )
+        inst = ServiceEventsInstrumentation(config)
+        inst.initialize()
+        names = [c.__class__.__name__ for c in inst.collectors]
+        inst.shutdown()
+        return inst, names
+
+    def test_ast_mode_collectors(self):
+        """Function-instrument mode runs EndpointMetric + IncidentSnapshot collectors.
+
+        FunctionCall telemetry is recorded directly into the OTel histogram from the
+        monitor, not via a dedicated collector, so the collector set matches
+        endpoint-only mode; AST mode differs by installing the AST hooks + wiring the
+        histogram.
+        """
+        inst, names = self._init_and_get_collector_names(
+            function_instrument_enabled=True, logs_endpoint="http://localhost:4318/v1/logs"
+        )
+        self.assertIn("EndpointMetricCollector", names)
+        self.assertIn("IncidentSnapshotCollector", names)
+
+    def test_endpoint_only_mode_collectors(self):
+        """Function instrument off: EndpointMetric + IncidentSnapshot run."""
+        inst, names = self._init_and_get_collector_names(
+            function_instrument_enabled=False, logs_endpoint="http://localhost:4318/v1/logs"
+        )
+        self.assertIn("EndpointMetricCollector", names)
+        self.assertIn("IncidentSnapshotCollector", names)
+
+    def test_incident_snapshot_always_active(self):
+        """IncidentSnapshotCollector runs in every mode."""
+        for ast in (True, False):
+            _, names = self._init_and_get_collector_names(function_instrument_enabled=ast)
+            self.assertIn(
+                "IncidentSnapshotCollector",
+                names,
+                f"IncidentSnapshotCollector missing for ast={ast}",
+            )
+
+    def test_ast_mode_otlp_emitter_wired(self):
+        """All collectors in function-instrument mode have otlp_emitter when logs_endpoint configured."""
+        inst, _ = self._init_and_get_collector_names(
+            function_instrument_enabled=True, logs_endpoint="http://localhost:4318/v1/logs"
+        )
+        for c in inst.collectors:
+            self.assertIsNotNone(c.otlp_emitter, f"{c.__class__.__name__} should have otlp_emitter")
+
+    def test_endpoint_only_mode_otlp_emitter_wired(self):
+        """EndpointMetricCollector and IncidentSnapshotCollector have emitter in endpoint-only mode."""
+        inst, _ = self._init_and_get_collector_names(
+            function_instrument_enabled=False, logs_endpoint="http://localhost:4318/v1/logs"
+        )
+        for c in inst.collectors:
+            if c.__class__.__name__ in ("EndpointMetricCollector", "IncidentSnapshotCollector"):
+                self.assertIsNotNone(c.otlp_emitter, f"{c.__class__.__name__} should have otlp_emitter")
+
+    def test_resource_includes_aws_local_service_as_copy_of_service_name(self):
+        """ServiceEvents Resource includes aws.local.service mirroring service.name."""
+        config = ServiceEventsConfig(
+            enabled=True,
+            service_name="my-test-service",
+            function_instrument_enabled=False,
+            logs_endpoint="http://localhost:4316/v1/logs",
+            metrics_endpoint="http://localhost:4316/v1/metrics",
+            sampling_mode="always",
+        )
+        inst = ServiceEventsInstrumentation(config)
+        inst.initialize()
+        try:
+            resource_attrs = inst._otlp_logger_provider._resource.attributes
+            self.assertEqual(resource_attrs.get("service.name"), "my-test-service")
+            self.assertEqual(resource_attrs.get("aws.local.service"), "my-test-service")
+        finally:
+            inst.shutdown()
+
+    def test_resource_includes_deployment_and_vcs_metadata_from_env(self):
+        """Deployment id, git commit SHA, and repo URL flow through to the OTel Resource
+        (not per-call attributes), so they ride along with every signal automatically."""
+        env = {
+            "OTEL_AWS_SERVICE_EVENTS_DEPLOYMENT_ID": "deploy-resource-test",
+            "OTEL_AWS_SERVICE_EVENTS_GIT_COMMIT_SHA": "sha-resource-test",
+            "OTEL_AWS_SERVICE_EVENTS_GIT_REPO_URL": "https://github.com/org/resource-test",
+        }
+        config = ServiceEventsConfig(
+            enabled=True,
+            service_name="resource-test-service",
+            environment="resource-env",
+            sdk_version="9.9.9",
+            function_instrument_enabled=False,
+            logs_endpoint="http://localhost:4316/v1/logs",
+            metrics_endpoint="http://localhost:4316/v1/metrics",
+            sampling_mode="always",
+        )
+        with patch.dict(os.environ, env, clear=False):
+            inst = ServiceEventsInstrumentation(config)
+            inst.initialize()
+            try:
+                resource_attrs = inst._otlp_logger_provider._resource.attributes
+                self.assertEqual(resource_attrs.get("deployment.environment.name"), "resource-env")
+                self.assertEqual(resource_attrs.get("aws.service_events.version"), "9.9.9")
+                self.assertEqual(resource_attrs.get("aws.service_events.deployment.id"), "deploy-resource-test")
+                self.assertEqual(resource_attrs.get("vcs.ref.head.revision"), "sha-resource-test")
+                self.assertEqual(
+                    resource_attrs.get("vcs.repository.url.full"),
+                    "https://github.com/org/resource-test",
+                )
+            finally:
+                inst.shutdown()
+
+    def test_no_otlp_emitter_without_endpoint(self):
+        """No otlp_emitter when logs_endpoint is empty."""
+        inst, _ = self._init_and_get_collector_names(function_instrument_enabled=True, logs_endpoint="")
+        for c in inst.collectors:
+            self.assertIsNone(c.otlp_emitter, f"{c.__class__.__name__} should NOT have otlp_emitter")
+
+    def test_endpoint_only_mode_standalone_deployment_event(self):
+        """Endpoint-only mode emits DeploymentEvent at startup via the standalone path."""
+        config = ServiceEventsConfig(
+            enabled=True,
+            function_instrument_enabled=False,
+            logs_endpoint="http://localhost:4318/v1/logs",
+            sampling_mode="always",
+        )
+        inst = ServiceEventsInstrumentation(config)
+        inst.initialize()
+        # OTLP emitter should be created
+        self.assertIsNotNone(inst._otlp_emitter)
+        inst.shutdown()
+
+
+class TestGetServiceEventsInstrumentation(TestCase):
+    """Test the get_serviceevents_instrumentation singleton accessor."""
+
+    def setUp(self):
+        # The accessor mutates a module-level singleton. Reset it before and after each
+        # test so cases don't leak state into one another, and neutralize atexit so the
+        # constructed instance never registers a real shutdown hook.
+        import amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation as se_module
+
+        self._se_module = se_module
+        self._original_singleton = se_module._serviceevents_instance
+        se_module._serviceevents_instance = None
+
+        patcher = patch("amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation.atexit")
+        self.mock_atexit = patcher.start()
+        self.addCleanup(patcher.stop)
+        self.addCleanup(self._restore_singleton)
+
+    def _restore_singleton(self):
+        self._se_module._serviceevents_instance = self._original_singleton
+
+    def test_returns_none_when_no_instance_and_no_config(self):
+        """No singleton and no config returns None."""
+        from amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation import (
+            get_serviceevents_instrumentation,
+        )
+
+        self.assertIsNone(get_serviceevents_instrumentation(None))
+
+    def test_creates_singleton_on_first_config(self):
+        """First call with a config constructs and returns the singleton."""
+        from amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation import (
+            get_serviceevents_instrumentation,
+        )
+
+        config = ServiceEventsConfig(service_name="first-service")
+        inst = get_serviceevents_instrumentation(config)
+
+        self.assertIsInstance(inst, ServiceEventsInstrumentation)
+        self.assertIs(inst.config, config)
+
+    def test_first_config_wins_and_second_config_ignored(self):
+        """Once created, a later config is ignored and the original instance is returned."""
+        from amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation import (
+            get_serviceevents_instrumentation,
+        )
+
+        first = get_serviceevents_instrumentation(ServiceEventsConfig(service_name="first-service"))
+        second = get_serviceevents_instrumentation(ServiceEventsConfig(service_name="second-service"))
+
+        self.assertIs(second, first)
+        self.assertEqual(second.config.service_name, "first-service")
+
+    def test_returns_existing_instance_when_called_without_config(self):
+        """A subsequent call without a config returns the existing singleton."""
+        from amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation import (
+            get_serviceevents_instrumentation,
+        )
+
+        first = get_serviceevents_instrumentation(ServiceEventsConfig(service_name="first-service"))
+        again = get_serviceevents_instrumentation(None)
+
+        self.assertIs(again, first)
+
+
+class TestServiceEventsOutputFileMode(TestCase):
+    """Test the output_file (local-testing file exporter) wiring branches."""
+
+    def setUp(self):
+        # Neutralize atexit registration (see TestServiceEventsInstrumentation.setUp).
+        patcher = patch("amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation.atexit")
+        self.mock_atexit = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        state_patcher = patch(
+            "amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation._ServiceEventsMonitorState"
+        )
+        self.mock_state = state_patcher.start()
+        self.mock_state.get_instance.return_value = MagicMock()
+        self.addCleanup(state_patcher.stop)
+
+        hooks_patcher = patch(
+            "amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation.install_ast_hooks"
+        )
+        hooks_patcher.start()
+        self.addCleanup(hooks_patcher.stop)
+
+        fd, self.output_path = tempfile.mkstemp(suffix=".ndjson")
+        os.close(fd)
+        self.addCleanup(lambda: os.path.exists(self.output_path) and os.remove(self.output_path))
+
+    def test_output_file_mode_builds_emitter_with_file_exporters(self):
+        """output_file mode creates the OTLP emitter using CloudWatch file exporters."""
+        config = ServiceEventsConfig(
+            enabled=True,
+            function_instrument_enabled=True,
+            output_file=self.output_path,
+            sampling_mode="always",
+        )
+        inst = ServiceEventsInstrumentation(config)
+        inst.initialize()
+        try:
+            self.assertIsNotNone(inst._otlp_emitter)
+            self.assertIsNotNone(inst._otlp_logger_provider)
+            self.assertIsNotNone(inst._otlp_meter_provider)
+        finally:
+            inst.shutdown()
+
+    def test_output_file_wins_over_logs_endpoint(self):
+        """When both output_file and logs_endpoint are set, output_file takes precedence."""
+        config = ServiceEventsConfig(
+            enabled=True,
+            function_instrument_enabled=False,
+            output_file=self.output_path,
+            logs_endpoint="http://localhost:4318/v1/logs",
+            metrics_endpoint="http://localhost:4318/v1/metrics",
+            sampling_mode="always",
+        )
+        inst = ServiceEventsInstrumentation(config)
+        logger_name = "amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation"
+        with self.assertLogs(logger_name, level="INFO") as captured:
+            inst.initialize()
+        try:
+            self.assertIsNotNone(inst._otlp_emitter)
+            self.assertTrue(
+                any("OUTPUT_FILE mode" in r.getMessage() for r in captured.records),
+                "expected OUTPUT_FILE mode log line",
+            )
+        finally:
+            inst.shutdown()
+
+
+class TestServiceEventsResourceAttributes(TestCase):
+    """Test platform resource attribute propagation into the OTLP Resource."""
+
+    def setUp(self):
+        # Neutralize atexit registration (see TestServiceEventsInstrumentation.setUp).
+        patcher = patch("amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation.atexit")
+        self.mock_atexit = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_platform_attributes_added_to_resource(self):
+        """Populated ResourceAttributes flow through to the OTel Resource."""
+        resource_attributes = ResourceAttributes(
+            cloud_provider="aws",
+            cloud_region="us-west-2",
+            host_id="i-0abc123",
+            container_id="container-xyz",
+        )
+        config = ServiceEventsConfig(
+            enabled=True,
+            function_instrument_enabled=False,
+            logs_endpoint="http://localhost:4316/v1/logs",
+            metrics_endpoint="http://localhost:4316/v1/metrics",
+            sampling_mode="always",
+            resource_attributes=resource_attributes,
+        )
+        inst = ServiceEventsInstrumentation(config)
+        inst.initialize()
+        try:
+            attrs = inst._otlp_logger_provider._resource.attributes
+            self.assertEqual(attrs.get("cloud.provider"), "aws")
+            self.assertEqual(attrs.get("cloud.region"), "us-west-2")
+            self.assertEqual(attrs.get("host.id"), "i-0abc123")
+            self.assertEqual(attrs.get("container.id"), "container-xyz")
+        finally:
+            inst.shutdown()
+
+
+class TestServiceEventsLatencyThresholds(TestCase):
+    """Test latency-threshold pattern wiring into the IncidentSnapshotCollector."""
+
+    def setUp(self):
+        # Neutralize atexit registration (see TestServiceEventsInstrumentation.setUp).
+        patcher = patch("amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation.atexit")
+        self.mock_atexit = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    @patch("amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation._ServiceEventsMonitorState")
+    @patch("amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation.install_ast_hooks")
+    def test_latency_patterns_applied_to_incident_collector(self, _mock_hooks, mock_state):
+        """Configured latency thresholds are applied to the IncidentSnapshotCollector."""
+        mock_state.get_instance.return_value = MagicMock()
+        config = ServiceEventsConfig(
+            enabled=True,
+            function_instrument_enabled=False,
+            latency_thresholds=["POST /api/checkout:500", "GET /api/health:50"],
+            sampling_mode="always",
+        )
+        inst = ServiceEventsInstrumentation(config)
+        logger_name = "amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation"
+        with self.assertLogs(logger_name, level="INFO") as captured:
+            inst.initialize()
+        try:
+            incident_collector = next(c for c in inst.collectors if c.__class__.__name__ == "IncidentSnapshotCollector")
+            patterns = incident_collector.get_all_latency_threshold_patterns()
+            self.assertIn(("POST /api/checkout", 500.0), patterns)
+            self.assertTrue(
+                any("latency threshold patterns" in r.getMessage() for r in captured.records),
+                "expected latency-threshold log line",
+            )
+        finally:
+            inst.shutdown()
+
+
+class TestServiceEventsFrameworkHooks(TestCase):
+    """Test the Flask/FastAPI/Django framework-hook error branches in initialize()."""
+
+    def setUp(self):
+        # Neutralize atexit registration (see TestServiceEventsInstrumentation.setUp).
+        patcher = patch("amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation.atexit")
+        self.mock_atexit = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        state_patcher = patch(
+            "amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation._ServiceEventsMonitorState"
+        )
+        self.mock_state = state_patcher.start()
+        self.mock_state.get_instance.return_value = MagicMock()
+        self.addCleanup(state_patcher.stop)
+
+        hooks_patcher = patch(
+            "amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation.install_ast_hooks"
+        )
+        hooks_patcher.start()
+        self.addCleanup(hooks_patcher.stop)
+
+    def _make_instrumentation(self):
+        config = ServiceEventsConfig(
+            enabled=True,
+            function_instrument_enabled=False,
+            sampling_mode="always",
+        )
+        return ServiceEventsInstrumentation(config)
+
+    def test_framework_import_errors_are_handled(self):
+        """Missing Flask/FastAPI/Django modules are skipped via ImportError handling."""
+        # Setting the module entries to None makes the deferred imports raise ImportError,
+        # exercising the "framework not installed" debug branches without uninstalling
+        # the real packages.
+        blocked = {
+            "amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation": None,
+            "amazon.opentelemetry.distro.serviceevents.instrumentation.fastapi_instrumentation": None,
+            "amazon.opentelemetry.distro.serviceevents.instrumentation.django_instrumentation": None,
+        }
+        inst = self._make_instrumentation()
+        with patch.dict(sys.modules, blocked):
+            inst.initialize()
+        try:
+            self.assertTrue(inst._initialized)
+        finally:
+            inst.shutdown()
+
+    def test_framework_install_exceptions_are_handled(self):
+        """Errors raised while installing framework hooks are caught, not propagated."""
+        inst = self._make_instrumentation()
+        flask_mod = (
+            "amazon.opentelemetry.distro.serviceevents.instrumentation.flask_instrumentation.install_flask_hooks"
+        )
+        fastapi_mod = (
+            "amazon.opentelemetry.distro.serviceevents.instrumentation." "fastapi_instrumentation.install_fastapi_hooks"
+        )
+        django_mod = (
+            "amazon.opentelemetry.distro.serviceevents.instrumentation.django_instrumentation.install_django_hooks"
+        )
+        with patch(flask_mod, side_effect=RuntimeError("flask boom")), patch(
+            fastapi_mod, side_effect=RuntimeError("fastapi boom")
+        ), patch(django_mod, side_effect=RuntimeError("django boom")):
+            inst.initialize()
+        try:
+            # Initialization still completes despite the framework-hook failures.
+            self.assertTrue(inst._initialized)
+        finally:
+            inst.shutdown()
+
+    def test_register_at_fork_attribute_error_is_handled(self):
+        """A platform without os.register_at_fork (e.g. Windows) is handled gracefully."""
+        inst = self._make_instrumentation()
+        with patch(
+            "amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation.os.register_at_fork",
+            side_effect=AttributeError("not available"),
+        ):
+            inst.initialize()
+        try:
+            self.assertTrue(inst._initialized)
+        finally:
+            inst.shutdown()
+
+
+class TestServiceEventsReinitializeAfterFork(TestCase):
+    """Test _reinitialize_after_fork collector restart and error handling."""
+
+    def setUp(self):
+        # Neutralize atexit registration (see TestServiceEventsInstrumentation.setUp).
+        patcher = patch("amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation.atexit")
+        self.mock_atexit = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_reinitialize_resets_and_restarts_collectors(self):
+        """After fork, every collector is reset and restarted, monitor state reset is called."""
+        config = ServiceEventsConfig()
+        inst = ServiceEventsInstrumentation(config)
+        mock_collector1 = MagicMock()
+        mock_collector2 = MagicMock()
+        inst.collectors = [mock_collector1, mock_collector2]
+
+        reset_mod = "amazon.opentelemetry.distro.serviceevents.python_monitor.reset_after_fork"
+        with patch(reset_mod) as mock_reset:
+            inst._reinitialize_after_fork()
+
+        mock_reset.assert_called_once()
+        mock_collector1._reset_for_fork.assert_called_once()
+        mock_collector1.start.assert_called_once()
+        mock_collector2._reset_for_fork.assert_called_once()
+        mock_collector2.start.assert_called_once()
+
+    def test_reinitialize_handles_exception(self):
+        """An error during post-fork reset is caught and does not propagate."""
+        config = ServiceEventsConfig()
+        inst = ServiceEventsInstrumentation(config)
+
+        reset_mod = "amazon.opentelemetry.distro.serviceevents.python_monitor.reset_after_fork"
+        with patch(reset_mod, side_effect=RuntimeError("fork boom")):
+            # Should not raise.
+            inst._reinitialize_after_fork()
+
+
+class TestServiceEventsShutdownEdgeCases(TestCase):
+    """Test shutdown() edge cases: atexit/emitter errors and the outer guard."""
+
+    def setUp(self):
+        # Neutralize atexit registration (see TestServiceEventsInstrumentation.setUp).
+        patcher = patch("amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation.atexit")
+        self.mock_atexit = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_shutdown_handles_atexit_unregister_failure(self):
+        """A failure in atexit.unregister during shutdown is swallowed."""
+        config = ServiceEventsConfig()
+        inst = ServiceEventsInstrumentation(config)
+        inst._initialized = True
+        inst._atexit_registered = True
+        self.mock_atexit.unregister.side_effect = RuntimeError("unregister boom")
+
+        # Should not raise; shutdown still completes.
+        inst.shutdown()
+
+        self.assertFalse(inst._atexit_registered)
+        self.assertFalse(inst._initialized)
+
+    def test_shutdown_handles_emitter_shutdown_failure(self):
+        """An error while shutting down the OTLP emitter is caught."""
+        config = ServiceEventsConfig()
+        inst = ServiceEventsInstrumentation(config)
+        inst._initialized = True
+        emitter = MagicMock()
+        emitter.shutdown.side_effect = RuntimeError("emitter boom")
+        inst._otlp_emitter = emitter
+
+        # Should not raise.
+        inst.shutdown()
+
+        emitter.shutdown.assert_called_once()
+        self.assertFalse(inst._initialized)
+
+    def test_shutdown_handles_unexpected_error_in_body(self):
+        """An unexpected error inside the shutdown body is caught by the outer guard."""
+        config = ServiceEventsConfig()
+        inst = ServiceEventsInstrumentation(config)
+        inst._initialized = True
+        # Iterating collectors raises -> exercises the outer try/except.
+        bad_collectors = MagicMock()
+        bad_collectors.__iter__.side_effect = RuntimeError("iteration boom")
+        inst.collectors = bad_collectors
+
+        # Should not raise.
+        inst.shutdown()
+
+
+class TestBuildLogOtlpExporterSigV4(TestCase):
+    """Cover the CloudWatch SigV4 branch of _build_log_otlp_exporter.
+
+    Kept in this file (in addition to test_direct_cw_otlp.py) so the module's
+    isolated coverage reaches the SigV4 path. boto3 and the AWS exporter module
+    are stubbed via sys.modules so the lazy imports resolve from cache, avoiding
+    AWS credential resolution and meta_path finder recursion.
+    """
+
+    def test_cloudwatch_endpoint_routes_to_sigv4_exporter(self):
+        """A CloudWatch logs endpoint is wrapped with the SigV4 AWS exporter."""
+        from amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation import _build_log_otlp_exporter
+        from opentelemetry.exporter.otlp.proto.http import Compression
+
+        stub_boto3 = types.ModuleType("boto3")
+        stub_boto3.Session = MagicMock(return_value=MagicMock(name="stub-boto3-session"))
+
+        exporter_module_path = "amazon.opentelemetry.distro.exporter.otlp.aws.logs.otlp_aws_log_record_exporter"
+        stub_exporter_module = types.ModuleType(exporter_module_path)
+        mock_ctor = MagicMock(name="OTLPAwsLogRecordExporter")
+        stub_exporter_module.OTLPAwsLogRecordExporter = mock_ctor
+
+        with patch.dict(
+            sys.modules,
+            {"boto3": stub_boto3, exporter_module_path: stub_exporter_module},
+        ):
+            _build_log_otlp_exporter(
+                "https://logs.us-east-2.amazonaws.com/v1/logs",
+                {"x-aws-log-group": "/my/group", "x-aws-log-stream": "my-stream"},
+                Compression.Gzip,
+            )
+
+        mock_ctor.assert_called_once()
+        kwargs = mock_ctor.call_args.kwargs
+        self.assertEqual(kwargs["aws_region"], "us-east-2")
+        self.assertEqual(kwargs["endpoint"], "https://logs.us-east-2.amazonaws.com/v1/logs")

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/test_serviceevents_package_init.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/test_serviceevents_package_init.py
@@ -1,0 +1,38 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest import TestCase
+
+import amazon.opentelemetry.distro.serviceevents as se
+
+
+class TestServiceEventsPackageInit(TestCase):
+    """Cover the lazy __getattr__ exports on the serviceevents package."""
+
+    def test_lazy_import_service_events_config(self):
+        """Accessing ServiceEventsConfig resolves the lazy import."""
+        self.assertIsNotNone(se.ServiceEventsConfig)
+
+    def test_lazy_import_service_events_instrumentation(self):
+        """Accessing ServiceEventsInstrumentation resolves the lazy import."""
+        self.assertIsNotNone(se.ServiceEventsInstrumentation)
+
+    def test_lazy_import_get_serviceevents_instrumentation(self):
+        """Accessing get_serviceevents_instrumentation resolves the lazy import."""
+        self.assertIsNotNone(se.get_serviceevents_instrumentation)
+
+    def test_all_lists_lazy_exported_names(self):
+        """__all__ advertises exactly the lazily-exported public names."""
+        self.assertEqual(
+            set(se.__all__),
+            {
+                "ServiceEventsConfig",
+                "ServiceEventsInstrumentation",
+                "get_serviceevents_instrumentation",
+            },
+        )
+
+    def test_unknown_attribute_raises_attribute_error(self):
+        """An unknown attribute falls through to the AttributeError branch."""
+        with self.assertRaises(AttributeError):
+            _ = se.does_not_exist

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/utils/test_instance_id.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/utils/test_instance_id.py
@@ -1,0 +1,90 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest import TestCase
+from unittest.mock import patch
+
+from amazon.opentelemetry.distro.serviceevents.utils.instance_id import clear_instance_id_cache, get_instance_id
+
+
+class TestGetInstanceId(TestCase):
+    """Test the get_instance_id function."""
+
+    def setUp(self):
+        """Clear the cache before each test."""
+        clear_instance_id_cache()
+
+    def tearDown(self):
+        """Clear the cache after each test."""
+        clear_instance_id_cache()
+
+    @patch.dict("os.environ", {"INSTANCE_ID": "my-instance-123"}, clear=False)
+    def test_instance_id_env_var(self):
+        """Test that INSTANCE_ID environment variable is used."""
+        result = get_instance_id()
+        self.assertEqual(result, "my-instance-123")
+
+    @patch.dict("os.environ", {"HOSTNAME": "my-hostname"}, clear=False)
+    @patch.dict("os.environ", {}, clear=False)
+    def test_hostname_env_var(self):
+        """Test that HOSTNAME environment variable is used as fallback."""
+        # Make sure INSTANCE_ID is not set
+        import os
+
+        os.environ.pop("INSTANCE_ID", None)
+        clear_instance_id_cache()
+
+        result = get_instance_id()
+        self.assertEqual(result, "my-hostname")
+
+    @patch.dict("os.environ", {"INSTANCE_ID": "instance-1", "HOSTNAME": "host-1"}, clear=False)
+    def test_instance_id_takes_priority_over_hostname(self):
+        """Test that INSTANCE_ID takes priority over HOSTNAME."""
+        result = get_instance_id()
+        self.assertEqual(result, "instance-1")
+
+    @patch(
+        "amazon.opentelemetry.distro.serviceevents.utils.instance_id.socket.gethostname", return_value="socket-hostname"
+    )
+    @patch.dict("os.environ", {}, clear=True)
+    def test_falls_back_to_socket_gethostname(self, mock_gethostname):
+        """Test fallback to socket.gethostname()."""
+        result = get_instance_id()
+        self.assertEqual(result, "socket-hostname")
+        mock_gethostname.assert_called_once()
+
+    @patch(
+        "amazon.opentelemetry.distro.serviceevents.utils.instance_id.socket.gethostname",
+        side_effect=Exception("DNS error"),
+    )
+    @patch.dict("os.environ", {}, clear=True)
+    def test_socket_error_returns_unknown(self, mock_gethostname):
+        """Test that socket.gethostname() error returns 'unknown'."""
+        result = get_instance_id()
+        self.assertEqual(result, "unknown")
+
+    @patch("amazon.opentelemetry.distro.serviceevents.utils.instance_id.socket.gethostname", return_value="cached-host")
+    @patch.dict("os.environ", {}, clear=True)
+    def test_caching_behavior(self, mock_gethostname):
+        """Test that result is cached - socket only called once."""
+        result1 = get_instance_id()
+        result2 = get_instance_id()
+
+        self.assertEqual(result1, "cached-host")
+        self.assertEqual(result2, "cached-host")
+        mock_gethostname.assert_called_once()
+
+    @patch("amazon.opentelemetry.distro.serviceevents.utils.instance_id.socket.gethostname")
+    @patch.dict("os.environ", {}, clear=True)
+    def test_clear_cache_resets(self, mock_gethostname):
+        """Test that clear_instance_id_cache resets the cache."""
+        mock_gethostname.side_effect = ["first-host", "second-host"]
+
+        result1 = get_instance_id()
+        self.assertEqual(result1, "first-host")
+
+        clear_instance_id_cache()
+
+        result2 = get_instance_id()
+        self.assertEqual(result2, "second-host")
+        self.assertEqual(mock_gethostname.call_count, 2)

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/utils/test_seh_histogram.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/utils/test_seh_histogram.py
@@ -1,0 +1,479 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for SEH (Sparse Exponential Histogram) implementation.
+
+Tests validate:
+- Bucket calculation accuracy
+- Value recovery precision
+- Zero value handling
+- Statistical correctness (min, max, sum, count)
+- Input validation
+- Bucket limit enforcement
+- Compression efficiency
+"""
+
+import math
+import unittest
+from unittest import mock
+
+from amazon.opentelemetry.distro.serviceevents.utils.seh_histogram import BUCKET_FACTOR, BUCKET_FOR_ZERO, SEHHistogram
+
+
+class TestSEHHistogram(unittest.TestCase):
+    """Test cases for SEHHistogram class."""
+
+    def test_initialization(self):
+        """Test histogram initialization."""
+        hist = SEHHistogram(max_buckets=100)
+        self.assertEqual(hist.max_buckets, 100)
+        self.assertEqual(hist.count, 0.0)
+        self.assertEqual(hist.sum, 0.0)
+        self.assertIsNone(hist.minimum)
+        self.assertIsNone(hist.maximum)
+        self.assertEqual(len(hist.buckets), 0)
+        self.assertTrue(hist.is_empty())
+
+    def test_record_single_value(self):
+        """Test recording a single value."""
+        hist = SEHHistogram()
+        result = hist.record(100.0)
+
+        self.assertTrue(result)
+        self.assertEqual(hist.count, 1.0)
+        self.assertEqual(hist.sum, 100.0)
+        self.assertEqual(hist.minimum, 100.0)
+        self.assertEqual(hist.maximum, 100.0)
+        self.assertFalse(hist.is_empty())
+
+    def test_record_multiple_values(self):
+        """Test recording multiple values."""
+        hist = SEHHistogram()
+        values = [10.0, 20.0, 30.0, 40.0, 50.0]
+
+        for value in values:
+            hist.record(value)
+
+        self.assertEqual(hist.count, 5.0)
+        self.assertEqual(hist.sum, 150.0)
+        self.assertEqual(hist.minimum, 10.0)
+        self.assertEqual(hist.maximum, 50.0)
+
+    def test_record_with_weights(self):
+        """Test recording values with weights."""
+        hist = SEHHistogram()
+        hist.record(100.0, weight=2.0)
+        hist.record(200.0, weight=3.0)
+
+        self.assertEqual(hist.count, 5.0)  # 2 + 3
+        self.assertEqual(hist.sum, 800.0)  # 100*2 + 200*3
+
+    def test_zero_value_handling(self):
+        """Test that zero values map to special bucket."""
+        hist = SEHHistogram()
+        hist.record(0.0)
+
+        self.assertEqual(hist.count, 1.0)
+        self.assertEqual(hist.sum, 0.0)
+        self.assertEqual(hist.minimum, 0.0)
+        self.assertEqual(hist.maximum, 0.0)
+
+        # Verify zero uses special bucket
+        self.assertIn(BUCKET_FOR_ZERO, hist.buckets)
+        self.assertEqual(hist.buckets[BUCKET_FOR_ZERO], 1.0)
+
+        # Verify value recovery returns 0
+        values, counts = hist.get_values_and_counts()
+        self.assertEqual(values[0], 0.0)
+        self.assertEqual(counts[0], 1.0)
+
+    def test_bucket_calculation_consistency(self):
+        """Test that similar values map to same bucket."""
+        hist = SEHHistogram()
+
+        # Values within ~10% should map to same bucket
+        similar_values = [1000.0, 1005.0, 1009.0]
+
+        buckets_used = set()
+        for value in similar_values:
+            bucket = hist._get_bucket(value)
+            buckets_used.add(bucket)
+            hist.record(value)
+
+        # All similar values should use same or adjacent buckets
+        self.assertLessEqual(len(buckets_used), 2)
+
+    def test_values_spanning_orders_of_magnitude(self):
+        """Test compression with values spanning multiple orders of magnitude."""
+        hist = SEHHistogram()
+
+        # Values from nanoseconds to seconds
+        values = [
+            1_000,  # 1 microsecond
+            10_000,  # 10 microseconds
+            100_000,  # 100 microseconds
+            1_000_000,  # 1 millisecond
+            10_000_000,  # 10 milliseconds
+            100_000_000,  # 100 milliseconds
+            1_000_000_000,  # 1 second
+        ]
+
+        for value in values:
+            hist.record(value)
+
+        # Should maintain all samples (values span too many orders of magnitude)
+        self.assertEqual(hist.count, 7.0)
+        self.assertEqual(len(hist.buckets), 7)  # Each value gets own bucket due to large range
+
+        # Verify statistics
+        self.assertEqual(hist.minimum, 1_000)
+        self.assertEqual(hist.maximum, 1_000_000_000)
+        self.assertEqual(hist.sum, sum(values))
+
+    def test_get_values_and_counts_format(self):
+        """Test that get_values_and_counts returns proper format."""
+        hist = SEHHistogram()
+        values_input = [100, 200, 300, 400, 500]
+
+        for value in values_input:
+            hist.record(value)
+
+        values, counts = hist.get_values_and_counts()
+
+        # Both should be lists
+        self.assertIsInstance(values, list)
+        self.assertIsInstance(counts, list)
+
+        # Same length
+        self.assertEqual(len(values), len(counts))
+
+        # Values should be sorted (ascending bucket order)
+        self.assertEqual(values, sorted(values))
+
+        # Counts should sum to total count
+        self.assertEqual(sum(counts), hist.count)
+
+    def test_value_recovery_accuracy(self):
+        """Test that recovered values are within ~10% of original."""
+        hist = SEHHistogram()
+        test_values = [1.0, 10.0, 100.0, 1000.0, 10000.0, 100000.0]
+
+        for value in test_values:
+            hist.record(value)
+
+        values, counts = hist.get_values_and_counts()
+
+        # Each recovered value should be within ~10% of an input value
+        for recovered_value in values:
+            # Find closest input value
+            min_error = float("inf")
+            for original in test_values:
+                relative_error = abs(recovered_value - original) / original
+                min_error = min(min_error, relative_error)
+
+            # Should be within ~10% (bucket width)
+            self.assertLess(min_error, 0.15)  # Allow some tolerance
+
+    def test_bucket_limit_folds_overflow_into_nearest_bucket(self):
+        """At the bucket cap, overflow samples fold into the nearest existing bucket
+        rather than being dropped — so count/sum stay consistent with sum(bucket weights)."""
+        hist = SEHHistogram(max_buckets=5)
+
+        # Exponentially spaced values guarantee distinct buckets.
+        values = [10**i for i in range(10)]  # 1, 10, ... 1e9
+        for value in values:
+            # Every sample is accepted now (folded when the cap is hit).
+            self.assertTrue(hist.record(value))
+
+        # Capped at exactly max_buckets distinct buckets.
+        self.assertEqual(len(hist.buckets), 5)
+        # No sample dropped: count reflects ALL recorded values.
+        self.assertEqual(hist.count, len(values))
+        self.assertEqual(hist.sum, sum(values))
+        # The emitted buckets account for every sample (Count == sum(Counts)).
+        _emitted_values, counts = hist.get_values_and_counts()
+        self.assertEqual(sum(counts), hist.count)
+        # min/max still track the true observed extremes, not the folded bucket.
+        self.assertEqual(hist.minimum, min(values))
+        self.assertEqual(hist.maximum, max(values))
+
+    def test_duplicate_values_dont_create_new_buckets(self):
+        """Test that duplicate values increment existing bucket count."""
+        hist = SEHHistogram(max_buckets=2)
+
+        # Record same value multiple times
+        for _ in range(10):
+            result = hist.record(100.0)
+            self.assertTrue(result)
+
+        # Should only have 1 bucket
+        self.assertEqual(len(hist.buckets), 1)
+        self.assertEqual(hist.count, 10.0)
+
+        values, counts = hist.get_values_and_counts()
+        self.assertEqual(len(values), 1)
+        self.assertEqual(counts[0], 10.0)
+
+    def test_input_validation_nan(self):
+        """Test that NaN values are rejected."""
+        hist = SEHHistogram()
+
+        with self.assertRaises(ValueError) as context:
+            hist.record(float("nan"))
+
+        self.assertIn("NaN", str(context.exception))
+
+    def test_input_validation_infinity(self):
+        """Test that Infinity values are rejected."""
+        hist = SEHHistogram()
+
+        with self.assertRaises(ValueError):
+            hist.record(float("inf"))
+
+        with self.assertRaises(ValueError):
+            hist.record(float("-inf"))
+
+    def test_input_validation_negative_weight(self):
+        """Test that negative weights are rejected."""
+        hist = SEHHistogram()
+
+        with self.assertRaises(ValueError) as context:
+            hist.record(100.0, weight=-1.0)
+
+        self.assertIn("positive", str(context.exception))
+
+    def test_input_validation_zero_weight(self):
+        """Test that zero weight is rejected."""
+        hist = SEHHistogram()
+
+        with self.assertRaises(ValueError):
+            hist.record(100.0, weight=0.0)
+
+    def test_input_validation_nan_weight(self):
+        """Test that NaN weights are rejected."""
+        hist = SEHHistogram()
+
+        with self.assertRaises(ValueError) as context:
+            hist.record(100.0, weight=float("nan"))
+
+        self.assertIn("NaN", str(context.exception))
+
+    def test_input_validation_infinity_weight(self):
+        """Test that Infinity weights are rejected."""
+        hist = SEHHistogram()
+
+        with self.assertRaises(ValueError) as context:
+            hist.record(100.0, weight=float("inf"))
+
+        self.assertIn("Infinity", str(context.exception))
+
+    def test_input_validation_value_below_minimum(self):
+        """Test that values below the supported minimum are rejected."""
+        hist = SEHHistogram()
+
+        with self.assertRaises(ValueError) as context:
+            hist.record(-(2**361))
+
+        self.assertIn("below minimum", str(context.exception))
+
+    def test_input_validation_value_above_maximum(self):
+        """Test that values above the supported maximum are rejected."""
+        hist = SEHHistogram()
+
+        with self.assertRaises(ValueError) as context:
+            hist.record(2**361)
+
+        self.assertIn("exceeds maximum", str(context.exception))
+
+    def test_record_returns_false_when_validation_fails(self):
+        """Test that record returns False when validation reports an invalid input."""
+        hist = SEHHistogram()
+
+        with mock.patch.object(hist, "_validate_input", return_value=False):
+            result = hist.record(100.0)
+
+        self.assertFalse(result)
+        self.assertEqual(hist.count, 0.0)
+        self.assertEqual(len(hist.buckets), 0)
+
+    def test_bucket_calculation_for_negative_values(self):
+        """Test bucket calculation negates the bucket number for negative values."""
+        hist = SEHHistogram()
+
+        value = 100.0
+        positive_bucket = hist._get_bucket(value)
+        negative_bucket = hist._get_bucket(-value)
+
+        self.assertEqual(negative_bucket, -positive_bucket)
+
+    def test_empty_histogram_values_and_counts(self):
+        """Test that empty histogram returns empty arrays."""
+        hist = SEHHistogram()
+        values, counts = hist.get_values_and_counts()
+
+        self.assertEqual(values, [])
+        self.assertEqual(counts, [])
+
+    def test_get_statistics(self):
+        """Test get_statistics method."""
+        hist = SEHHistogram()
+        values = [10.0, 20.0, 30.0]
+
+        for value in values:
+            hist.record(value)
+
+        stats = hist.get_statistics()
+
+        self.assertEqual(stats["min"], 10.0)
+        self.assertEqual(stats["max"], 30.0)
+        self.assertEqual(stats["sum"], 60.0)
+        self.assertEqual(stats["count"], 3.0)
+
+    def test_empty_histogram_statistics(self):
+        """Test statistics on empty histogram."""
+        hist = SEHHistogram()
+        stats = hist.get_statistics()
+
+        self.assertEqual(stats["min"], 0.0)
+        self.assertEqual(stats["max"], 0.0)
+        self.assertEqual(stats["sum"], 0.0)
+        self.assertEqual(stats["count"], 0.0)
+
+    def test_realistic_duration_values(self):
+        """Test with realistic function duration values (nanoseconds)."""
+        hist = SEHHistogram()
+
+        # Realistic durations: 10ms to 900ms
+        durations_ns = [
+            20_000_000,  # 20ms
+            50_000_000,  # 50ms
+            75_000_000,  # 75ms
+            100_000_000,  # 100ms
+            150_000_000,  # 150ms
+            200_000_000,  # 200ms
+            500_000_000,  # 500ms
+            900_000_000,  # 900ms
+        ]
+
+        for duration in durations_ns:
+            hist.record(duration)
+
+        values, counts = hist.get_values_and_counts()
+
+        # Should compress (not all durations need separate buckets)
+        self.assertGreater(len(values), 0)
+        self.assertLessEqual(len(values), len(durations_ns))
+
+        # Verify statistics are exact
+        self.assertEqual(hist.count, 8.0)
+        self.assertEqual(hist.sum, sum(durations_ns))
+        self.assertEqual(hist.minimum, min(durations_ns))
+        self.assertEqual(hist.maximum, max(durations_ns))
+
+    def test_bucket_calculation_for_zero(self):
+        """Test bucket calculation returns special value for zero."""
+        hist = SEHHistogram()
+        bucket = hist._get_bucket(0.0)
+        self.assertEqual(bucket, BUCKET_FOR_ZERO)
+
+    def test_bucket_calculation_for_positive_values(self):
+        """Test bucket calculation for positive values."""
+        hist = SEHHistogram()
+
+        # Test known values
+        # bucket = floor(log(value) / log(1.1))
+        value = 100.0
+        expected_bucket = int(math.floor(math.log(value) / BUCKET_FACTOR))
+        actual_bucket = hist._get_bucket(value)
+
+        self.assertEqual(actual_bucket, expected_bucket)
+
+    def test_value_recovery_for_zero_bucket(self):
+        """Test value recovery returns 0 for zero bucket."""
+        hist = SEHHistogram()
+        recovered = hist._recover_value(BUCKET_FOR_ZERO)
+        self.assertEqual(recovered, 0.0)
+
+    def test_value_recovery_formula(self):
+        """Test value recovery uses correct formula."""
+        hist = SEHHistogram()
+
+        bucket_num = 10
+        expected_value = math.exp((bucket_num + 0.5) * BUCKET_FACTOR)
+        actual_value = hist._recover_value(bucket_num)
+
+        self.assertAlmostEqual(actual_value, expected_value, places=10)
+
+    def test_repr(self):
+        """Test string representation."""
+        hist = SEHHistogram()
+        hist.record(100.0)
+        hist.record(200.0)
+
+        repr_str = repr(hist)
+
+        self.assertIn("SEHHistogram", repr_str)
+        self.assertIn("count=2", repr_str)
+        self.assertIn("min=100", repr_str)
+        self.assertIn("max=200", repr_str)
+
+    def test_compression_ratio(self):
+        """Test that SEH provides good compression for typical workloads."""
+        hist = SEHHistogram()
+
+        # Simulate 1000 samples with realistic variation
+        import random
+
+        random.seed(42)
+
+        base_duration = 50_000_000  # 50ms
+        for _ in range(1000):
+            # Add ±50% variation
+            variation = random.uniform(0.5, 1.5)
+            duration = int(base_duration * variation)
+            hist.record(duration)
+
+        values, counts = hist.get_values_and_counts()
+
+        # Should compress significantly (1000 samples -> much fewer buckets)
+        self.assertEqual(hist.count, 1000.0)
+        self.assertLess(len(values), 100)  # Should be well under 100 buckets
+
+        print(f"\nCompression: 1000 samples -> {len(values)} buckets")
+
+    def test_emf_compatibility(self):
+        """Test that output format is compatible with CloudWatch EMF."""
+        hist = SEHHistogram()
+
+        durations = [10_000_000, 20_000_000, 30_000_000, 15_000_000, 25_000_000]
+        for duration in durations:
+            hist.record(duration)
+
+        values, counts = hist.get_values_and_counts()
+        stats = hist.get_statistics()
+
+        # EMF format requirements
+        emf_data = {
+            "Values": values,
+            "Counts": counts,
+            "Max": stats["max"],
+            "Min": stats["min"],
+            "Count": stats["count"],
+            "Sum": stats["sum"],
+        }
+
+        # Verify structure
+        self.assertIsInstance(emf_data["Values"], list)
+        self.assertIsInstance(emf_data["Counts"], list)
+        self.assertEqual(len(emf_data["Values"]), len(emf_data["Counts"]))
+        self.assertLessEqual(len(emf_data["Values"]), 100)  # CloudWatch limit
+
+        # Verify values are sorted
+        self.assertEqual(emf_data["Values"], sorted(emf_data["Values"]))
+
+        print(f"\nEMF format sample: Values={len(values)} buckets, Count={stats['count']}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py
@@ -41,9 +41,11 @@ from amazon.opentelemetry.distro.aws_opentelemetry_configurator import (
     _export_unsampled_span_for_lambda,
     _fetch_logs_header,
     _init_logging,
+    _init_serviceevents,
     _is_application_signals_enabled,
     _is_application_signals_runtime_enabled,
     _is_defer_to_workers_enabled,
+    _is_serviceevents_enabled,
     _is_wsgi_master_process,
     _parse_config_string,
     is_enhanced_code_attributes,
@@ -331,6 +333,115 @@ class TestAwsOpenTelemetryConfigurator(TestCase):
         os.environ.pop("OTEL_AWS_APPLICATION_SIGNALS_ENABLED", None)
         os.environ.setdefault("OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED", None)
         self.assertFalse(_is_application_signals_enabled())
+
+    def test_is_serviceevents_enabled_follows_app_signals_when_unset(self):
+        # Unset OTEL_AWS_SERVICE_EVENTS_ENABLED → follow OTEL_AWS_APPLICATION_SIGNALS_ENABLED
+        with patch.dict(
+            os.environ,
+            {"OTEL_AWS_APPLICATION_SIGNALS_ENABLED": "true"},
+            clear=True,
+        ):
+            self.assertTrue(_is_serviceevents_enabled())
+
+        with patch.dict(
+            os.environ,
+            {"OTEL_AWS_APPLICATION_SIGNALS_ENABLED": "false"},
+            clear=True,
+        ):
+            self.assertFalse(_is_serviceevents_enabled())
+
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertFalse(_is_serviceevents_enabled())
+
+    def test_is_serviceevents_enabled_explicit_override(self):
+        # Explicit true forces ServiceEvents on even when App Signals is off
+        with patch.dict(
+            os.environ,
+            {
+                "OTEL_AWS_SERVICE_EVENTS_ENABLED": "true",
+                "OTEL_AWS_APPLICATION_SIGNALS_ENABLED": "false",
+            },
+            clear=True,
+        ):
+            self.assertTrue(_is_serviceevents_enabled())
+
+        # Explicit false forces ServiceEvents off even when App Signals is on
+        with patch.dict(
+            os.environ,
+            {
+                "OTEL_AWS_SERVICE_EVENTS_ENABLED": "false",
+                "OTEL_AWS_APPLICATION_SIGNALS_ENABLED": "true",
+            },
+            clear=True,
+        ):
+            self.assertFalse(_is_serviceevents_enabled())
+
+    def test_is_serviceevents_enabled_disabled_on_lambda(self):
+        # Lambda always disables ServiceEvents, regardless of the other flags
+        with patch.dict(
+            os.environ,
+            {
+                "AWS_LAMBDA_FUNCTION_NAME": "my-fn",
+                "OTEL_AWS_SERVICE_EVENTS_ENABLED": "true",
+                "OTEL_AWS_APPLICATION_SIGNALS_ENABLED": "true",
+            },
+            clear=True,
+        ):
+            self.assertFalse(_is_serviceevents_enabled())
+
+    @patch("amazon.opentelemetry.distro.serviceevents.get_serviceevents_instrumentation")
+    def test_init_serviceevents_backfills_endpoints_when_app_signals_enabled(self, mock_get_inst):
+        mock_get_inst.return_value = None  # short-circuit after the policy check
+
+        with patch.dict(
+            os.environ,
+            {
+                "OTEL_AWS_APPLICATION_SIGNALS_ENABLED": "true",
+                "OTEL_AWS_OTLP_LOGS_ENDPOINT": "",
+                "OTEL_AWS_OTLP_METRICS_ENDPOINT": "",
+            },
+            clear=True,
+        ):
+            _init_serviceevents()
+
+        config = mock_get_inst.call_args[0][0]
+        self.assertEqual(config.logs_endpoint, "http://localhost:4316/v1/logs")
+        self.assertEqual(config.metrics_endpoint, "http://localhost:4316/v1/metrics")
+
+    @patch("amazon.opentelemetry.distro.serviceevents.get_serviceevents_instrumentation")
+    def test_init_serviceevents_refuses_force_enabled_without_endpoints(self, mock_get_inst):
+        # Force-enabled ServiceEvents with App Signals off and no endpoints → skip init
+        with patch.dict(
+            os.environ,
+            {
+                "OTEL_AWS_SERVICE_EVENTS_ENABLED": "true",
+                "OTEL_AWS_APPLICATION_SIGNALS_ENABLED": "false",
+            },
+            clear=True,
+        ):
+            _init_serviceevents()
+
+        mock_get_inst.assert_not_called()
+
+    @patch("amazon.opentelemetry.distro.serviceevents.get_serviceevents_instrumentation")
+    def test_init_serviceevents_honors_explicit_endpoints_when_force_enabled(self, mock_get_inst):
+        mock_get_inst.return_value = None
+
+        with patch.dict(
+            os.environ,
+            {
+                "OTEL_AWS_SERVICE_EVENTS_ENABLED": "true",
+                "OTEL_AWS_APPLICATION_SIGNALS_ENABLED": "false",
+                "OTEL_AWS_OTLP_LOGS_ENDPOINT": "http://custom:9999/v1/logs",
+                "OTEL_AWS_OTLP_METRICS_ENDPOINT": "http://custom:9999/v1/metrics",
+            },
+            clear=True,
+        ):
+            _init_serviceevents()
+
+        config = mock_get_inst.call_args[0][0]
+        self.assertEqual(config.logs_endpoint, "http://custom:9999/v1/logs")
+        self.assertEqual(config.metrics_endpoint, "http://custom:9999/v1/metrics")
 
     def test_customize_sampler(self):
         mock_sampler: Sampler = MagicMock()

--- a/contract-tests/images/applications/serviceevents-django-uwsgi/Dockerfile
+++ b/contract-tests/images/applications/serviceevents-django-uwsgi/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.10
+WORKDIR /serviceevents-django-uwsgi
+COPY ./dist/$DISTRO /serviceevents-django-uwsgi
+COPY ./contract-tests/images/applications/serviceevents-django-uwsgi /serviceevents-django-uwsgi
+
+ENV PIP_ROOT_USER_ACTION=ignore
+ARG DISTRO
+RUN pip install --upgrade pip && pip install -r requirements.txt && pip install ${DISTRO} --force-reinstall
+RUN opentelemetry-bootstrap -a install
+
+CMD ["opentelemetry-instrument", "uwsgi", \
+     "--module", "serviceevents_django.wsgi:application", \
+     "--http", "0.0.0.0:8080", \
+     "--processes", "2", \
+     "--lazy-apps", \
+     "--enable-threads", \
+     "--import", "opentelemetry.instrumentation.auto_instrumentation.sitecustomize", \
+     "--master", \
+     "--die-on-term"]

--- a/contract-tests/images/applications/serviceevents-django-uwsgi/manage.py
+++ b/contract-tests/images/applications/serviceevents-django-uwsgi/manage.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import os
+import sys
+
+from django.core.management import execute_from_command_line
+
+# Importing execute_from_command_line above does not read settings; only the call
+# below does, so the env default still takes effect before any command runs.
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "serviceevents_django.settings")
+
+execute_from_command_line(sys.argv)

--- a/contract-tests/images/applications/serviceevents-django-uwsgi/requirements.txt
+++ b/contract-tests/images/applications/serviceevents-django-uwsgi/requirements.txt
@@ -1,0 +1,4 @@
+typing-extensions==4.12.2
+django==5.1.14
+uwsgi
+python-dateutil

--- a/contract-tests/images/applications/serviceevents-django-uwsgi/serviceevents_django/helpers.py
+++ b/contract-tests/images/applications/serviceevents-django-uwsgi/serviceevents_django/helpers.py
@@ -1,0 +1,24 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Helper functions for serviceevents Django+uWSGI contract test.
+
+These are in a separate module so that the AST instrumentation hooks
+can transform them properly.
+"""
+
+
+def compute_result(x):
+    return x * 2
+
+
+def validate_input(value):
+    if not value:
+        raise ValueError("Invalid input")
+    return True
+
+
+class BusinessLogic:
+    # process() is deliberately an instance method (not static) so the AST
+    # instrumentation hooks exercise method-level function telemetry.
+    def process(self, data):  # pylint: disable=no-self-use
+        return compute_result(len(data))

--- a/contract-tests/images/applications/serviceevents-django-uwsgi/serviceevents_django/settings.py
+++ b/contract-tests/images/applications/serviceevents-django-uwsgi/serviceevents_django/settings.py
@@ -1,0 +1,19 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+SECRET_KEY = "serviceevents-test-secret"
+
+DEBUG = True
+
+ALLOWED_HOSTS = ["*"]
+
+ROOT_URLCONF = "serviceevents_django.urls"
+
+WSGI_APPLICATION = "serviceevents_django.wsgi.application"
+
+MIDDLEWARE = [
+    "django.middleware.common.CommonMiddleware",
+]

--- a/contract-tests/images/applications/serviceevents-django-uwsgi/serviceevents_django/urls.py
+++ b/contract-tests/images/applications/serviceevents-django-uwsgi/serviceevents_django/urls.py
@@ -1,0 +1,12 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+from django.urls import path
+from serviceevents_django.views import error, exception_endpoint, fault, health, success
+
+urlpatterns = [
+    path("health", health),
+    path("success", success),
+    path("error", error),
+    path("fault", fault),
+    path("exception", exception_endpoint),
+]

--- a/contract-tests/images/applications/serviceevents-django-uwsgi/serviceevents_django/views.py
+++ b/contract-tests/images/applications/serviceevents-django-uwsgi/serviceevents_django/views.py
@@ -1,0 +1,39 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+
+from django.http import HttpResponse, JsonResponse
+
+logging.basicConfig(level=logging.INFO)
+
+
+def health(request):
+    return HttpResponse("Ready")
+
+
+def success(request):
+    # Deferred import: helpers must be imported after the AST hooks are active
+    # so its functions get instrumented (see helpers.py module docstring).
+    # pylint: disable-next=import-outside-toplevel
+    from serviceevents_django.helpers import BusinessLogic, compute_result
+
+    bl = BusinessLogic()
+    result = bl.process("test_data")
+    compute_result(42)
+    return JsonResponse({"status": "ok", "result": result})
+
+
+def error(request):
+    return JsonResponse({"error": "bad request"}, status=400)
+
+
+def fault(request):
+    raise RuntimeError("Intentional server fault")
+
+
+def exception_endpoint(request):
+    # Deferred import (see success()): keep helpers import inside the view.
+    # pylint: disable-next=import-outside-toplevel
+    from serviceevents_django.helpers import validate_input
+
+    validate_input(None)

--- a/contract-tests/images/applications/serviceevents-django-uwsgi/serviceevents_django/wsgi.py
+++ b/contract-tests/images/applications/serviceevents-django-uwsgi/serviceevents_django/wsgi.py
@@ -1,0 +1,11 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import os
+
+from django.core.wsgi import get_wsgi_application
+
+# Importing get_wsgi_application above does not read settings; only the call below
+# does, so the env default still takes effect before the application is built.
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "serviceevents_django.settings")
+
+application = get_wsgi_application()

--- a/contract-tests/images/applications/serviceevents-django/Dockerfile
+++ b/contract-tests/images/applications/serviceevents-django/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.10
+WORKDIR /serviceevents-django
+COPY ./dist/$DISTRO /serviceevents-django
+COPY ./contract-tests/images/applications/serviceevents-django /serviceevents-django
+
+ENV PIP_ROOT_USER_ACTION=ignore
+ARG DISTRO
+RUN pip install --upgrade pip && pip install -r requirements.txt && pip install ${DISTRO} --force-reinstall
+RUN opentelemetry-bootstrap -a install
+
+CMD ["opentelemetry-instrument", "python", "-u", "./manage.py", "runserver", "0.0.0.0:8080", "--noreload"]

--- a/contract-tests/images/applications/serviceevents-django/manage.py
+++ b/contract-tests/images/applications/serviceevents-django/manage.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import os
+import sys
+
+from django.core.management import execute_from_command_line
+
+# Importing execute_from_command_line above does not read settings; only the call
+# below does, so the env default still takes effect before any command runs.
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "serviceevents_django.settings")
+
+execute_from_command_line(sys.argv)

--- a/contract-tests/images/applications/serviceevents-django/requirements.txt
+++ b/contract-tests/images/applications/serviceevents-django/requirements.txt
@@ -1,0 +1,3 @@
+typing-extensions==4.12.2
+django==5.1.14
+python-dateutil

--- a/contract-tests/images/applications/serviceevents-django/serviceevents_django/helpers.py
+++ b/contract-tests/images/applications/serviceevents-django/serviceevents_django/helpers.py
@@ -1,0 +1,24 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Helper functions for serviceevents Django contract test.
+
+These are in a separate module so that the AST instrumentation hooks
+can transform them properly.
+"""
+
+
+def compute_result(x):
+    return x * 2
+
+
+def validate_input(value):
+    if not value:
+        raise ValueError("Invalid input")
+    return True
+
+
+class BusinessLogic:
+    # process() is deliberately an instance method (not static) so the AST
+    # instrumentation hooks exercise method-level function telemetry.
+    def process(self, data):  # pylint: disable=no-self-use
+        return compute_result(len(data))

--- a/contract-tests/images/applications/serviceevents-django/serviceevents_django/settings.py
+++ b/contract-tests/images/applications/serviceevents-django/serviceevents_django/settings.py
@@ -1,0 +1,19 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+SECRET_KEY = "serviceevents-test-secret"
+
+DEBUG = True
+
+ALLOWED_HOSTS = ["*"]
+
+ROOT_URLCONF = "serviceevents_django.urls"
+
+WSGI_APPLICATION = "serviceevents_django.wsgi.application"
+
+MIDDLEWARE = [
+    "django.middleware.common.CommonMiddleware",
+]

--- a/contract-tests/images/applications/serviceevents-django/serviceevents_django/urls.py
+++ b/contract-tests/images/applications/serviceevents-django/serviceevents_django/urls.py
@@ -1,0 +1,12 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+from django.urls import path
+from serviceevents_django.views import error, exception_endpoint, fault, health, success
+
+urlpatterns = [
+    path("health", health),
+    path("success", success),
+    path("error", error),
+    path("fault", fault),
+    path("exception", exception_endpoint),
+]

--- a/contract-tests/images/applications/serviceevents-django/serviceevents_django/views.py
+++ b/contract-tests/images/applications/serviceevents-django/serviceevents_django/views.py
@@ -1,0 +1,39 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+
+from django.http import HttpResponse, JsonResponse
+
+logging.basicConfig(level=logging.INFO)
+
+
+def health(request):
+    return HttpResponse("Ready")
+
+
+def success(request):
+    # Deferred import: helpers must be imported after the AST hooks are active
+    # so its functions get instrumented (see helpers.py module docstring).
+    # pylint: disable-next=import-outside-toplevel
+    from serviceevents_django.helpers import BusinessLogic, compute_result
+
+    bl = BusinessLogic()
+    result = bl.process("test_data")
+    compute_result(42)
+    return JsonResponse({"status": "ok", "result": result})
+
+
+def error(request):
+    return JsonResponse({"error": "bad request"}, status=400)
+
+
+def fault(request):
+    raise RuntimeError("Intentional server fault")
+
+
+def exception_endpoint(request):
+    # Deferred import (see success()): keep helpers import inside the view.
+    # pylint: disable-next=import-outside-toplevel
+    from serviceevents_django.helpers import validate_input
+
+    validate_input(None)

--- a/contract-tests/images/applications/serviceevents-django/serviceevents_django/wsgi.py
+++ b/contract-tests/images/applications/serviceevents-django/serviceevents_django/wsgi.py
@@ -1,0 +1,11 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import os
+
+from django.core.wsgi import get_wsgi_application
+
+# Importing get_wsgi_application above does not read settings; only the call below
+# does, so the env default still takes effect before the application is built.
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "serviceevents_django.settings")
+
+application = get_wsgi_application()

--- a/contract-tests/images/applications/serviceevents-fastapi/Dockerfile
+++ b/contract-tests/images/applications/serviceevents-fastapi/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.10
+WORKDIR /serviceevents-fastapi
+COPY ./dist/$DISTRO /serviceevents-fastapi
+COPY ./contract-tests/images/applications/serviceevents-fastapi /serviceevents-fastapi
+
+ENV PIP_ROOT_USER_ACTION=ignore
+ARG DISTRO
+RUN pip install --upgrade pip && pip install -r requirements.txt && pip install ${DISTRO} --force-reinstall
+RUN opentelemetry-bootstrap -a install
+
+CMD ["opentelemetry-instrument", "python", "-u", "./serviceevents_fastapi_server.py"]

--- a/contract-tests/images/applications/serviceevents-fastapi/helpers.py
+++ b/contract-tests/images/applications/serviceevents-fastapi/helpers.py
@@ -1,0 +1,25 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Helper functions for serviceevents FastAPI contract test.
+
+These are in a separate module so that the AST instrumentation hooks
+(installed before user-code imports) can transform them properly.
+The __main__ module is loaded before hooks are active.
+"""
+
+
+def compute_result(x):
+    return x * 2
+
+
+def validate_input(value):
+    if not value:
+        raise ValueError("Invalid input")
+    return True
+
+
+class BusinessLogic:
+    # process() is deliberately an instance method (not static) so the AST
+    # instrumentation hooks exercise method-level function telemetry.
+    def process(self, data):  # pylint: disable=no-self-use
+        return compute_result(len(data))

--- a/contract-tests/images/applications/serviceevents-fastapi/requirements.txt
+++ b/contract-tests/images/applications/serviceevents-fastapi/requirements.txt
@@ -1,0 +1,4 @@
+typing-extensions==4.12.2
+fastapi
+uvicorn
+python-dateutil

--- a/contract-tests/images/applications/serviceevents-fastapi/serviceevents_fastapi_server.py
+++ b/contract-tests/images/applications/serviceevents-fastapi/serviceevents_fastapi_server.py
@@ -1,0 +1,58 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+
+import uvicorn
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, PlainTextResponse
+
+logging.basicConfig(level=logging.INFO)
+
+app = FastAPI()
+
+
+@app.get("/health")
+async def health():
+    return PlainTextResponse("Ready")
+
+
+@app.get("/success")
+async def success():
+    # Deferred import: helpers must be imported after the AST hooks are active
+    # so its functions get instrumented (see helpers.py module docstring).
+    # pylint: disable-next=import-outside-toplevel
+    from helpers import BusinessLogic, compute_result
+
+    bl = BusinessLogic()
+    result = bl.process("test_data")
+    compute_result(42)
+    return {"status": "ok", "result": result}
+
+
+@app.get("/error")
+async def error():
+    return JSONResponse(status_code=400, content={"error": "bad request"})
+
+
+@app.get("/fault")
+async def fault():
+    raise RuntimeError("Intentional server fault")
+
+
+@app.get("/exception")
+async def exception_endpoint():
+    # Deferred import (see /success): keep helpers import inside the view.
+    # pylint: disable-next=import-outside-toplevel
+    from helpers import validate_input
+
+    validate_input(None)
+
+
+@app.exception_handler(Exception)
+async def global_exception_handler(request: Request, exc: Exception):
+    return JSONResponse(status_code=500, content={"detail": str(exc)})
+
+
+if __name__ == "__main__":
+    print("Ready")
+    uvicorn.run(app, host="0.0.0.0", port=8080, log_level="info")

--- a/contract-tests/images/applications/serviceevents-flask/Dockerfile
+++ b/contract-tests/images/applications/serviceevents-flask/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.10
+WORKDIR /serviceevents-flask
+COPY ./dist/$DISTRO /serviceevents-flask
+COPY ./contract-tests/images/applications/serviceevents-flask /serviceevents-flask
+
+ENV PIP_ROOT_USER_ACTION=ignore
+ARG DISTRO
+RUN pip install --upgrade pip && pip install -r requirements.txt && pip install ${DISTRO} --force-reinstall
+RUN opentelemetry-bootstrap -a install
+
+CMD ["opentelemetry-instrument", "python", "-u", "./serviceevents_flask_server.py"]

--- a/contract-tests/images/applications/serviceevents-flask/helpers.py
+++ b/contract-tests/images/applications/serviceevents-flask/helpers.py
@@ -1,0 +1,25 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Helper functions for serviceevents Flask contract test.
+
+These are in a separate module so that the AST instrumentation hooks
+(installed before user-code imports) can transform them properly.
+The __main__ module is loaded before hooks are active.
+"""
+
+
+def compute_result(x):
+    return x * 2
+
+
+def validate_input(value):
+    if not value:
+        raise ValueError("Invalid input")
+    return True
+
+
+class BusinessLogic:
+    # process() is deliberately an instance method (not static) so the AST
+    # instrumentation hooks exercise method-level function telemetry.
+    def process(self, data):  # pylint: disable=no-self-use
+        return compute_result(len(data))

--- a/contract-tests/images/applications/serviceevents-flask/requirements.txt
+++ b/contract-tests/images/applications/serviceevents-flask/requirements.txt
@@ -1,0 +1,3 @@
+typing-extensions==4.12.2
+flask
+python-dateutil

--- a/contract-tests/images/applications/serviceevents-flask/serviceevents_flask_server.py
+++ b/contract-tests/images/applications/serviceevents-flask/serviceevents_flask_server.py
@@ -1,0 +1,53 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+import os
+
+from flask import Flask, jsonify
+
+logging.basicConfig(level=logging.INFO)
+
+app = Flask(__name__)
+
+
+@app.route("/health")
+def health():
+    return "Ready"
+
+
+@app.route("/success")
+def success():
+    # Deferred import: helpers must be imported after the AST hooks are active
+    # so its functions get instrumented (see helpers.py module docstring).
+    # pylint: disable-next=import-outside-toplevel
+    from helpers import BusinessLogic, compute_result
+
+    bl = BusinessLogic()
+    result = bl.process("test_data")
+    compute_result(42)
+    return jsonify({"status": "ok", "result": result})
+
+
+@app.route("/error")
+def error():
+    return jsonify({"error": "bad request"}), 400
+
+
+@app.route("/fault")
+def fault():
+    raise RuntimeError("Intentional server fault")
+
+
+@app.route("/exception")
+def exception_endpoint():
+    # Deferred import (see /success): keep helpers import inside the view.
+    # pylint: disable-next=import-outside-toplevel
+    from helpers import validate_input
+
+    validate_input(None)
+
+
+if __name__ == "__main__":
+    threaded = os.environ.get("FLASK_THREADED", "true").lower() == "true"
+    print("Ready", flush=True)
+    app.run(host="0.0.0.0", port=8080, debug=False, threaded=threaded)

--- a/contract-tests/images/mock-collector/mock_collector_server.py
+++ b/contract-tests/images/mock-collector/mock_collector_server.py
@@ -38,6 +38,7 @@ def _create_http_handler(logs_collector: MockCollectorLogsService, metrics_colle
         return raw
 
     class OtlpHttpHandler(BaseHTTPRequestHandler):
+        # do_POST is the required BaseHTTPRequestHandler dispatch method name (external API contract).
         def do_POST(self):  # pylint: disable=invalid-name
             if self.path == "/v1/logs":
                 body = _read_body(self)
@@ -89,7 +90,8 @@ def main() -> None:
     mock_collector_server.start()
     atexit.register(mock_collector_server.stop, None)
 
-    # HTTP server on port 4316 (OTLP HTTP /v1/logs and /v1/metrics for the DI snapshot emitter)
+    # HTTP server on port 4316 (OTLP HTTP /v1/logs and /v1/metrics for the
+    # Dynamic Instrumentation snapshot emitter and the ServiceEvents emitter)
     handler_class = _create_http_handler(logs_collector, metrics_collector)
     http_server = HTTPServer(("0.0.0.0", 4316), handler_class)
     http_thread = threading.Thread(target=http_server.serve_forever, daemon=True)

--- a/contract-tests/tests/test/amazon/serviceevents/django_test.py
+++ b/contract-tests/tests/test/amazon/serviceevents/django_test.py
@@ -1,0 +1,26 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+from typing import Dict
+
+from typing_extensions import override
+
+from amazon.serviceevents.serviceevents_contract_test_base import ServiceEventsContractTestBase
+
+_APP_IMAGE = "aws-application-signals-tests-serviceevents-django-app"
+
+
+class DjangoServiceEventsTest(ServiceEventsContractTestBase):
+    __test__ = True
+
+    @override
+    @staticmethod
+    def get_application_image_name() -> str:
+        return _APP_IMAGE
+
+    @override
+    def get_application_wait_pattern(self) -> str:
+        return "Quit the server with CONTROL-C."
+
+    @override
+    def get_application_extra_environment_variables(self) -> Dict[str, str]:
+        return {"DJANGO_SETTINGS_MODULE": "serviceevents_django.settings"}

--- a/contract-tests/tests/test/amazon/serviceevents/django_uwsgi_test.py
+++ b/contract-tests/tests/test/amazon/serviceevents/django_uwsgi_test.py
@@ -1,0 +1,98 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import time
+from typing import Dict, List
+
+from typing_extensions import override
+
+from amazon.serviceevents.serviceevents_contract_test_base import (
+    OTLP_POLL_INTERVAL,
+    OTLP_POLL_TIMEOUT,
+    ServiceEventsContractTestBase,
+)
+
+_APP_IMAGE = "aws-application-signals-tests-serviceevents-django-uwsgi-app"
+
+
+class DjangoUwsgiServiceEventsTest(ServiceEventsContractTestBase):
+    __test__ = True
+
+    @override
+    @staticmethod
+    def get_application_image_name() -> str:
+        return _APP_IMAGE
+
+    @override
+    def get_application_wait_pattern(self) -> str:
+        return "spawned uWSGI worker"
+
+    @override
+    def get_application_extra_environment_variables(self) -> Dict[str, str]:
+        return {
+            "DJANGO_SETTINGS_MODULE": "serviceevents_django.settings",
+            "OTEL_AWS_PYTHON_DEFER_TO_WORKERS_ENABLED": "true",
+        }
+
+    @override
+    def get_application_start_timeout(self) -> int:
+        return 60
+
+    # -------------------------------------------------------------------------
+    # uWSGI aggregation helper
+    # -------------------------------------------------------------------------
+
+    def _wait_for_endpoint_count(self, method: str, route: str, min_total: int) -> List:
+        """Poll until the summed count across matching EndpointSummary OTLP logs reaches min_total."""
+        start = time.time()
+        while time.time() - start < OTLP_POLL_TIMEOUT:
+            logs = self.get_endpoint_summary_logs(method, route)
+            total = sum(self.attrs(log).get("aws.service_events.request.count", 0) for log in logs)
+            if total >= min_total:
+                return logs
+            time.sleep(OTLP_POLL_INTERVAL)
+        logs = self.get_endpoint_summary_logs(method, route)
+        total = sum(self.attrs(log).get("aws.service_events.request.count", 0) for log in logs)
+        self.assertGreaterEqual(total, min_total, f"Timed out: total count {total} < {min_total} for {method} {route}")
+        return logs
+
+    # -------------------------------------------------------------------------
+    # Overridden EndpointSummary tests (aggregate across workers)
+    # -------------------------------------------------------------------------
+
+    @override
+    def test_endpoint_summary_success(self) -> None:
+        for _ in range(3):
+            response = self.send_request("GET", "success")
+            self.assertEqual(200, response.status_code)
+
+        logs = self._wait_for_endpoint_count("GET", "/success", 3)
+        total_faults = sum(self.attrs(log).get("aws.service_events.request.faults", 0) for log in logs)
+        self.assertEqual(total_faults, 0)
+
+    @override
+    def test_endpoint_summary_fault(self) -> None:
+        for _ in range(2):
+            response = self.send_request("GET", "fault")
+            self.assertEqual(500, response.status_code)
+
+        logs = self._wait_for_endpoint_count("GET", "/fault", 2)
+        total_faults = sum(self.attrs(log).get("aws.service_events.request.faults", 0) for log in logs)
+        self.assertGreater(total_faults, 0, "Expected faults > 0")
+
+    # -------------------------------------------------------------------------
+    # uWSGI-specific tests
+    # -------------------------------------------------------------------------
+
+    def test_uwsgi_multiprocess_telemetry(self) -> None:
+        """Verify serviceevents collectors work in uWSGI forked worker processes."""
+        for _ in range(5):
+            self.send_request("GET", "success")
+
+        # If collectors failed to re-initialize in workers, no records would appear.
+        # FunctionCall now flows through the service.function.duration histogram metric.
+        data_points = self.wait_for_function_duration_metric()
+        self.assertGreater(len(data_points), 0)
+
+        # Each uWSGI worker has its own collector; counts may split across multiple
+        # EndpointSummary logs. Wait until total reaches 5.
+        self._wait_for_endpoint_count("GET", "/success", 5)

--- a/contract-tests/tests/test/amazon/serviceevents/fastapi_test.py
+++ b/contract-tests/tests/test/amazon/serviceevents/fastapi_test.py
@@ -1,0 +1,20 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+from typing_extensions import override
+
+from amazon.serviceevents.serviceevents_contract_test_base import ServiceEventsContractTestBase
+
+_APP_IMAGE = "aws-application-signals-tests-serviceevents-fastapi-app"
+
+
+class FastApiServiceEventsTest(ServiceEventsContractTestBase):
+    __test__ = True
+
+    @override
+    @staticmethod
+    def get_application_image_name() -> str:
+        return _APP_IMAGE
+
+    @override
+    def get_application_wait_pattern(self) -> str:
+        return "Uvicorn running on"

--- a/contract-tests/tests/test/amazon/serviceevents/flask_test.py
+++ b/contract-tests/tests/test/amazon/serviceevents/flask_test.py
@@ -1,0 +1,224 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import time
+from typing import Dict
+
+from typing_extensions import override
+
+from amazon.serviceevents.serviceevents_contract_test_base import (
+    SERVICE_EVENTS_FLUSH_INTERVAL_MS,
+    ServiceEventsContractTestBase,
+    ServiceEventsTestInfrastructure,
+)
+
+_APP_IMAGE = "aws-application-signals-tests-serviceevents-flask-app"
+
+
+class FlaskServiceEventsTest(ServiceEventsContractTestBase):
+    __test__ = True
+
+    @override
+    @staticmethod
+    def get_application_image_name() -> str:
+        return _APP_IMAGE
+
+    @override
+    def get_application_wait_pattern(self) -> str:
+        return "Running on"
+
+    # -------------------------------------------------------------------------
+    # Flask-only tests (framework-agnostic feature coverage)
+    # -------------------------------------------------------------------------
+
+    def test_endpoint_summary_error_count(self) -> None:
+        """3x GET /error (400), verify errors >= 3, faults == 0."""
+        for _ in range(3):
+            response = self.send_request("GET", "error")
+            self.assertEqual(400, response.status_code)
+
+        logs = self.wait_for_endpoint_summary("GET", "/error")
+        total_errors = sum(self.attrs(log).get("aws.service_events.request.errors", 0) for log in logs)
+        total_faults = sum(self.attrs(log).get("aws.service_events.request.faults", 0) for log in logs)
+        self.assertGreaterEqual(total_errors, 3, "Expected errors >= 3")
+        self.assertEqual(total_faults, 0)
+
+    # test_endpoint_error_metrics_counter lives in the shared base now (it runs across
+    # all frameworks — async and WSGI-fork are exactly where a metrics-pipeline
+    # regression is most likely), so it is intentionally not duplicated here.
+
+    def test_endpoint_summary_incident_exemplar(self) -> None:
+        """GET /exception, verify incidents_exemplar body entry with snapshot_id."""
+        response = self.send_request("GET", "exception")
+        self.assertEqual(500, response.status_code)
+
+        logs = self.wait_for_endpoint_summary("GET", "/exception")
+        found_exemplar = False
+        for log in logs:
+            body = self.body(log)
+            exemplars = body.get("incidents_exemplar", []) if isinstance(body, dict) else []
+            if exemplars and exemplars[0].get("snapshot_id"):
+                found_exemplar = True
+                exemplar = exemplars[0]
+                # The exemplar carries the snapshot_id plus the trigger_type/timestamp
+                # of the incident it points to. /exception triggers an "exception".
+                self.assertEqual(exemplar.get("trigger_type"), "exception")
+                self.assertGreater(exemplar.get("timestamp", 0), 0, "Expected a non-zero exemplar timestamp")
+                # The incident.count attribute tracks the same incidents as the body
+                # exemplar list, so it must be >= 1 on the log that carries one.
+                self.assert_endpoint_summary(log, min_incident_count=1)
+                break
+        self.assertTrue(found_exemplar, "Expected at least one incidents_exemplar entry with snapshot_id")
+
+    def test_function_call_exception_tracking(self) -> None:
+        """GET /exception — verify the function-duration histogram has a data point
+        tagged status=error.
+
+        Exception class names are intentionally NOT exposed on the histogram
+        (cardinality control); the ValueError class is asserted on the
+        IncidentSnapshot log signal in test_incident_snapshot_value_error.
+        """
+        response = self.send_request("GET", "exception")
+        self.assertEqual(500, response.status_code)
+
+        data_points = self.wait_for_function_duration_metric()
+        self.assertGreater(len(data_points), 0)
+
+        found_error = False
+        for dp in data_points:
+            attrs = self.dp_attrs(dp)
+            if attrs.get("status") == "error":
+                # exception.type must NOT be on the histogram.
+                self.assertNotIn("exception.type", attrs)
+                found_error = True
+                break
+        self.assertTrue(
+            found_error,
+            "Expected at least one service.function.duration data point with status=error",
+        )
+
+    def test_incident_snapshot_deduplication(self) -> None:
+        """5x GET /exception, verify snapshot count is capped (deduplication)."""
+        for _ in range(5):
+            self.send_request("GET", "exception")
+
+        # Wait for at least one snapshot to flush, then give dedup time to settle.
+        self.wait_for_otlp_logs("aws.service_events.incident_snapshot")
+        time.sleep(float(SERVICE_EVENTS_FLUSH_INTERVAL_MS) / 1000 + 1)
+
+        logs = self.get_otlp_logs_by_event_name("aws.service_events.incident_snapshot")
+        self.assertGreater(len(logs), 0, "Expected at least one IncidentSnapshot log")
+        self.assertLessEqual(len(logs), 5, "Expected deduplication to cap snapshot count")
+
+
+class FlaskEndpointFilterTest(ServiceEventsTestInfrastructure):
+    """Test that endpoint exclude patterns filter out matching endpoints."""
+
+    @override
+    @staticmethod
+    def get_application_image_name() -> str:
+        return _APP_IMAGE
+
+    @override
+    def get_application_wait_pattern(self) -> str:
+        return "Running on"
+
+    @override
+    def get_application_extra_environment_variables(self) -> Dict[str, str]:
+        return {"OTEL_AWS_SERVICE_EVENTS_ENDPOINT_EXCLUDE_PATTERNS": "GET /success"}
+
+    def test_endpoint_exclude_pattern(self) -> None:
+        """Verify /success is excluded from EndpointSummary when filtered."""
+        for _ in range(3):
+            self.send_request("GET", "success")
+        for _ in range(2):
+            self.send_request("GET", "fault")
+
+        # Wait for /fault (which should appear)
+        self.wait_for_endpoint_summary("GET", "/fault")
+
+        # /success should be absent from OTLP
+        success_logs = self.get_endpoint_summary_logs("GET", "/success")
+        self.assertEqual(len(success_logs), 0, "Expected /success to be excluded by filter pattern")
+
+
+class FlaskDisabledTest(ServiceEventsTestInfrastructure):
+    """Test that disabling serviceevents produces no telemetry OTLP logs."""
+
+    @override
+    @staticmethod
+    def get_application_image_name() -> str:
+        return _APP_IMAGE
+
+    @override
+    def get_application_wait_pattern(self) -> str:
+        return "Running on"
+
+    @override
+    def get_application_extra_environment_variables(self) -> Dict[str, str]:
+        return {"OTEL_AWS_SERVICE_EVENTS_ENABLED": "false"}
+
+    def test_serviceevents_disabled_produces_no_records(self) -> None:
+        """Verify zero serviceevents OTLP logs when disabled."""
+        for _ in range(3):
+            self.send_request("GET", "success")
+        self.send_request("GET", "exception")
+
+        time.sleep(float(SERVICE_EVENTS_FLUSH_INTERVAL_MS) / 1000 + 2)
+
+        for event_name in [
+            "aws.service_events.endpoint_summary",
+            "aws.service_events.incident_snapshot",
+            "aws.service_events.deployment_event",
+        ]:
+            logs = self.get_otlp_logs_by_event_name(event_name)
+            self.assertEqual(len(logs), 0, f"Expected no {event_name} logs when disabled, found {len(logs)}")
+
+        # The function-duration histogram should also be silent when disabled.
+        data_points = self._peek_function_duration_data_points()
+        self.assertEqual(
+            len(data_points),
+            0,
+            f"Expected no service.function.duration data points when disabled, found {len(data_points)}",
+        )
+
+
+class FlaskAppSignalsBundledTest(ServiceEventsTestInfrastructure):
+    """Bundled mode: when OTEL_AWS_APPLICATION_SIGNALS_ENABLED=true, EndpointSummary
+    is suppressed (App Signals carries equivalent per-endpoint metrics), while
+    FunctionCall / IncidentSnapshot / DeploymentEvent continue to flow.
+    """
+
+    @override
+    @staticmethod
+    def get_application_image_name() -> str:
+        return _APP_IMAGE
+
+    @override
+    def get_application_wait_pattern(self) -> str:
+        return "Running on"
+
+    @override
+    def get_application_extra_environment_variables(self) -> Dict[str, str]:
+        return {"OTEL_AWS_APPLICATION_SIGNALS_ENABLED": "true"}
+
+    def test_endpoint_summary_suppressed_when_app_signals_on(self) -> None:
+        for _ in range(3):
+            self.send_request("GET", "success")
+        self.send_request("GET", "exception")
+
+        # Wait for other serviceevents signals to confirm the pipeline is alive,
+        # then assert EndpointSummary never arrived.
+        self.wait_for_function_duration_metric()
+        time.sleep(float(SERVICE_EVENTS_FLUSH_INTERVAL_MS) / 1000 + 2)
+
+        summary_logs = self.get_otlp_logs_by_event_name("aws.service_events.endpoint_summary")
+        self.assertEqual(
+            len(summary_logs),
+            0,
+            f"Expected EndpointSummary suppressed under App Signals, found {len(summary_logs)}",
+        )
+
+        # Other serviceevents signals still flow.
+        self.assertGreater(len(self._peek_function_duration_data_points()), 0)
+        self.assertGreater(len(self.get_otlp_logs_by_event_name("aws.service_events.incident_snapshot")), 0)
+        self.assertGreaterEqual(len(self.get_otlp_logs_by_event_name("aws.service_events.deployment_event")), 1)

--- a/contract-tests/tests/test/amazon/serviceevents/serviceevents_contract_test_base.py
+++ b/contract-tests/tests/test/amazon/serviceevents/serviceevents_contract_test_base.py
@@ -1,0 +1,725 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import sys
+import time
+import uuid
+from logging import INFO, Logger, getLogger
+from typing import Any, Dict, List, Optional
+from unittest import TestCase
+
+from docker import DockerClient
+from docker.models.networks import Network, NetworkCollection
+from docker.types import EndpointConfig
+from requests import Response, request
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_for_logs
+
+_logger: Logger = getLogger(__name__)
+_logger.setLevel(INFO)
+
+SERVICE_EVENTS_FLUSH_INTERVAL_MS: str = "2000"
+OTLP_POLL_TIMEOUT: float = 20.0
+OTLP_POLL_INTERVAL: float = 1.0
+
+# Deployment/VCS metadata injected via env so the OTLP VCS + deployment attributes
+# (vcs.ref.head.revision, vcs.repository.url.full, aws.service_events.deployment.id)
+# can be asserted end-to-end on EndpointSummary / IncidentSnapshot signals.
+TEST_DEPLOYMENT_ID: str = "deploy-contract-test"
+TEST_GIT_COMMIT_SHA: str = "0123456789abcdef0123456789abcdef01234567"
+TEST_GIT_REPO_URL: str = "https://github.com/aws/contract-test-repo"
+# DeploymentEvent-only metadata: these ride solely on the deployment_event signal
+# (aws.service_events.deployment.{url,timestamp}), so they're asserted there.
+TEST_DEPLOYMENT_URL: str = "https://github.com/aws/contract-test-repo/actions/runs/123"
+TEST_DEPLOYMENT_TIMESTAMP: str = "2026-01-01T00:00:00Z"
+
+VALID_SEVERITIES = {"critical", "high", "medium", "low", "info"}
+
+# Mock collector config
+_MOCK_COLLECTOR_IMAGE: str = "aws-application-signals-mock-collector-python"
+_MOCK_COLLECTOR_GRPC_PORT: int = 4315
+_MOCK_COLLECTOR_HTTP_PORT: int = 4316
+_MOCK_COLLECTOR_ALIAS: str = "collector"
+_NETWORK_NAME: str = "serviceevents-contract-test-network"
+
+# Add mock collector client to path
+sys.path.insert(0, str(__import__("pathlib").Path(__file__).resolve().parents[5] / "images" / "mock-collector"))
+
+
+# pylint: disable=broad-exception-caught
+class ServiceEventsTestInfrastructure(TestCase):
+    """Infrastructure base class with container lifecycle and OTLP assertion helpers.
+
+    Telemetry is exported exclusively via OTLP to a mock collector container.
+    The file exporter is not supported. Tests must inspect OTLP LogRecords/Metrics
+    via the mock collector client.
+    """
+
+    application: Optional[DockerContainer] = None
+    mock_collector: Optional[DockerContainer] = None
+    mock_collector_client = None
+    _network: Optional[Network] = None
+
+    def setUp(self) -> None:
+        self.addCleanup(self.tear_down)
+        # Initialize so tear_down can run even if setUp fails mid-way.
+        self.application = None
+        self.mock_collector = None
+        self.mock_collector_client = None
+        self._network = None
+
+        # Unique network name per test to avoid 409 conflicts across parallel or
+        # sequential tests that didn't clean up cleanly.
+        network_name = f"{_NETWORK_NAME}-{uuid.uuid4().hex[:8]}"
+
+        self._network = NetworkCollection(client=DockerClient()).create(network_name)
+        collector_networking_config = {network_name: EndpointConfig(version="1.22", aliases=[_MOCK_COLLECTOR_ALIAS])}
+        app_networking_config = {network_name: EndpointConfig(version="1.22", aliases=["application"])}
+
+        self.mock_collector = (
+            DockerContainer(_MOCK_COLLECTOR_IMAGE)
+            .with_exposed_ports(_MOCK_COLLECTOR_GRPC_PORT, _MOCK_COLLECTOR_HTTP_PORT)
+            .with_kwargs(network=network_name, networking_config=collector_networking_config)
+        )
+        self.mock_collector.start()
+        wait_for_logs(self.mock_collector, "Ready", timeout=20)
+
+        from mock_collector_client import MockCollectorClient
+
+        collector_host = self.mock_collector.get_container_host_ip()
+        collector_grpc_port = self.mock_collector.get_exposed_port(_MOCK_COLLECTOR_GRPC_PORT)
+        self.mock_collector_client = MockCollectorClient(collector_host, collector_grpc_port)
+
+        # OTLPLogExporter/OTLPMetricExporter POST to the endpoint as-is (no /v1/logs appended
+        # when endpoint is passed to the constructor). Include the full path.
+        otlp_logs_endpoint = f"http://{_MOCK_COLLECTOR_ALIAS}:{_MOCK_COLLECTOR_HTTP_PORT}/v1/logs"
+        otlp_metrics_endpoint = f"http://{_MOCK_COLLECTOR_ALIAS}:{_MOCK_COLLECTOR_HTTP_PORT}/v1/metrics"
+
+        self.application = (
+            DockerContainer(self.get_application_image_name())
+            .with_exposed_ports(self.get_application_port())
+            .with_kwargs(network=network_name, networking_config=app_networking_config)
+            # Standard OTel config
+            .with_env("OTEL_PYTHON_DISTRO", "aws_distro")
+            .with_env("OTEL_PYTHON_CONFIGURATOR", "aws_configurator")
+            .with_env("OTEL_TRACES_EXPORTER", "none")
+            .with_env("OTEL_METRICS_EXPORTER", "none")
+            .with_env("OTEL_LOGS_EXPORTER", "none")
+            .with_env("OTEL_AWS_APPLICATION_SIGNALS_ENABLED", "false")
+            .with_env("OTEL_TRACES_SAMPLER", "always_on")
+            .with_env("OTEL_SERVICE_NAME", self.get_application_otel_service_name())
+            .with_env("OTEL_RESOURCE_ATTRIBUTES", "deployment.environment.name=test")
+            # ServiceEvents config (OTLP-only export path)
+            .with_env("OTEL_AWS_SERVICE_EVENTS_ENABLED", "true")
+            .with_env("OTEL_AWS_SERVICE_EVENTS_FUNCTION_INSTRUMENT_ENABLED", "true")
+            # Flush intervals (and any subclass knobs) are internal now; inject the fast test
+            # cadence via the test-config hook. See get_test_config_hook_overrides().
+            .with_env("DEBUG_SE_TEST_CONFIG", self._build_test_config_hook_value())
+            .with_env("OTEL_AWS_SERVICE_EVENTS_SAMPLING_MODE", "always")
+            # Deployment/VCS metadata — feeds the VCS + deployment OTLP attributes.
+            .with_env("OTEL_AWS_SERVICE_EVENTS_DEPLOYMENT_ID", TEST_DEPLOYMENT_ID)
+            .with_env("OTEL_AWS_SERVICE_EVENTS_GIT_COMMIT_SHA", TEST_GIT_COMMIT_SHA)
+            .with_env("OTEL_AWS_SERVICE_EVENTS_GIT_REPO_URL", TEST_GIT_REPO_URL)
+            # DeploymentEvent-only metadata — feeds deployment.url / deployment.timestamp.
+            .with_env("OTEL_AWS_SERVICE_EVENTS_DEPLOYMENT_URL", TEST_DEPLOYMENT_URL)
+            .with_env("OTEL_AWS_SERVICE_EVENTS_DEPLOYMENT_TIMESTAMP", TEST_DEPLOYMENT_TIMESTAMP)
+            # Explicit allowlist required — there is no implicit default scope. Covers the
+            # contract-test apps' own modules: `helpers` (Flask/FastAPI) and the
+            # `serviceevents_*_server` / `serviceevents_django.*` app code. fnmatch's
+            # `*` spans dots, so `serviceevents_*` also matches `serviceevents_django.views`.
+            .with_env(
+                "OTEL_AWS_SERVICE_EVENTS_PACKAGES_INCLUDE",
+                "helpers,serviceevents_*",
+            )
+            .with_env("OTEL_AWS_SERVICE_EVENTS_INCIDENT_SNAPSHOT_MAX_PER_MINUTE", "1000")
+            .with_env("OTEL_AWS_SERVICE_EVENTS_INCIDENT_SNAPSHOT_MAX_SAME_ERROR", "100")
+            .with_env("OTEL_AWS_OTLP_LOGS_ENDPOINT", otlp_logs_endpoint)
+            .with_env("OTEL_AWS_OTLP_METRICS_ENDPOINT", otlp_metrics_endpoint)
+            # Force the OTel metric reader to flush every 2s so contract tests
+            # see service.function.duration / count
+            # within the OTLP_POLL_TIMEOUT window. Production defaults to 60s.
+            .with_env("OTEL_METRIC_EXPORT_INTERVAL", SERVICE_EVENTS_FLUSH_INTERVAL_MS)
+        )
+
+        extra_env: Dict[str, str] = self.get_application_extra_environment_variables()
+        for key in extra_env:
+            self.application.with_env(key, extra_env.get(key))
+
+        self.application.start()
+        wait_for_logs(
+            self.application, self.get_application_wait_pattern(), timeout=self.get_application_start_timeout()
+        )
+        time.sleep(0.5)
+
+    def tear_down(self) -> None:
+        try:
+            if self.application is not None:
+                _logger.info("Application stdout")
+                _logger.info(self.application.get_logs()[0].decode())
+                _logger.info("Application stderr")
+                _logger.info(self.application.get_logs()[1].decode())
+                self.application.stop()
+        except Exception:
+            _logger.exception("Failed to tear down application")
+        try:
+            if self.mock_collector is not None:
+                self.mock_collector.stop()
+        except Exception:
+            _logger.exception("Failed to tear down mock collector")
+        try:
+            if self._network is not None:
+                self._network.remove()
+        except Exception:
+            _logger.exception("Failed to remove Docker network")
+
+    # -------------------------------------------------------------------------
+    # OTLP value parsing helpers
+    # -------------------------------------------------------------------------
+
+    @staticmethod
+    def _any_value_to_python(any_value) -> Any:
+        """Convert an OTLP AnyValue protobuf to a Python primitive/dict/list."""
+        kind = any_value.WhichOneof("value")
+        if kind == "string_value":
+            return any_value.string_value
+        if kind == "bool_value":
+            return any_value.bool_value
+        if kind == "int_value":
+            return any_value.int_value
+        if kind == "double_value":
+            return any_value.double_value
+        if kind == "array_value":
+            return [ServiceEventsTestInfrastructure._any_value_to_python(v) for v in any_value.array_value.values]
+        if kind == "kvlist_value":
+            return {
+                kv.key: ServiceEventsTestInfrastructure._any_value_to_python(kv.value)
+                for kv in any_value.kvlist_value.values
+            }
+        if kind == "bytes_value":
+            return any_value.bytes_value
+        return None
+
+    @classmethod
+    def attrs(cls, log) -> Dict[str, Any]:
+        """Return log record's attributes as a flat {key: python_value} dict."""
+        return {kv.key: cls._any_value_to_python(kv.value) for kv in log.log_record.attributes}
+
+    @classmethod
+    def body(cls, log) -> Any:
+        """Return log record's body converted to a python primitive/dict/list."""
+        return cls._any_value_to_python(log.log_record.body)
+
+    # -------------------------------------------------------------------------
+    # OTLP log helpers
+    # -------------------------------------------------------------------------
+
+    def get_otlp_logs_by_event_name(self, event_name: str) -> List:
+        """Get OTLP log records from mock collector filtered by event.name (non-blocking)."""
+        if self.mock_collector_client is None:
+            return []
+        return self.mock_collector_client.peek_logs_by_event_name(event_name)
+
+    def wait_for_otlp_logs(self, event_name: str, min_count: int = 1, timeout: Optional[float] = None) -> List:
+        """Poll mock collector until min_count logs with event_name appear."""
+        if self.mock_collector_client is None:
+            self.fail("Mock collector not initialized — cannot poll OTLP logs")
+        if timeout is None:
+            timeout = OTLP_POLL_TIMEOUT
+
+        start = time.time()
+        records: List = []
+        while time.time() - start < timeout:
+            records = self.get_otlp_logs_by_event_name(event_name)
+            if len(records) >= min_count:
+                return records
+            time.sleep(OTLP_POLL_INTERVAL)
+
+        records = self.get_otlp_logs_by_event_name(event_name)
+        if len(records) < min_count:
+            self.fail(
+                f"Timed out waiting for {min_count} OTLP log(s) with event.name='{event_name}'. "
+                f"Found {len(records)} after {timeout}s."
+            )
+        return records
+
+    def get_endpoint_summary_logs(self, method: str, route: str) -> List:
+        """Return EndpointSummary OTLP logs filtered by method + route."""
+        logs = self.get_otlp_logs_by_event_name("aws.service_events.endpoint_summary")
+        result = []
+        for log in logs:
+            a = self.attrs(log)
+            if a.get("http.request.method") == method and a.get("url.route") == route:
+                result.append(log)
+        return result
+
+    def wait_for_endpoint_summary(self, method: str, route: str, timeout: Optional[float] = None) -> List:
+        """Poll for an EndpointSummary log matching method + route."""
+        if timeout is None:
+            timeout = OTLP_POLL_TIMEOUT
+        start = time.time()
+        logs: List = []
+        while time.time() - start < timeout:
+            logs = self.get_endpoint_summary_logs(method, route)
+            if logs:
+                return logs
+            time.sleep(OTLP_POLL_INTERVAL)
+        logs = self.get_endpoint_summary_logs(method, route)
+        if not logs:
+            self.fail(f"Timed out waiting for EndpointSummary log for {method} {route} after {timeout}s.")
+        return logs
+
+    # -------------------------------------------------------------------------
+    # OTLP metric helpers — function-call latency Histogram
+    # -------------------------------------------------------------------------
+    #
+    # FunctionCall telemetry flows through a single OTel metric:
+    #
+    #   - service.function.duration (Histogram): sampled calls only — latency
+
+    _FUNCTION_DURATION_METRIC_NAME: str = "service.function.duration"
+
+    def _peek_function_duration_data_points(self) -> List:
+        """Return all data points for the service.function.duration histogram (non-blocking)."""
+        if self.mock_collector_client is None:
+            return []
+        # exact_match=False so we don't time out when other metrics aren't present yet.
+        try:
+            metrics = self.mock_collector_client.get_metrics({self._FUNCTION_DURATION_METRIC_NAME}, exact_match=False)
+        except RuntimeError:
+            return []
+        data_points: List = []
+        for rsm in metrics:
+            if rsm.metric.name != self._FUNCTION_DURATION_METRIC_NAME:
+                continue
+            histogram_proto = rsm.metric.WhichOneof("data")
+            if histogram_proto == "exponential_histogram":
+                data_points.extend(rsm.metric.exponential_histogram.data_points)
+            elif histogram_proto == "histogram":
+                data_points.extend(rsm.metric.histogram.data_points)
+        return data_points
+
+    def wait_for_function_duration_metric(self, min_count: int = 1, timeout: Optional[float] = None) -> List:
+        """Poll until at least min_count data points appear in the function-duration histogram."""
+        if self.mock_collector_client is None:
+            self.fail("Mock collector not initialized — cannot poll OTLP metrics")
+        if timeout is None:
+            timeout = OTLP_POLL_TIMEOUT
+        start = time.time()
+        data_points: List = []
+        while time.time() - start < timeout:
+            data_points = self._peek_function_duration_data_points()
+            if len(data_points) >= min_count:
+                return data_points
+            time.sleep(OTLP_POLL_INTERVAL)
+        if len(data_points) < min_count:
+            self.fail(
+                f"Timed out waiting for {min_count} '{self._FUNCTION_DURATION_METRIC_NAME}' "
+                f"histogram data point(s). Found {len(data_points)} after {timeout}s."
+            )
+        return data_points
+
+    # EndpointErrorMetrics flows through a single OTel Counter:
+    #
+    #   - count (Sum, monotonic): per-endpoint, per-exception-type error count
+    #
+    # Dimensions: Telemetry.Source, service_name, environment, operation, exception.
+
+    _ERROR_COUNT_METRIC_NAME: str = "count"
+
+    def _peek_error_count_data_points(self) -> List:
+        """Return all data points for the `count` error Counter (non-blocking)."""
+        if self.mock_collector_client is None:
+            return []
+        # exact_match=False so we don't time out when other metrics aren't present yet.
+        try:
+            metrics = self.mock_collector_client.get_metrics({self._ERROR_COUNT_METRIC_NAME}, exact_match=False)
+        except RuntimeError:
+            return []
+        data_points: List = []
+        for rsm in metrics:
+            if rsm.metric.name != self._ERROR_COUNT_METRIC_NAME:
+                continue
+            if rsm.metric.WhichOneof("data") == "sum":
+                data_points.extend(rsm.metric.sum.data_points)
+        return data_points
+
+    def wait_for_error_count_metric(self, min_count: int = 1, timeout: Optional[float] = None) -> List:
+        """Poll until at least min_count data points appear in the `count` error Counter."""
+        if self.mock_collector_client is None:
+            self.fail("Mock collector not initialized — cannot poll OTLP metrics")
+        if timeout is None:
+            timeout = OTLP_POLL_TIMEOUT
+        start = time.time()
+        data_points: List = []
+        while time.time() - start < timeout:
+            data_points = self._peek_error_count_data_points()
+            if len(data_points) >= min_count:
+                return data_points
+            time.sleep(OTLP_POLL_INTERVAL)
+        if len(data_points) < min_count:
+            self.fail(
+                f"Timed out waiting for {min_count} '{self._ERROR_COUNT_METRIC_NAME}' "
+                f"Counter data point(s). Found {len(data_points)} after {timeout}s."
+            )
+        return data_points
+
+    @classmethod
+    def dp_attrs(cls, data_point) -> Dict[str, Any]:
+        """Return a metric data point's attributes as a flat {key: python_value} dict."""
+        return {kv.key: cls._any_value_to_python(kv.value) for kv in data_point.attributes}
+
+    @staticmethod
+    def dp_value(data_point) -> float:
+        """Return a NumberDataPoint's value, regardless of int/double oneof."""
+        if data_point.WhichOneof("value") == "as_int":
+            return data_point.as_int
+        return data_point.as_double
+
+    def assert_function_duration_data_point(self, data_point, **kwargs) -> None:
+        """Assert a `service.function.duration` data point has the expected attribute structure.
+
+        Note: ``exception.type`` is intentionally NOT a histogram dimension —
+        the only error signal on this metric is ``status="error"``. Exception
+        class names live on the IncidentSnapshot log signal so cardinality stays
+        bounded. Use ``status`` here, and assert the class on incident snapshot
+        logs (see ``assert_incident_snapshot``).
+        """
+        attrs = self.dp_attrs(data_point)
+        self.assertIn("function.name", attrs)
+        self.assertGreater(data_point.count, 0, "Expected histogram data point count > 0")
+
+        if "function_name" in kwargs:
+            self.assertEqual(attrs["function.name"], kwargs["function_name"])
+        if "status" in kwargs:
+            self.assertEqual(attrs.get("status"), kwargs["status"])
+        if "has_caller" in kwargs and kwargs["has_caller"]:
+            self.assertIn("aws.service_events.caller", attrs)
+
+    # -------------------------------------------------------------------------
+    # Request helper
+    # -------------------------------------------------------------------------
+
+    def send_request(self, method: str, path: str, **kwargs) -> Response:
+        address: str = self.application.get_container_host_ip()
+        port: str = self.application.get_exposed_port(self.get_application_port())
+        url: str = f"http://{address}:{port}/{path}"
+        return request(method, url, timeout=20, **kwargs)
+
+    # -------------------------------------------------------------------------
+    # Assertion helpers for OTLP LogRecords
+    # -------------------------------------------------------------------------
+
+    def assert_endpoint_summary(self, log, **kwargs) -> None:
+        """Assert an EndpointSummary OTLP log has expected attributes and body structure."""
+        attrs = self.attrs(log)
+        body = self.body(log)
+
+        self.assertEqual(attrs.get("event.name"), "aws.service_events.endpoint_summary")
+        self.assertIn("http.request.method", attrs)
+        self.assertIn("url.route", attrs)
+        self.assertIn("aws.service_events.operation", attrs)
+        self.assertIn("aws.service_events.request.count", attrs)
+        # incident.count is always emitted (0 when no incidents fired this window).
+        self.assertIn("aws.service_events.incident.count", attrs)
+        self.assertIsInstance(body, dict)
+        self.assertIn("duration", body)
+
+        if "method" in kwargs:
+            self.assertEqual(attrs["http.request.method"], kwargs["method"])
+        if "route" in kwargs:
+            self.assertEqual(attrs["url.route"], kwargs["route"])
+        if "operation" in kwargs:
+            self.assertEqual(attrs["aws.service_events.operation"], kwargs["operation"])
+        if "min_count" in kwargs:
+            self.assertGreaterEqual(attrs["aws.service_events.request.count"], kwargs["min_count"])
+        if "min_incident_count" in kwargs:
+            self.assertGreaterEqual(attrs["aws.service_events.incident.count"], kwargs["min_incident_count"])
+        if "has_faults" in kwargs and kwargs["has_faults"]:
+            self.assertGreater(attrs.get("aws.service_events.request.faults", 0), 0, "Expected faults > 0")
+        if "no_faults" in kwargs and kwargs["no_faults"]:
+            self.assertEqual(attrs.get("aws.service_events.request.faults", 0), 0, "Expected faults == 0")
+        if "has_errors" in kwargs and kwargs["has_errors"]:
+            self.assertGreater(attrs.get("aws.service_events.request.errors", 0), 0, "Expected errors > 0")
+        if "no_errors" in kwargs and kwargs["no_errors"]:
+            self.assertEqual(attrs.get("aws.service_events.request.errors", 0), 0, "Expected errors == 0")
+
+    def assert_vcs_and_deployment_attrs(self, log) -> None:
+        """Assert the VCS + deployment attributes set from env flow onto the OTLP signal.
+
+        These ride on EndpointSummary and IncidentSnapshot via the emitter's
+        _put_vcs_and_deployment_attrs(), sourced from the OTEL_AWS_SERVICE_EVENTS_*
+        env vars wired in setUp.
+        """
+        attrs = self.attrs(log)
+        self.assertEqual(attrs.get("vcs.ref.head.revision"), TEST_GIT_COMMIT_SHA)
+        self.assertEqual(attrs.get("vcs.repository.url.full"), TEST_GIT_REPO_URL)
+        self.assertEqual(attrs.get("aws.service_events.deployment.id"), TEST_DEPLOYMENT_ID)
+
+    def assert_incident_snapshot(self, log, **kwargs) -> None:
+        """Assert an IncidentSnapshot OTLP log has expected attributes and body."""
+        attrs = self.attrs(log)
+        body = self.body(log)
+
+        self.assertEqual(attrs.get("event.name"), "aws.service_events.incident_snapshot")
+        self.assertIn("aws.service_events.snapshot_id", attrs)
+        self.assertIn("aws.service_events.trigger_type", attrs)
+        self.assertIn("aws.service_events.operation", attrs)
+        self.assertIsInstance(body, dict)
+        self.assertIn("exception_info", body)
+
+        # Always-emitted snapshot attributes — assert their presence/contract so a
+        # regression that drops them is caught regardless of the per-test kwargs.
+        self.assertIn("aws.service_events.duration_ms", attrs)
+        self.assertIn("aws.service_events.is_partial", attrs)
+        self.assertEqual(attrs.get("aws.service_events.request.type"), "http")
+
+        if "trigger_type" in kwargs:
+            self.assertEqual(attrs["aws.service_events.trigger_type"], kwargs["trigger_type"])
+        if "operation" in kwargs:
+            self.assertEqual(attrs["aws.service_events.operation"], kwargs["operation"])
+        if "status_code" in kwargs:
+            # http.response.status_code is a top-level snapshot attribute, distinct
+            # from the body's request_context.status_code.
+            self.assertEqual(attrs.get("http.response.status_code"), kwargs["status_code"])
+        if "exception_type" in kwargs:
+            exc_info = body.get("exception_info", [])
+            self.assertTrue(len(exc_info) > 0, "Expected non-empty exception_info")
+            self.assertEqual(exc_info[0].get("exception_type"), kwargs["exception_type"])
+        if "has_call_path" in kwargs and kwargs["has_call_path"]:
+            exc_info = body.get("exception_info", [])
+            self.assertTrue(len(exc_info) > 0, "Expected non-empty exception_info")
+            call_path = exc_info[0].get("call_path", [])
+            self.assertTrue(len(call_path) > 0, "Expected non-empty call_path")
+
+    def assert_duration_structure(self, duration: Dict) -> None:
+        """Assert a duration histogram body has the expected shape."""
+        for key in ("Values", "Counts", "Max", "Min", "Count", "Sum"):
+            self.assertIn(key, duration)
+        self.assertGreater(duration["Count"], 0)
+        self.assertGreater(duration["Sum"], 0)
+
+    # -------------------------------------------------------------------------
+    # Overridable methods
+    # -------------------------------------------------------------------------
+
+    @staticmethod
+    def get_application_image_name() -> str:
+        raise NotImplementedError("Subclasses must implement get_application_image_name")
+
+    def get_application_port(self) -> int:
+        return 8080
+
+    def get_application_extra_environment_variables(self) -> Dict[str, str]:
+        return {}
+
+    def get_test_config_hook_overrides(self) -> Dict[str, str]:
+        """Internal test-config hook overrides (KEY -> value) injected via DEBUG_SE_TEST_CONFIG.
+
+        These knobs are internal (no public env var); black-box tests set them through the hook.
+        The base wires the fast flush cadence; subclasses extend (don't replace) for extra knobs
+        like SAMPLE_TIER1_THRESHOLD.
+        """
+        return {
+            "ENDPOINT_FLUSH_INTERVAL": SERVICE_EVENTS_FLUSH_INTERVAL_MS,
+            "INCIDENT_SNAPSHOT_FLUSH_INTERVAL": SERVICE_EVENTS_FLUSH_INTERVAL_MS,
+        }
+
+    def _build_test_config_hook_value(self) -> str:
+        """Serialize get_test_config_hook_overrides() into the delimited hook format."""
+        return ";".join(f"{key}={value}" for key, value in self.get_test_config_hook_overrides().items())
+
+    def get_application_wait_pattern(self) -> str:
+        return "Ready"
+
+    def get_application_otel_service_name(self) -> str:
+        return self.get_application_image_name()
+
+    def get_application_start_timeout(self) -> int:
+        return 30
+
+
+class ServiceEventsContractTestBase(ServiceEventsTestInfrastructure):
+    """Standard OTLP test suite inherited by all framework test classes."""
+
+    __test__ = False
+
+    def test_endpoint_summary_success(self) -> None:
+        for _ in range(3):
+            response = self.send_request("GET", "success")
+            self.assertEqual(200, response.status_code)
+
+        logs = self.wait_for_endpoint_summary("GET", "/success")
+        total_count = sum(self.attrs(log).get("aws.service_events.request.count", 0) for log in logs)
+        total_faults = sum(self.attrs(log).get("aws.service_events.request.faults", 0) for log in logs)
+        total_errors = sum(self.attrs(log).get("aws.service_events.request.errors", 0) for log in logs)
+        self.assertGreaterEqual(total_count, 3)
+        self.assertEqual(total_faults, 0)
+        self.assertEqual(total_errors, 0)
+        self.assert_endpoint_summary(logs[0], method="GET", route="/success", operation="GET /success")
+        # Verify resource attrs carry service.name and deployment.environment.name
+        resource_attrs = {
+            kv.key: self._any_value_to_python(kv.value) for kv in logs[0].resource_logs.resource.attributes
+        }
+        self.assertEqual(resource_attrs.get("service.name"), self.get_application_otel_service_name())
+        self.assertEqual(resource_attrs.get("deployment.environment.name"), "test")
+        # VCS + deployment metadata (from env) ride on the EndpointSummary attributes.
+        self.assert_vcs_and_deployment_attrs(logs[0])
+
+    def test_endpoint_summary_fault(self) -> None:
+        for _ in range(2):
+            response = self.send_request("GET", "fault")
+            self.assertEqual(500, response.status_code)
+
+        logs = self.wait_for_endpoint_summary("GET", "/fault")
+        total_faults = sum(self.attrs(log).get("aws.service_events.request.faults", 0) for log in logs)
+        self.assertGreater(total_faults, 0, "Expected faults > 0")
+
+    def test_endpoint_summary_duration(self) -> None:
+        self.send_request("GET", "success")
+
+        logs = self.wait_for_endpoint_summary("GET", "/success")
+        self.assert_duration_structure(self.body(logs[0])["duration"])
+
+    def test_function_call_records_exist(self) -> None:
+        """FunctionCall telemetry now flows through the service.function.duration histogram."""
+        for _ in range(3):
+            self.send_request("GET", "success")
+
+        data_points = self.wait_for_function_duration_metric()
+        self.assertGreater(len(data_points), 0)
+        for dp in data_points:
+            self.assert_function_duration_data_point(dp)
+
+        # At least one data point should carry the caller attribute (nested calls).
+        has_caller = any("aws.service_events.caller" in self.dp_attrs(dp) for dp in data_points)
+        self.assertTrue(has_caller, "Expected at least one data point with 'aws.service_events.caller'")
+
+    # NOTE: operation (e.g., "GET /success") is intentionally NOT a histogram
+    # attribute on `service.function.duration`. Tagging by operation × function ×
+    # status × exception.type would balloon attribute cardinality without bound.
+    # Operation→function correlation lives on the EndpointSummary log signal,
+    # asserted in test_endpoint_summary_basic_attributes via the
+    # `operation="GET /success"` kwarg.
+
+    def test_incident_snapshot_on_exception(self) -> None:
+        response = self.send_request("GET", "exception")
+        self.assertEqual(500, response.status_code)
+
+        logs = self.wait_for_otlp_logs("aws.service_events.incident_snapshot")
+        self.assertGreater(len(logs), 0)
+        self.assert_incident_snapshot(
+            logs[0],
+            trigger_type="exception",
+            exception_type="ValueError",
+            operation="GET /exception",
+            status_code=500,
+        )
+        # Verify trace context present (trace_id and span_id are bytes in OTLP proto).
+        self.assertTrue(any(logs[0].log_record.trace_id), "Expected non-zero trace_id")
+        self.assertTrue(any(logs[0].log_record.span_id), "Expected non-zero span_id")
+        # The OTLP proto LogRecord exposes the trace flags as `flags`; SAMPLED (1)
+        # is set when both trace_id and span_id are present.
+        self.assertEqual(logs[0].log_record.flags, 1, "Expected SAMPLED trace flags")
+        # VCS + deployment metadata (from env) also ride on IncidentSnapshot attributes.
+        self.assert_vcs_and_deployment_attrs(logs[0])
+        # Verify request_context body fields
+        body = self.body(logs[0])
+        req_ctx = body.get("request_context", {})
+        self.assertEqual(req_ctx.get("type"), "http")
+        self.assertEqual(req_ctx.get("status_code"), 500)
+
+    def test_endpoint_error_metrics_counter(self) -> None:
+        """`/exception` (500, ValueError) populates the EndpointErrorMetrics `count`
+        Counter with the per-exception-type breakdown, across every framework.
+
+        Unlike the EndpointSummary error fields, this is a distinct OTel Counter
+        (name=count, unit=Count) carrying the exception class as a dimension — which
+        EndpointSummary does not — so the backend can break errors down by exception
+        type. Only endpoints raising an exception (status>=400 with extracted
+        error_info) populate it; /error (400, no exception) does not. The exception
+        breakdown also surfaces in the EndpointSummary body's exception_breakdown.
+        """
+        for _ in range(3):
+            response = self.send_request("GET", "exception")
+            self.assertEqual(500, response.status_code)
+
+        data_points = self.wait_for_error_count_metric()
+        matching = [
+            dp
+            for dp in data_points
+            if self.dp_attrs(dp).get("operation") == "GET /exception"
+            and self.dp_attrs(dp).get("exception") == "ValueError"
+        ]
+        self.assertGreater(
+            len(matching),
+            0,
+            "Expected a `count` data point with operation='GET /exception' and exception='ValueError'",
+        )
+        dp = matching[0]
+        attrs = self.dp_attrs(dp)
+        self.assertEqual(attrs.get("Telemetry.Source"), "ServiceEvents")
+        self.assertGreaterEqual(self.dp_value(dp), 1, "Expected error count >= 1")
+
+        # The same per-exception-type breakdown surfaces in the EndpointSummary body.
+        summary_logs = self.wait_for_endpoint_summary("GET", "/exception")
+        breakdown = None
+        for log in summary_logs:
+            body = self.body(log)
+            if isinstance(body, dict) and body.get("exception_breakdown"):
+                breakdown = body["exception_breakdown"]
+                break
+        self.assertIsNotNone(breakdown, "Expected a non-empty exception_breakdown in the EndpointSummary body")
+        exception_types = {
+            exc.get("exception_type")
+            for entry in breakdown
+            for exc in entry.get("exceptions", [])
+            if isinstance(exc, dict)
+        }
+        self.assertIn("ValueError", exception_types)
+
+    def test_incident_snapshot_on_fault(self) -> None:
+        response = self.send_request("GET", "fault")
+        self.assertEqual(500, response.status_code)
+
+        logs = self.wait_for_otlp_logs("aws.service_events.incident_snapshot")
+        self.assertGreater(len(logs), 0)
+        self.assert_incident_snapshot(logs[0], trigger_type="exception", exception_type="RuntimeError")
+
+    def test_incident_snapshot_has_call_path(self) -> None:
+        self.send_request("GET", "exception")
+
+        logs = self.wait_for_otlp_logs("aws.service_events.incident_snapshot")
+        self.assertGreater(len(logs), 0)
+        self.assert_incident_snapshot(logs[0], has_call_path=True)
+
+    def test_deployment_event_exported(self) -> None:
+        self.send_request("GET", "success")
+
+        logs = self.wait_for_otlp_logs("aws.service_events.deployment_event")
+        self.assertGreaterEqual(len(logs), 1)
+        self.assertEqual(logs[0].scope_logs.scope.name, "serviceevents")
+        self.assertEqual(logs[0].scope_logs.scope.version, "1.0")
+        # The collector stamps a trigger on every emit; the first (startup) emit is
+        # always present, and any later emits are "periodic". Assert the contract.
+        triggers = [self.attrs(log).get("aws.service_events.deployment.trigger") for log in logs]
+        for trigger in triggers:
+            self.assertIn(trigger, ("startup", "periodic", "shutdown"))
+        self.assertIn("startup", triggers, "Expected the first DeploymentEvent to carry trigger='startup'")
+
+        # DeploymentContext (from OTEL_AWS_SERVICE_EVENTS_* env) rides on this signal.
+        # deployment.url / deployment.timestamp are emitted ONLY here, so assert them.
+        attrs = self.attrs(logs[0])
+        self.assertEqual(attrs.get("aws.service_events.deployment.id"), TEST_DEPLOYMENT_ID)
+        self.assertEqual(attrs.get("vcs.ref.head.revision"), TEST_GIT_COMMIT_SHA)
+        self.assertEqual(attrs.get("vcs.repository.url.full"), TEST_GIT_REPO_URL)
+        self.assertEqual(attrs.get("aws.service_events.deployment.url"), TEST_DEPLOYMENT_URL)
+        self.assertEqual(attrs.get("aws.service_events.deployment.timestamp"), TEST_DEPLOYMENT_TIMESTAMP)
+
+    def test_all_telemetry_types_present(self) -> None:
+        self.send_request("GET", "success")
+        self.send_request("GET", "exception")
+
+        # FunctionCall is now a histogram metric, not an OTLP log.
+        self.wait_for_function_duration_metric()
+        self.wait_for_otlp_logs("aws.service_events.endpoint_summary")
+        self.wait_for_otlp_logs("aws.service_events.incident_snapshot")
+        self.wait_for_otlp_logs("aws.service_events.deployment_event")


### PR DESCRIPTION
## Description of changes

This PR adds the **ServiceEvents** feature to the ADOT Python distro: a set of
higher-level telemetry signals derived from function-level and HTTP endpoint
activity, emitted via OTLP.

ServiceEvents is **opt-in and bundled-gated behind Application Signals**
(`OTEL_AWS_SERVICE_EVENTS_ENABLED` / `OTEL_AWS_APPLICATION_SIGNALS_ENABLED`); it
is disabled in AWS Lambda.

## Summary

When active, ServiceEvents emits function-call duration metrics, HTTP endpoint
summaries, per-exception error counts, deployment events, and incident snapshots.
Function-level instrumentation is scoped by an explicit allowlist, and endpoint
tracking is wired through framework middleware for Flask, FastAPI, and Django.

## What's included

- ServiceEvents package and configurator wiring to initialize it when enabled.
- Unit tests for the package.
- Contract tests with sample apps and mock-collector infrastructure.

## Testing

- Unit and contract test suites pass.
- `tox -e lint` and `tox -e spellcheck` pass.

By submitting this pull request, I confirm that my contribution is made under