### PR TITLE
ci(claude-review): dedupe findings across pushes and reduce noise

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   claude-review:
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ !github.event.pull_request.draft && !contains(github.event.pull_request.title, '[skip-claude]') }}
     timeout-minutes: 30
     runs-on: ubuntu-latest
     permissions:
@@ -43,7 +43,32 @@ jobs:
         with:
           use_bedrock: "true"
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          use_sticky_comment: "true"
+          track_progress: "true"
           claude_args: |
             --model us.anthropic.claude-opus-4-6-v1 --allowedTools "Bash(gh pr diff ${{ github.event.pull_request.number }}),Bash(gh pr diff ${{ github.event.pull_request.number }} *),Bash(gh pr view ${{ github.event.pull_request.number }}),Bash(gh pr view ${{ github.event.pull_request.number }} *),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews*)"
           prompt: |
-            Review PR #${{ github.event.pull_request.number }} in this repository for bugs, security issues, and code quality. Post your findings as inline review comments on the relevant lines of this PR only. Do not modify, comment on, or interact with any other PR.
+            You are reviewing PR #${{ github.event.pull_request.number }} in ${{ github.repository }}.
+
+            STEP 1 — Read prior bot reviews FIRST, before looking at the diff:
+              gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews
+              gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments
+
+            Identify your prior comments (author login matches "claude" or contains "github-actions"). Note the most recent review's commit_id and the (path, line, body) of every existing comment you have already posted.
+
+            STEP 2 — Scope what is new:
+              gh pr view ${{ github.event.pull_request.number }} --json commits
+            Determine which commits landed AFTER your most recent review's commit_id. If there are no new commits and no unaddressed prior findings warrant a follow-up, post nothing and exit.
+
+            STEP 3 — Review only the changes since your last review:
+              gh pr diff ${{ github.event.pull_request.number }}
+            Focus your attention on lines touched by commits newer than your last review's commit_id. On the very first review of this PR, review the full diff.
+
+            STEP 4 — Dedupe before posting. For each candidate finding:
+              - If a prior comment already exists at the same (file, line) raising the same underlying issue, skip it — even if your wording would differ.
+              - If a prior finding is still applicable but unaddressed, do not re-post; the original comment is still on the line.
+              - Only post genuinely new findings.
+
+            STEP 5 — Post findings as inline review comments on this PR only.
+
+            Bias toward silence: posting nothing is the correct outcome when no new substantive issues exist. Do not modify, comment on, or interact with any other PR.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -46,7 +46,7 @@ jobs:
           use_sticky_comment: "true"
           track_progress: "true"
           claude_args: |
-            --model us.anthropic.claude-opus-4-6-v1 --allowedTools "Bash(gh pr diff ${{ github.event.pull_request.number }}),Bash(gh pr diff ${{ github.event.pull_request.number }} *),Bash(gh pr view ${{ github.event.pull_request.number }}),Bash(gh pr view ${{ github.event.pull_request.number }} *),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews*)"
+            --model us.anthropic.claude-opus-4-6-v1 --allowedTools "Read,Glob,Grep,Bash(gh pr diff ${{ github.event.pull_request.number }}),Bash(gh pr diff ${{ github.event.pull_request.number }} *),Bash(gh pr view ${{ github.event.pull_request.number }}),Bash(gh pr view ${{ github.event.pull_request.number }} *),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files*),Bash(gh api repos/${{ github.repository }}/contents/*)"
           prompt: |
             You are reviewing PR #${{ github.event.pull_request.number }} in ${{ github.repository }} for bugs, security issues, and code quality.
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -48,7 +48,7 @@ jobs:
           claude_args: |
             --model us.anthropic.claude-opus-4-6-v1 --allowedTools "Bash(gh pr diff ${{ github.event.pull_request.number }}),Bash(gh pr diff ${{ github.event.pull_request.number }} *),Bash(gh pr view ${{ github.event.pull_request.number }}),Bash(gh pr view ${{ github.event.pull_request.number }} *),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews*)"
           prompt: |
