### PR TITLE
feat(agent-observability): add AWS_AGENTIC_INSTRUMENTATION env var as auto-detection escape hatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 ## Unreleased
 
 - feat(agent-observability): add `AWS_AGENTIC_INSTRUMENTATION` (`auto`/`enabled`/`disabled`, case-insensitive) as an escape hatch over auto-detection when `AGENT_OBSERVABILITY_ENABLED=true`; the switch only governs AWS native instrumentors and never disables third-party ones
+  ([#769](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/769))
 - fix(otlp-aws-exporter): avoid `RecursionError` when `pip_system_certs` replaces `ssl.SSLContext` (truststore injection) by rebinding stale `botocore`/`urllib3` SSL context references and caching credentials in `AwsAuthSession`
 - feat: add opt-in Dynamic Instrumentation (runtime breakpoints/probes) gated by `OTEL_AWS_DYNAMIC_INSTRUMENTATION_ENABLED` (default off)
   ([#761](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/761))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- feat(agent-observability): add `AWS_AGENTIC_INSTRUMENTATION` (`auto`/`enabled`/`disabled`, case-insensitive) as an escape hatch over auto-detection when `AGENT_OBSERVABILITY_ENABLED=true`; the switch only governs AWS native instrumentors and never disables third-party ones
 - fix(otlp-aws-exporter): avoid `RecursionError` when `pip_system_certs` replaces `ssl.SSLContext` (truststore injection) by rebinding stale `botocore`/`urllib3` SSL context references and caching credentials in `AwsAuthSession`
 - feat: add opt-in Dynamic Instrumentation (runtime breakpoints/probes) gated by `OTEL_AWS_DYNAMIC_INSTRUMENTATION_ENABLED` (default off)
   ([#761](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/761))

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
@@ -109,9 +109,14 @@ _logger: Logger = getLogger(__name__)
 _load._logger.setLevel(LEVELS.get(os.environ.get(OTEL_PYTHON_LOG_LEVEL, "error").lower(), ERROR))
 
 
-# When set to "true", opt in to AWS agentic instrumentors over third-party ones (e.g. OpenInference),
-# even if both are installed. By default, auto-detection prefers third-party when present.
-AWS_AGENTIC_INSTRUMENTATION_OPT_IN = "AWS_AGENTIC_INSTRUMENTATION_OPT_IN"
+# Controls AWS native agentic instrumentors when AGENT_OBSERVABILITY_ENABLED=true.
+# This switch only governs the aws_* side; third-party instrumentors are never disabled
+# by ADOT — uninstall them or use OTEL_PYTHON_DISABLED_INSTRUMENTATIONS to opt out.
+# Values:
+#   "auto" (default, also when unset): load aws_* unless a same-library third-party is registered.
+#   "enabled" : load all aws_* unconditionally.
+#   "disabled": skip all aws_*.
+AWS_AGENTIC_INSTRUMENTATION = "AWS_AGENTIC_INSTRUMENTATION"
 
 # Maps third-party instrumentor entry point names to their AWS native equivalents.
 # Used for mutual exclusion: only one side instruments each library at a time.
@@ -253,14 +258,13 @@ class AwsOpenTelemetryDistro(OpenTelemetryDistro):
             _logger.debug("Debugger initialization skipped: %s", exception)
 
     def load_instrumentor(self, entry_point: EntryPoint, **kwargs):
-        """Mutual exclusion between AWS native and third-party agentic instrumentors.
+        """Skip AWS native agentic instrumentors that should not load.
 
         When agent observability is enabled:
         - Skip ADOT-owned dists that duplicate an aws_* entry point (e.g. openai-agents-v2).
-        - Auto-detect: if a third-party instrumentor is registered for the same library,
-          skip the AWS native one. If not, skip the third-party one.
-        - AWS_AGENTIC_INSTRUMENTATION_OPT_IN=true overrides auto-detection and forces
-          AWS native instrumentors, skipping third-party ones.
+        - AWS_AGENTIC_INSTRUMENTATION (auto/enabled/disabled) governs the aws_* side only.
+          See the constant docstring for semantics. Third-party instrumentors are never
+          touched here.
         """
         if is_agent_observability_enabled() and self._should_skip_instrumentor(entry_point):
             return
@@ -271,21 +275,33 @@ class AwsOpenTelemetryDistro(OpenTelemetryDistro):
         if entry_point.dist and entry_point.dist.name in _ADOT_OWNED_DISTS:
             return True
 
-        prefer_native = os.environ.get(AWS_AGENTIC_INSTRUMENTATION_OPT_IN, "false").lower() == "true"
+        is_native = entry_point.name in _THIRDPARTY_TO_AWS_NATIVE.values()
+        if not is_native:
+            return False
+
+        mode = os.environ.get(AWS_AGENTIC_INSTRUMENTATION, "auto").lower()
+        if mode not in ("auto", "enabled", "disabled"):
+            _logger.warning(
+                "Unknown %s=%r — falling back to 'auto'. Valid values: auto, enabled, disabled.",
+                AWS_AGENTIC_INSTRUMENTATION,
+                mode,
+            )
+            mode = "auto"
+
+        if mode == "enabled":
+            return False
+        if mode == "disabled":
+            _logger.debug("Skipping %s: AWS_AGENTIC_INSTRUMENTATION=disabled", entry_point.name)
+            return True
+
+        # mode == "auto": skip the native side if a same-library third-party is registered.
         third_party_names = {
             ep.name
             for ep in entry_points(group="opentelemetry_instrumentor")
             if not (ep.dist and ep.dist.name in _ADOT_OWNED_DISTS)
         }
-
-        if entry_point.name in _THIRDPARTY_TO_AWS_NATIVE.values() and not prefer_native:
-            for tp_name, aws_name in _THIRDPARTY_TO_AWS_NATIVE.items():
-                if entry_point.name == aws_name and tp_name in third_party_names:
-                    _logger.debug("Skipping %s: third-party %s is registered", aws_name, tp_name)
-                    return True
-
-        if entry_point.name in _THIRDPARTY_TO_AWS_NATIVE and prefer_native:
-            _logger.debug("Skipping third-party %s: AWS native preferred", entry_point.name)
-            return True
-
+        for tp_name, aws_name in _THIRDPARTY_TO_AWS_NATIVE.items():
+            if entry_point.name == aws_name and tp_name in third_party_names:
+                _logger.debug("Skipping %s: third-party %s is registered", aws_name, tp_name)
+                return True
         return False

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
@@ -279,12 +279,13 @@ class AwsOpenTelemetryDistro(OpenTelemetryDistro):
         if not is_native:
             return False
 
-        mode = os.environ.get(AWS_AGENTIC_INSTRUMENTATION, "auto").lower()
+        raw_mode = os.environ.get(AWS_AGENTIC_INSTRUMENTATION, "auto")
+        mode = raw_mode.lower()
         if mode not in ("auto", "enabled", "disabled"):
             _logger.warning(
                 "Unknown %s=%r — falling back to 'auto'. Valid values: auto, enabled, disabled.",
                 AWS_AGENTIC_INSTRUMENTATION,
-                mode,
+                raw_mode,
             )
             mode = "auto"
 

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelemetry_distro.py
@@ -57,7 +57,7 @@ class TestAwsOpenTelemetryDistro(TestCase):
             "DJANGO_SETTINGS_MODULE",
             OTEL_EXPORTER_OTLP_ENDPOINT,
             OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,
-            "AWS_AGENTIC_INSTRUMENTATION_OPT_IN",
+            "AWS_AGENTIC_INSTRUMENTATION",
             "CREWAI_DISABLE_TELEMETRY",
         ]
 
@@ -509,12 +509,15 @@ class TestAwsOpenTelemetryDistro(TestCase):
             ep.dist = None
         return ep
 
-    def _load_instrumentor_with_agent(self, ep, third_party_eps=None, prefer_native=False):
-        """Helper to test load_instrumentor with agent observability enabled."""
+    def _load_instrumentor_with_agent(self, ep, third_party_eps=None, mode=None):
+        """Helper to test load_instrumentor with agent observability enabled.
+
+        mode: None (unset → auto), "auto", "enabled", or "disabled".
+        """
         distro = AwsOpenTelemetryDistro()
-        AwsOpenTelemetryDistro._third_party_instrumentors = None
-        if prefer_native:
-            os.environ["AWS_AGENTIC_INSTRUMENTATION_OPT_IN"] = "true"
+        os.environ.pop("AWS_AGENTIC_INSTRUMENTATION", None)
+        if mode is not None:
+            os.environ["AWS_AGENTIC_INSTRUMENTATION"] = mode
         with patch(
             "amazon.opentelemetry.distro.aws_opentelemetry_distro.is_agent_observability_enabled", return_value=True
         ), patch(
@@ -554,26 +557,63 @@ class TestAwsOpenTelemetryDistro(TestCase):
         mock_super = self._load_instrumentor_with_agent(ep, third_party_eps=[])
         mock_super.assert_called_once_with(ep)
 
-    def test_skip_third_party_when_prefer_native(self):
-        """Third-party langchain should be skipped when AWS_AGENTIC_INSTRUMENTATION_OPT_IN=true."""
-        ep = self._make_ep("langchain", "openinference-instrumentation-langchain")
-        third_party = [self._make_ep("langchain", "openinference-instrumentation-langchain")]
-        mock_super = self._load_instrumentor_with_agent(ep, third_party_eps=third_party, prefer_native=True)
-        mock_super.assert_not_called()
-
-    def test_load_third_party_when_not_prefer_native(self):
-        """Third-party langchain should load when auto-detect (default)."""
+    def test_load_third_party_when_auto_detect(self):
+        """Third-party langchain always loads — ADOT never disables third-party instrumentors."""
         ep = self._make_ep("langchain", "openinference-instrumentation-langchain")
         third_party = [self._make_ep("langchain", "openinference-instrumentation-langchain")]
         mock_super = self._load_instrumentor_with_agent(ep, third_party_eps=third_party)
         mock_super.assert_called_once_with(ep)
 
-    def test_load_native_when_prefer_native(self):
-        """aws_langchain should load when AWS_AGENTIC_INSTRUMENTATION_OPT_IN=true even if third-party registered."""
+    def test_load_native_when_mode_enabled(self):
+        """aws_langchain should load when AWS_AGENTIC_INSTRUMENTATION=enabled even if third-party registered."""
         ep = self._make_ep("aws_langchain", "aws-opentelemetry-distro")
         third_party = [self._make_ep("langchain", "openinference-instrumentation-langchain")]
-        mock_super = self._load_instrumentor_with_agent(ep, third_party_eps=third_party, prefer_native=True)
+        mock_super = self._load_instrumentor_with_agent(ep, third_party_eps=third_party, mode="enabled")
         mock_super.assert_called_once_with(ep)
+
+    def test_load_third_party_when_mode_enabled(self):
+        """Third-party langchain still loads under mode=enabled — only the aws_* side is governed."""
+        ep = self._make_ep("langchain", "openinference-instrumentation-langchain")
+        third_party = [self._make_ep("langchain", "openinference-instrumentation-langchain")]
+        mock_super = self._load_instrumentor_with_agent(ep, third_party_eps=third_party, mode="enabled")
+        mock_super.assert_called_once_with(ep)
+
+    def test_skip_native_when_mode_disabled(self):
+        """aws_langchain should be skipped when AWS_AGENTIC_INSTRUMENTATION=disabled, even with no third-party."""
+        ep = self._make_ep("aws_langchain", "aws-opentelemetry-distro")
+        mock_super = self._load_instrumentor_with_agent(ep, third_party_eps=[], mode="disabled")
+        mock_super.assert_not_called()
+
+    def test_load_third_party_when_mode_disabled(self):
+        """Third-party langchain should load when AWS_AGENTIC_INSTRUMENTATION=disabled."""
+        ep = self._make_ep("langchain", "openinference-instrumentation-langchain")
+        third_party = [self._make_ep("langchain", "openinference-instrumentation-langchain")]
+        mock_super = self._load_instrumentor_with_agent(ep, third_party_eps=third_party, mode="disabled")
+        mock_super.assert_called_once_with(ep)
+
+    def test_unknown_mode_falls_back_to_auto(self):
+        """An unrecognized value should warn and behave like auto."""
+        ep = self._make_ep("aws_langchain", "aws-opentelemetry-distro")
+        third_party = [self._make_ep("langchain", "openinference-instrumentation-langchain")]
+        mock_super = self._load_instrumentor_with_agent(ep, third_party_eps=third_party, mode="bogus")
+        mock_super.assert_not_called()
+
+    def test_mode_value_is_case_insensitive(self):
+        """Values like ENABLED / Disabled / Auto should be accepted."""
+        ep = self._make_ep("aws_langchain", "aws-opentelemetry-distro")
+        third_party = [self._make_ep("langchain", "openinference-instrumentation-langchain")]
+
+        # ENABLED — load aws_* even with same-library third-party present
+        mock_super = self._load_instrumentor_with_agent(ep, third_party_eps=third_party, mode="ENABLED")
+        mock_super.assert_called_once_with(ep)
+
+        # Disabled — skip aws_*
+        mock_super = self._load_instrumentor_with_agent(ep, third_party_eps=[], mode="Disabled")
+        mock_super.assert_not_called()
+
+        # Auto — same as unset, skip native because third-party covers it
+        mock_super = self._load_instrumentor_with_agent(ep, third_party_eps=third_party, mode="Auto")
+        mock_super.assert_not_called()
 
     def test_load_regular_instrumentor(self):
         """Regular instrumentors should always be loaded."""

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelemetry_distro.py
@@ -592,11 +592,13 @@ class TestAwsOpenTelemetryDistro(TestCase):
         mock_super.assert_called_once_with(ep)
 
     def test_unknown_mode_falls_back_to_auto(self):
-        """An unrecognized value should warn and behave like auto."""
+        """An unrecognized value should warn (with the raw casing) and behave like auto."""
         ep = self._make_ep("aws_langchain", "aws-opentelemetry-distro")
         third_party = [self._make_ep("langchain", "openinference-instrumentation-langchain")]
-        mock_super = self._load_instrumentor_with_agent(ep, third_party_eps=third_party, mode="bogus")
+        with self.assertLogs("amazon.opentelemetry.distro.aws_opentelemetry_distro", level="WARNING") as cm:
+            mock_super = self._load_instrumentor_with_agent(ep, third_party_eps=third_party, mode="BoGuS")
         mock_super.assert_not_called()
+        self.assertTrue(any("'BoGuS'" in line for line in cm.output), cm.output)
 
     def test_mode_value_is_case_insensitive(self):
         """Values like ENABLED / Disabled / Auto should be accepted."""


### PR DESCRIPTION
## Summary

When `AGENT_OBSERVABILITY_ENABLED=true`, AWS native agentic instrumentors are selected by auto-detection (skipped when a same-library third-party is registered). This PR adds **`AWS_AGENTIC_INSTRUMENTATION`** as a manual override for cases where auto-detection misfires or a native instrumentor has a bug:

| Value (case-insensitive) | Behavior |
| --- | --- |
| `auto` (default / unset) | existing auto-detection — load `aws_*` unless a same-library third-party is registered |
| `enabled` | load all `aws_*` unconditionally |
| `disabled` | skip all `aws_*` |

The switch only governs the `aws_*` side. Third-party instrumentors are never disabled by ADOT — users who want to opt out of third-party should uninstall the package or use `OTEL_PYTHON_DISABLED_INSTRUMENTATIONS`.

Unrecognized values warn and fall back to `auto`.

## Test plan

- [x] Unit tests pass (`pytest tests/...test_aws_opentelemetry_distro.py` — 42 passed)
- [x] New tests cover: `enabled` / `disabled` / `auto`, case-insensitivity (`ENABLED`/`Disabled`/`Auto`), and unknown-value fallback
- [x] black / isort / flake8 / pylint clean on changed files