### PR TITLE
fix(debugger): make InstrumentationName optional for PROBE

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/debugger/_data_models.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/debugger/_data_models.py
@@ -178,7 +178,7 @@ class BreakpointConfiguration:
         capture_config: Configuration for data capture
         config_id: Unique identifier from API
         instrumentation_type: Type of instrumentation ("PROBE" or "BREAKPOINT")
-        instrumentation_name: Name for permanent instrumentations (required for PROBE)
+        instrumentation_name: Optional name for the instrumentation (defaults to "" if absent)
         expires_at: Optional expiration timestamp (ignored for PROBE)
         max_hits: Maximum hits before breakpoint is disabled (ignored for PROBE)
         attribute_filters: List of attribute filter objects
@@ -190,7 +190,7 @@ class BreakpointConfiguration:
     capture_config: CaptureConfig
     config_id: str
     instrumentation_type: str = "BREAKPOINT"  # "PROBE" or "BREAKPOINT"
-    instrumentation_name: Optional[str] = None  # Required for PROBE
+    instrumentation_name: Optional[str] = None
     expires_at: Optional[datetime] = None
     max_hits: int = DEFAULT_MAX_HITS
     attribute_filters: List[Dict[str, Any]] = field(default_factory=list)
@@ -363,13 +363,7 @@ class BreakpointConfiguration:
                 )
                 instrumentation_type = "BREAKPOINT"
 
-            # Parse instrumentation name (required for PROBE)
-            instrumentation_name = breakpoint_config.get("InstrumentationName")
-            if instrumentation_type == "PROBE" and not instrumentation_name:
-                logger.warning(
-                    "PROBE instrumentation for %s.%s missing InstrumentationName. Skipping.", module, function
-                )
-                return None
+            instrumentation_name = breakpoint_config.get("InstrumentationName") or ""
 
             # Parse line number safely - 0 or missing means function-level only, >0 means line-level
             # For PROBE: Always force line_number to 0 (function-level only)

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_data_models_branches.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_data_models_branches.py
@@ -122,15 +122,17 @@ class TestFromApiConfigInvalidInstrumentationType(unittest.TestCase):
 
 
 class TestFromApiConfigProbeRules(unittest.TestCase):
-    """Covers PROBE-specific branches: missing name (354-357), ExpiresAt ignored (456), MaxHits ignored (483)."""
+    """Covers PROBE-specific branches: optional name, ExpiresAt ignored, MaxHits ignored."""
 
-    def test_probe_missing_instrumentation_name_returns_none(self):
+    def test_probe_missing_instrumentation_name_defaults_to_empty(self):
         api_config = {
             "Location": _location(line_number=0),
             "InstrumentationType": "PROBE",
             "LocationHash": "h",
         }
-        self.assertIsNone(BreakpointConfiguration.from_api_config(api_config))
+        config = BreakpointConfiguration.from_api_config(api_config)
+        self.assertIsNotNone(config)
+        self.assertEqual(config.instrumentation_name, "")
 
     def test_probe_ignores_expires_at_and_max_hits(self):
         api_config = {


### PR DESCRIPTION
## Summary
- Match ADOT Java behavior: PROBE configs without `InstrumentationName` are no longer rejected. The field now defaults to `""` when absent, mirroring [`InstrumentationConfiguration.fromApiConfig` in aws-otel-java-instrumentation](https://github.com/aws-observability/aws-otel-java-instrumentation/blob/main/awsagentprovider/src/main/java/software/amazon/opentelemetry/javaagent/providers/dynamicInstrumentation/model/InstrumentationConfiguration.java) (`if (instrName == null) { instrName = ""; }`).
- Updates the PROBE branch test to assert the new default-to-empty behavior.

## Test plan
- [x] `pytest tests/amazon/opentelemetry/distro/debugger/` — 526 passed, 25 skipped