-            You are reviewing PR #${{ github.event.pull_request.number }} in ${{ github.repository }}.
+            You are reviewing PR #${{ github.event.pull_request.number }} in ${{ github.repository }} for bugs, security issues, and code quality.
 
             STEP 1 — Read prior bot reviews FIRST, before looking at the diff:
               gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -50,25 +50,23 @@ jobs:
           prompt: |
             You are reviewing PR #${{ github.event.pull_request.number }} in ${{ github.repository }} for bugs, security issues, and code quality.
 
-            STEP 1 — Read prior bot reviews FIRST, before looking at the diff:
-              gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews
+            SELF-IDENTIFICATION: every inline comment you post MUST end with this exact hidden HTML marker on its own line so future runs can reliably identify your prior reviews:
+              <!-- claude-code-review:v1 -->
+
+            STEP 1 — Read prior reviews FIRST, before looking at the diff:
               gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments
+              gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews
 
-            Identify your prior comments (author login matches "claude" or contains "github-actions"). Note the most recent review's commit_id and the (path, line, body) of every existing comment you have already posted.
+            Identify YOUR prior comments by matching the marker `<!-- claude-code-review:v1 -->` in the body. Do NOT match on author login (github-actions[bot] is shared by many workflows — linting, coverage, etc. — and matching by login causes false dedup). Build a set of your prior (path, line, finding) tuples.
 
-            STEP 2 — Scope what is new:
-              gh pr view ${{ github.event.pull_request.number }} --json commits
-            Determine which commits landed AFTER your most recent review's commit_id. If there are no new commits and no unaddressed prior findings warrant a follow-up, post nothing and exit.
-
-            STEP 3 — Review only the changes since your last review:
+            STEP 2 — Review the full PR diff:
               gh pr diff ${{ github.event.pull_request.number }}
-            Focus your attention on lines touched by commits newer than your last review's commit_id. On the very first review of this PR, review the full diff.
 
-            STEP 4 — Dedupe before posting. For each candidate finding:
-              - If a prior comment already exists at the same (file, line) raising the same underlying issue, skip it — even if your wording would differ.
+            STEP 3 — Dedupe before posting. For each candidate finding:
+              - If you have a prior comment at the same (path, line) raising the same underlying issue, skip it — even if your wording would differ.
               - If a prior finding is still applicable but unaddressed, do not re-post; the original comment is still on the line.
               - Only post genuinely new findings.
 
-            STEP 5 — Post your findings as inline review comments on the relevant lines of this PR only.
+            STEP 4 — Post your findings as inline review comments on the relevant lines of this PR only. Append the `<!-- claude-code-review:v1 -->` marker to every comment body.
 
             Bias toward silence: posting nothing is the correct outcome when no new substantive issues exist. Do not modify, comment on, or interact with any other PR.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -48,7 +48,16 @@ jobs:
           claude_args: |
             --model us.anthropic.claude-opus-4-6-v1 --allowedTools "Read,Glob,Grep,Bash(gh pr diff ${{ github.event.pull_request.number }}),Bash(gh pr diff ${{ github.event.pull_request.number }} *),Bash(gh pr view ${{ github.event.pull_request.number }}),Bash(gh pr view ${{ github.event.pull_request.number }} *),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files*),Bash(gh api repos/${{ github.repository }}/contents/*)"
           prompt: |
-            You are reviewing PR #${{ github.event.pull_request.number }} in ${{ github.repository }} for bugs, security issues, and code quality.
+            You are reviewing PR #${{ github.event.pull_request.number }} in ${{ github.repository }}.
+
+            Review for:
+              1. Code quality — clean code, error handling, edge cases, readability and maintainability
+              2. Security — input validation, credential handling, injection risks, auth/authz logic
+              3. Performance — bottlenecks, inefficient queries, memory issues, resource leaks
+              4. Testing — coverage of new code, edge cases, error paths
+              5. Documentation — code comments where the WHY is non-obvious; README/API doc accuracy
+
+            Use the repository's CLAUDE.md (if present) for guidance on style and conventions.
 
             SELF-IDENTIFICATION: every inline comment you post MUST end with this exact hidden HTML marker on its own line so future runs can reliably identify your prior reviews:
               <!-- claude-code-review:v1 -->
