### PR TITLE
fix(debugger): populate service.name on DI snapshot OTLP exports

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/debugger/_snapshot_otlp_emitter.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/debugger/_snapshot_otlp_emitter.py
@@ -76,7 +76,7 @@ class SnapshotOtlpEmitter:
 
             try:
                 exporter = OTLPLogExporter(endpoint=self._logs_endpoint)
-                resource = self._resource if self._resource else Resource.get_empty()
+                resource = self._resource if self._resource else Resource.create()
 
                 self._logger_provider = LoggerProvider(resource=resource)
                 self._logger_provider.add_log_record_processor(BatchLogRecordProcessor(exporter))

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_snapshot_otlp_emitter_extra.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_snapshot_otlp_emitter_extra.py
@@ -108,6 +108,41 @@ class TestEnsureInitialized(unittest.TestCase):
         self.assertTrue(emitter._ensure_initialized())
         self.assertEqual(emitter._logger_provider.resource.attributes.get("service.name"), "explicit-service")
 
+    @mock.patch.dict(
+        os.environ,
+        {
+            "OTEL_SERVICE_NAME": "env-service",
+            "OTEL_RESOURCE_ATTRIBUTES": "deployment.environment.name=ec2:my-asg,custom.tag=hello",
+        },
+    )
+    @mock.patch.object(emitter_module, "BatchLogRecordProcessor")
+    @mock.patch.object(emitter_module, "OTLPLogExporter")
+    def test_default_resource_merges_otel_resource_attributes_env(self, _mock_exporter, _mock_processor):
+        # Regression: OTEL_RESOURCE_ATTRIBUTES values must reach the OTLP-exported
+        # resource alongside OTEL_SERVICE_NAME. Resource.get_empty() bypassed both.
+        emitter = SnapshotOtlpEmitter()
+        self.assertTrue(emitter._ensure_initialized())
+        attrs = emitter._logger_provider.resource.attributes
+        self.assertEqual(attrs.get("service.name"), "env-service")
+        self.assertEqual(attrs.get("deployment.environment.name"), "ec2:my-asg")
+        self.assertEqual(attrs.get("custom.tag"), "hello")
+
+    @mock.patch.dict(
+        os.environ,
+        {
+            "OTEL_SERVICE_NAME": "explicit-wins",
+            "OTEL_RESOURCE_ATTRIBUTES": "service.name=from-env-attrs",
+        },
+    )
+    @mock.patch.object(emitter_module, "BatchLogRecordProcessor")
+    @mock.patch.object(emitter_module, "OTLPLogExporter")
+    def test_otel_service_name_takes_precedence_over_resource_attributes(self, _mock_exporter, _mock_processor):
+        # OTEL_SERVICE_NAME wins over service.name in OTEL_RESOURCE_ATTRIBUTES,
+        # per the OTel resource spec. Confirm we don't accidentally invert that.
+        emitter = SnapshotOtlpEmitter()
+        self.assertTrue(emitter._ensure_initialized())
+        self.assertEqual(emitter._logger_provider.resource.attributes.get("service.name"), "explicit-wins")
+
 
 class TestShutdownAndReset(unittest.TestCase):
     """Tests for shutdown and reset lifecycle."""

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_snapshot_otlp_emitter_extra.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_snapshot_otlp_emitter_extra.py
@@ -88,6 +88,26 @@ class TestEnsureInitialized(unittest.TestCase):
         emitter._init_failed = True
         self.assertFalse(emitter._ensure_initialized())
 
+    @mock.patch.dict(os.environ, {"OTEL_SERVICE_NAME": "my-service"})
+    @mock.patch.object(emitter_module, "BatchLogRecordProcessor")
+    @mock.patch.object(emitter_module, "OTLPLogExporter")
+    def test_default_resource_picks_up_service_name_from_env(self, _mock_exporter, _mock_processor):
+        # Regression: default resource must run OTel detectors so OTEL_SERVICE_NAME
+        # propagates onto OTLP-exported LogRecords. Resource.get_empty() skipped them.
+        emitter = SnapshotOtlpEmitter()
+        self.assertTrue(emitter._ensure_initialized())
+        self.assertEqual(emitter._logger_provider.resource.attributes.get("service.name"), "my-service")
+
+    @mock.patch.object(emitter_module, "BatchLogRecordProcessor")
+    @mock.patch.object(emitter_module, "OTLPLogExporter")
+    def test_explicit_resource_is_preserved(self, _mock_exporter, _mock_processor):
+        from opentelemetry.sdk.resources import Resource
+
+        explicit = Resource.create({"service.name": "explicit-service"})
+        emitter = SnapshotOtlpEmitter(resource=explicit)
+        self.assertTrue(emitter._ensure_initialized())
+        self.assertEqual(emitter._logger_provider.resource.attributes.get("service.name"), "explicit-service")
+
 
 class TestShutdownAndReset(unittest.TestCase):
     """Tests for shutdown and reset lifecycle."""


### PR DESCRIPTION
## Bug

`SnapshotOtlpEmitter` (added in #761) builds its default `LoggerProvider` with `Resource.get_empty()`, which skips the OTel SDK detector chain. `OTEL_SERVICE_NAME` and `OTEL_RESOURCE_ATTRIBUTES` are never read, so DI snapshot LogRecords ship with no `service.name`. The CW Agent transform then routes them to `/aws/service-events/unknown_service` instead of the customer's log group.

Other DI paths (status reporter, snapshot body) read `OTEL_SERVICE_NAME` directly via `os.environ.get(...)`, so only the OTLP resource path was broken.

## Fix

[_snapshot_otlp_emitter.py:79](aws-opentelemetry-distro/src/amazon/opentelemetry/distro/debugger/_snapshot_otlp_emitter.py#L79)

```diff
-resource = self._resource if self._resource else Resource.get_empty()
+resource = self._resource if self._resource else Resource.create()
```

`Resource.create()` runs the standard detector chain (`OTELResourceDetector`, ...) which reads `OTEL_SERVICE_NAME` and `OTEL_RESOURCE_ATTRIBUTES`. Explicit resources passed by callers are still preserved.

## Tests

Three regression tests in `test_snapshot_otlp_emitter_extra.py`, all verified to fail on `Resource.get_empty()` and pass on `Resource.create()`:
- `OTEL_SERVICE_NAME` lands on the resource
- `OTEL_RESOURCE_ATTRIBUTES` keys merge in alongside it
- `OTEL_SERVICE_NAME` wins over `service.name=...` inside `OTEL_RESOURCE_ATTRIBUTES`

Plus one test confirming an explicit `Resource` passed to the constructor is preserved unchanged.

## Validated end-to-end

EC2 soak with `OTEL_SERVICE_NAME=python-ec2-di-main-service`: snapshots route to `/aws/service-events/python-ec2-di-main-service` and are queryable by `aws.di.location_hash`.