### PR TITLE
ci(claude-review): use runtime API for author check

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,18 +9,54 @@ on:
     # paths:
     #   - "**/*.py"
     #   - "**/*.pyi"
+  # TEMP: pull_request trigger added to validate the runtime-API gate on PR 767's own
+  # checks. Remove this trigger before merging — the pull_request event runs the
+  # workflow file from the PR head (untrusted), which is unsafe in steady state.
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
 
 concurrency:
   group: claude-review-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
-  claude-review:
+  # Gate via runtime API call rather than the webhook's author_association field.
+  # Reason: when org membership visibility is set to PRIVATE (the default for
+  # aws-observability), the webhook delivers author_association=NONE even for
+  # actual MEMBER users, causing the legacy gate to skip every fork PR from the
+  # team. The REST API returns the correct permission regardless of visibility.
+  check-author:
     if: >-
       !github.event.pull_request.draft &&
-      !contains(github.event.pull_request.title, '[skip-claude]') &&
-      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
-               github.event.pull_request.author_association)
+      !contains(github.event.pull_request.title, '[skip-claude]')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      is_trusted: ${{ steps.check.outputs.is_trusted }}
+    steps:
+      - id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const author = context.payload.pull_request.user.login;
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: author,
+              });
+              const trusted = ['admin', 'maintain', 'write'].includes(data.permission);
+              core.info(`User ${author}: permission=${data.permission}, trusted=${trusted}`);
+              core.setOutput('is_trusted', trusted ? 'true' : 'false');
+            } catch (e) {
+              core.warning(`Failed to check permission for ${author}: ${e.message}`);
+              core.setOutput('is_trusted', 'false');
+            }
+
+  claude-review:
+    needs: check-author
+    if: needs.check-author.outputs.is_trusted == 'true'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -26,7 +26,7 @@ jobs:
       is_trusted: ${{ steps.check.outputs.is_trusted }}
     steps:
       - id: check
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           script: |
             const author = context.payload.pull_request.user.login;

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,11 +15,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Gate via runtime API call rather than the webhook's author_association field.
-  # Reason: when org membership visibility is set to PRIVATE (the default for
-  # aws-observability), the webhook delivers author_association=NONE even for
-  # actual MEMBER users, causing the legacy gate to skip every fork PR from the
-  # team. The REST API returns the correct permission regardless of visibility.
   check-author:
     if: >-
       !github.event.pull_request.draft &&

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,11 +9,6 @@ on:
     # paths:
     #   - "**/*.py"
     #   - "**/*.pyi"
-  # TEMP: pull_request trigger added to validate the runtime-API gate on PR 767's own
-  # checks. Remove this trigger before merging — the pull_request event runs the
-  # workflow file from the PR head (untrusted), which is unsafe in steady state.
-  pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
 
 concurrency:
   group: claude-review-${{ github.event.pull_request.number }}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This project is a redistribution of the [OpenTelemetry Distro for Python](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-distro),
 preconfigured for use with AWS services. Please check out that project too to get a better
 understanding of the underlying internals. You won't see much code in this repository since we only
-apply some small configuration changes, and our OpenTelemetry friends takes care of the rest. The 
+apply some small configuration changes, and our OpenTelemetry friends take care of the rest. The 
 exception to this is support for Application Signals.
 
 We provided a Python agent that can be attached to any application using a supported Python version and dynamically injects

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This project is a redistribution of the [OpenTelemetry Distro for Python](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-distro),
 preconfigured for use with AWS services. Please check out that project too to get a better
 understanding of the underlying internals. You won't see much code in this repository since we only
-apply some small configuration changes, and our OpenTelemetry friends take care of the rest. The 
+apply some small configuration changes, and our OpenTelemetry friends takes care of the rest. The 
 exception to this is support for Application Signals.
 
 We provided a Python agent that can be attached to any application using a supported Python version and dynamically injects


### PR DESCRIPTION
## Summary

The webhook's `pull_request.author_association` returns `NONE` for org members with **private** membership visibility (the default for `aws-observability`), so the existing gate skips every fork PR from MEMBER users. Replace it with a runtime API call to `repos/.../collaborators/{user}/permission`.

## Test

The new gate evaluation was validated on this PR's earlier `pull_request` test runs — `check-author` correctly identified `liustve` as `admin` and proceeded. Once merged, subsequent pushes will run under production `pull_request_target` conditions.