@@ -67,6 +76,10 @@ jobs:
               - If a prior finding is still applicable but unaddressed, do not re-post; the original comment is still on the line.
               - Only post genuinely new findings.
 
-            STEP 4 — Post your findings as inline review comments on the relevant lines of this PR only. Append the `<!-- claude-code-review:v1 -->` marker to every comment body.
+            STEP 4 — Post findings as comments on this PR only:
+              - Use inline comments for line-specific issues.
+              - Use one top-level summary comment for general observations or praise (optional).
+              - Append the `<!-- claude-code-review:v1 -->` marker to every comment body.
+              - Be concise and actionable.
 
             Bias toward silence: posting nothing is the correct outcome when no new substantive issues exist. Do not modify, comment on, or interact with any other PR.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -69,6 +69,6 @@ jobs:
               - If a prior finding is still applicable but unaddressed, do not re-post; the original comment is still on the line.
               - Only post genuinely new findings.
 
-            STEP 5 — Post findings as inline review comments on this PR only.
+            STEP 5 — Post your findings as inline review comments on the relevant lines of this PR only.
 
             Bias toward silence: posting nothing is the correct outcome when no new substantive issues exist. Do not modify, comment on, or interact with any other PR.


### PR DESCRIPTION
## Summary

The Claude Code Review bot currently re-reviews the entire PR diff on every push and re-posts duplicate findings. This PR updates [.github/workflows/claude-code-review.yml](.github/workflows/claude-code-review.yml) to dedupe across runs and reduce reviewer noise.

**Prompt-level changes:**
- Self-identify with hidden HTML marker `<!-- claude-code-review:v1 -->` on every comment so future runs reliably recognize prior reviews (avoids false-dedup against unrelated bots posting under `github-actions[bot]`)
- Step 1: Bot reads prior comments via `gh api .../comments` and `.../reviews` **before** looking at the diff
- Step 2: Reviews the full PR diff
- Step 3: Dedupes candidates by `(path, line, underlying issue)` against existing comments — even when wording would differ
- Step 4: Bias toward silence — explicit "post nothing and exit" path when no new findings exist
- Expanded review criteria to the 5-area checklist used by `anthropics/claude-code-action`'s `pr-review-comprehensive.yml` template (Quality / Security / Performance / Testing / Documentation)
- References the repo's CLAUDE.md for style/convention guidance
- Output format guidance: inline for line-specific, optional top-level summary, concise and actionable

**Action-level changes** (built-in noise controls in `anthropics/claude-code-action`):
- `use_sticky_comment: "true"` — collapses the top-level summary into a single comment that is overwritten on subsequent runs instead of appending
- `track_progress: "true"` — single checkbox tracking comment for visibility
- `[skip-claude]` PR title token — adds a per-PR opt-out via the `if:` guard

**Permission changes** (all read-only, scoped to this repo's API surface):
- `Read`, `Glob`, `Grep` for filesystem inspection of the base branch
- `gh api .../pulls/<N>/commits` and `/files` for cleaner change scoping
- `gh api .../contents/*` to read files at any ref (PR head versions)

## Test plan

- [ ] Open a test PR and confirm the bot posts a single review on `opened` with the hidden marker appended to each comment
- [ ] Push a follow-up commit that does NOT change a previously-flagged line; confirm the bot posts no duplicate comment
- [ ] Push a follow-up commit that introduces a new issue; confirm the bot posts only the new finding
- [ ] Push a no-op commit (e.g., comment-only) and confirm the bot exits silently
- [ ] Open a PR with `[skip-claude]` in the title and confirm the workflow is skipped
- [ ] Confirm the summary comment is overwritten (not appended) across pushes