### PR TITLE
fix(debugger): align capture-limit defaults with Java/JS SDKs

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/debugger/_data_models.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/debugger/_data_models.py
@@ -25,13 +25,13 @@ logger = logging.getLogger(__name__)
 
 # Default capture configuration limits
 DEFAULT_MAX_HITS = 100
-DEFAULT_MAX_STRING_LENGTH = 100
-DEFAULT_MAX_COLLECTION_WIDTH = 10
+DEFAULT_MAX_STRING_LENGTH = 255
+DEFAULT_MAX_COLLECTION_WIDTH = 20
 DEFAULT_MAX_COLLECTION_DEPTH = 3
 DEFAULT_MAX_STACK_FRAMES = 20
 DEFAULT_MAX_STACK_TRACE_SIZE = 200
 DEFAULT_MAX_OBJECT_DEPTH = 3
-DEFAULT_MAX_FIELDS_PER_OBJECT = 10
+DEFAULT_MAX_FIELDS_PER_OBJECT = 20
 DEFAULT_RETURN_ATTRIBUTE_NAME = "aws.di.return_value"
 
 # Validation ranges
@@ -51,16 +51,19 @@ class CaptureConfig:
     Configuration for parameter and return value capture.
 
     Attributes:
-        capture_args: Whether to capture function arguments as span attributes
-        capture_return: Whether to capture return value as span attribute
-        capture_stack_trace: Whether to capture stack trace as span attribute
-        arg_mappings: Dictionary mapping parameter names to custom attribute names
-        return_attribute_name: Custom attribute name for return value
-        max_value_length: Maximum length for string representation of captured values
-        max_number_of_attributes: Maximum number of function arguments to capture
-        max_number_of_stack_frames: Maximum number of stack frames to capture
-        max_size_of_stack_trace: Maximum total size of stack trace
-        capture_args_list: Optional list of specific arguments to capture
+        capture_return: Whether to capture the return value
+        capture_stack_trace: Whether to capture the stack trace
+        capture_arguments: Arguments to capture (None=don't capture, []=all, [names]=named only)
+        capture_locals: Locals to capture (None=don't capture, []=all, [names]=named only)
+        arg_mappings: Maps parameter names to custom attribute names
+        return_attribute_name: Custom attribute name for the return value
+        max_string_length: Maximum length for captured string values (truncated beyond this)
+        max_collection_width: Maximum number of elements captured per collection
+        max_collection_depth: Maximum nesting depth for captured collections
+        max_stack_frames: Maximum number of stack frames to capture
+        max_stack_trace_size: Maximum total size of the captured stack trace
+        max_object_depth: Maximum nesting depth for captured objects
+        max_fields_per_object: Maximum number of fields captured per object
     """
 
     capture_return: bool = False

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/debugger/_function_wrapper.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/debugger/_function_wrapper.py
@@ -29,7 +29,9 @@ from enum import Enum
 from typing import Any, Callable, Optional, Tuple, Type, Union
 
 from amazon.opentelemetry.distro.debugger._data_models import (
+    DEFAULT_MAX_COLLECTION_WIDTH,
     DEFAULT_MAX_FIELDS_PER_OBJECT,
+    DEFAULT_MAX_OBJECT_DEPTH,
     DEFAULT_MAX_STRING_LENGTH,
     CaptureConfig,
 )
@@ -113,8 +115,8 @@ class FunctionWrapper:
         return SnapshotSerializer(
             max_fields=capture_config.max_fields_per_object if capture_config else DEFAULT_MAX_FIELDS_PER_OBJECT,
             max_string_length=capture_config.max_string_length if capture_config else DEFAULT_MAX_STRING_LENGTH,
-            max_depth=capture_config.max_object_depth if capture_config else 3,
-            max_collection_size=capture_config.max_collection_width if capture_config else 10,
+            max_depth=capture_config.max_object_depth if capture_config else DEFAULT_MAX_OBJECT_DEPTH,
+            max_collection_size=capture_config.max_collection_width if capture_config else DEFAULT_MAX_COLLECTION_WIDTH,
         )
 
     def instrument_function(  # pylint: disable=too-many-arguments

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/debugger/instrumentation_engine/_bytecode_injection_engine.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/debugger/instrumentation_engine/_bytecode_injection_engine.py
@@ -19,7 +19,9 @@ from typing import Any, Dict, Optional, Set
 
 from amazon.opentelemetry.distro._utils import IS_BYTECODE_INSTALLED
 from amazon.opentelemetry.distro.debugger._data_models import (
+    DEFAULT_MAX_COLLECTION_WIDTH,
     DEFAULT_MAX_FIELDS_PER_OBJECT,
+    DEFAULT_MAX_OBJECT_DEPTH,
     DEFAULT_MAX_STRING_LENGTH,
     CaptureConfig,
 )
@@ -316,8 +318,10 @@ class BytecodeInjectionEngine(InstrumentationEngine):
             serializer = SnapshotSerializer(
                 max_fields=capture_config.max_fields_per_object if capture_config else DEFAULT_MAX_FIELDS_PER_OBJECT,
                 max_string_length=capture_config.max_string_length if capture_config else DEFAULT_MAX_STRING_LENGTH,
-                max_depth=capture_config.max_object_depth if capture_config else 3,
-                max_collection_size=capture_config.max_collection_width if capture_config else 10,
+                max_depth=capture_config.max_object_depth if capture_config else DEFAULT_MAX_OBJECT_DEPTH,
+                max_collection_size=(
+                    capture_config.max_collection_width if capture_config else DEFAULT_MAX_COLLECTION_WIDTH
+                ),
             )
 
             # Serialize local variables into CapturedValue map

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/debugger/instrumentation_engine/_sys_monitoring_engine.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/debugger/instrumentation_engine/_sys_monitoring_engine.py
@@ -13,7 +13,9 @@ from types import CodeType, FunctionType
 from typing import Any, Dict, Optional, Set
 
 from amazon.opentelemetry.distro.debugger._data_models import (
+    DEFAULT_MAX_COLLECTION_WIDTH,
     DEFAULT_MAX_FIELDS_PER_OBJECT,
+    DEFAULT_MAX_OBJECT_DEPTH,
     DEFAULT_MAX_STRING_LENGTH,
     CaptureConfig,
 )
@@ -347,8 +349,10 @@ class SysMonitoringEngine(InstrumentationEngine):
                         capture_config.max_fields_per_object if capture_config else DEFAULT_MAX_FIELDS_PER_OBJECT
                     ),
                     max_string_length=capture_config.max_string_length if capture_config else DEFAULT_MAX_STRING_LENGTH,
-                    max_depth=capture_config.max_object_depth if capture_config else 3,
-                    max_collection_size=capture_config.max_collection_width if capture_config else 10,
+                    max_depth=capture_config.max_object_depth if capture_config else DEFAULT_MAX_OBJECT_DEPTH,
+                    max_collection_size=(
+                        capture_config.max_collection_width if capture_config else DEFAULT_MAX_COLLECTION_WIDTH
+                    ),
                 )
 
                 if local_vars:

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_data_models.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_data_models.py
@@ -41,6 +41,12 @@ class TestCaptureConfig(unittest.TestCase):
         self.assertEqual(config.max_object_depth, DEFAULT_MAX_OBJECT_DEPTH)
         self.assertEqual(config.max_fields_per_object, DEFAULT_MAX_FIELDS_PER_OBJECT)
 
+        # Lock the cross-SDK parity values (must match Java/JS defaults of 255/20/20)
+        # independently of the constant indirection above.
+        self.assertEqual(config.max_string_length, 255)
+        self.assertEqual(config.max_collection_width, 20)
+        self.assertEqual(config.max_fields_per_object, 20)
+
     def test_custom_values(self):
         """Test custom configuration values."""
         config = CaptureConfig(
@@ -501,6 +507,20 @@ class TestBreakpointConfiguration(unittest.TestCase):
                 "expected_defaults": {
                     "max_string_length": DEFAULT_MAX_STRING_LENGTH,
                     "max_collection_width": DEFAULT_MAX_COLLECTION_WIDTH,
+                },
+            },
+            "capture_limits_omitted_uses_parity_defaults": {
+                # CodeCapture present but CaptureLimits omitted -> defaults must match
+                # Java/JS (255/20/20). Literal assertions guard against re-divergence.
+                "api_config": {
+                    "Location": {"CodeLocation": {"Language": "python", "CodeUnit": "myapp", "MethodName": "func"}},
+                    "CaptureConfiguration": {"CodeCapture": {"CaptureReturn": True}},
+                    "LocationHash": "test",
+                },
+                "expected_defaults": {
+                    "max_string_length": 255,
+                    "max_collection_width": 20,
+                    "max_fields_per_object": 20,
                 },
             },
             "invalid_field_types": {

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_function_wrapper_capture_limits.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_function_wrapper_capture_limits.py
@@ -1,0 +1,231 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests that the function-level capture path honors the per-instrumentation
+capture_config limits (MaxStringLength / MaxCollectionWidth / MaxFieldsPerObject)
+and applies the cross-SDK parity defaults (255/20/20) when limits are omitted.
+
+Regression coverage for the bug where FunctionWrapper serialized arguments and
+return values with a fixed, config-ignoring SnapshotSerializer, so user-supplied
+limits were silently dropped on the function-level path.
+"""
+
+import sys
+import threading
+import types
+import unittest
+
+from amazon.opentelemetry.distro.debugger._data_models import CaptureConfig
+from amazon.opentelemetry.distro.debugger._function_wrapper import FunctionWrapper, set_snapshot_emitter
+
+
+def _make_module(name, **attrs):
+    """Create a fake module with given attributes and register it in sys.modules."""
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    sys.modules[name] = mod
+    return mod
+
+
+def _remove_module(name):
+    sys.modules.pop(name, None)
+
+
+def _echo(text):
+    """Module-level function so its qualified name is stable (no <locals> qualifier)."""
+    return text
+
+
+class _ManyFields:
+    """An object with more attributes than a small max_fields_per_object limit."""
+
+    def __init__(self, count):
+        for i in range(count):
+            setattr(self, f"attr_{i}", i)
+
+
+class TestEntryContextRespectsLimits(unittest.TestCase):
+    """_capture_entry_context must serialize arguments using capture_config limits."""
+
+    def setUp(self):
+        self.wrapper = FunctionWrapper()
+
+    def test_string_argument_truncated_at_configured_limit(self):
+        def func(text):
+            return text
+
+        config = CaptureConfig(capture_arguments=[], max_string_length=10)
+        long_text = "x" * 50
+
+        ctx = self.wrapper._capture_entry_context(func, (long_text,), {}, config)
+
+        self.assertIsNotNone(ctx)
+        captured = ctx.arguments["text"]
+        self.assertEqual(captured.type, "str")
+        self.assertEqual(len(captured.value), 10)
+        self.assertTrue(captured.truncated)
+        self.assertEqual(captured.size, 50)
+
+    def test_collection_argument_capped_at_configured_width(self):
+        def func(items):
+            return items
+
+        config = CaptureConfig(capture_arguments=[], max_collection_width=2)
+        big_list = list(range(5))
+
+        ctx = self.wrapper._capture_entry_context(func, (big_list,), {}, config)
+
+        captured = ctx.arguments["items"]
+        self.assertEqual(captured.type, "list")
+        self.assertEqual(len(captured.elements), 2)
+        self.assertTrue(captured.truncated)
+        self.assertEqual(captured.size, 5)
+
+    def test_object_argument_capped_at_configured_fields(self):
+        def func(obj):
+            return obj
+
+        config = CaptureConfig(capture_arguments=[], max_fields_per_object=2)
+        obj = _ManyFields(6)
+
+        ctx = self.wrapper._capture_entry_context(func, (obj,), {}, config)
+
+        captured = ctx.arguments["obj"]
+        self.assertEqual(len(captured.fields), 2)
+        self.assertEqual(captured.not_captured_reason, "fieldCount")
+        self.assertEqual(captured.size, 6)
+
+
+class TestReturnContextRespectsLimits(unittest.TestCase):
+    """_capture_return_context must serialize the return value using capture_config limits."""
+
+    def setUp(self):
+        self.wrapper = FunctionWrapper()
+
+    def test_return_string_truncated_at_configured_limit(self):
+        config = CaptureConfig(capture_return=True, max_string_length=8)
+        result = "y" * 40
+
+        ctx = self.wrapper._capture_return_context(result, None, config)
+
+        self.assertIsNotNone(ctx)
+        self.assertEqual(len(ctx.return_value.value), 8)
+        self.assertTrue(ctx.return_value.truncated)
+        self.assertEqual(ctx.return_value.size, 40)
+
+
+class TestParityDefaultsOnFunctionPath(unittest.TestCase):
+    """With default limits, the function path must use the parity defaults (255/20/20)."""
+
+    def setUp(self):
+        self.wrapper = FunctionWrapper()
+
+    def test_string_below_default_not_truncated(self):
+        def func(text):
+            return text
+
+        config = CaptureConfig(capture_arguments=[])  # default max_string_length == 255
+        text = "a" * 200
+
+        ctx = self.wrapper._capture_entry_context(func, (text,), {}, config)
+
+        captured = ctx.arguments["text"]
+        self.assertFalse(captured.truncated)
+        self.assertEqual(captured.value, text)
+
+    def test_string_above_default_truncated_at_255(self):
+        def func(text):
+            return text
+
+        config = CaptureConfig(capture_arguments=[])  # default max_string_length == 255
+        text = "a" * 300
+
+        ctx = self.wrapper._capture_entry_context(func, (text,), {}, config)
+
+        captured = ctx.arguments["text"]
+        self.assertTrue(captured.truncated)
+        self.assertEqual(len(captured.value), 255)
+        self.assertEqual(captured.size, 300)
+
+
+class _RecordingEmitter:
+    """Captures the last emitted snapshot for assertions."""
+
+    def __init__(self):
+        self.snapshots = []
+
+    def emit_snapshot(self, snapshot):
+        self.snapshots.append(snapshot)
+
+
+class _FakeBreakpoint:
+    def __init__(self):
+        self.instrumentation_type = "BREAKPOINT"
+
+
+class _FakeBreakpointSet:
+    """Minimal stand-in for FunctionBreakpointSet with a function-level (line 0) breakpoint."""
+
+    def __init__(self):
+        self.breakpoints = {0: _FakeBreakpoint()}
+        self.states = {}
+
+
+class _FakeManager:
+    """Minimal manager exposing the surface sync_wrapper touches for a function-level breakpoint."""
+
+    def __init__(self, func_key):
+        self._lock = threading.RLock()
+        self._active_functions = {func_key: _FakeBreakpointSet()}
+
+    def increment_hit_count(self, _breakpoint_key):
+        return True
+
+
+class TestEndToEndFunctionCaptureRespectsLimits(unittest.TestCase):
+    """Instrument a real function and assert the emitted snapshot honors capture_config limits."""
+
+    def setUp(self):
+        self.module_name = "_test_capture_limits_module"
+        _remove_module(self.module_name)
+        self.emitter = _RecordingEmitter()
+        set_snapshot_emitter(self.emitter)
+
+    def tearDown(self):
+        _remove_module(self.module_name)
+        set_snapshot_emitter(None)
+
+    def test_instrumented_function_truncates_return_at_configured_limit(self):
+        module = _make_module(self.module_name, echo=_echo)
+        wrapper = FunctionWrapper()
+        # The wrapper keys breakpoints by "<module>.<qualified_name>"; use the same key
+        # the wrapper computes so the fake manager's function-level breakpoint is found.
+        func_key = f"{self.module_name}.{FunctionWrapper._get_qualified_name(_echo)}"
+        manager = _FakeManager(func_key)
+
+        config = CaptureConfig(capture_arguments=[], capture_return=True, max_string_length=10)
+
+        _original, instrumented = wrapper.instrument_function(
+            module_name=self.module_name,
+            function_name="echo",
+            capture_config=config,
+            location_hash="test-hash",
+            manager=manager,
+        )
+        module.echo = instrumented
+
+        long_text = "z" * 50
+        self.assertEqual(module.echo(long_text), long_text)  # user output unaffected
+
+        self.assertEqual(len(self.emitter.snapshots), 1)
+        captures = self.emitter.snapshots[0].captures
+        return_value = captures.return_context.return_value
+        self.assertEqual(len(return_value.value), 10)
+        self.assertTrue(return_value.truncated)
+        self.assertEqual(return_value.size, 50)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/contract-tests/images/applications/di-flask/di_flask_server.py
+++ b/contract-tests/images/applications/di-flask/di_flask_server.py
@@ -88,6 +88,17 @@ def process_large_collection(large_list):
     return len(large_list)
 
 
+def process_small_limit_string(small_limit_string):
+    """BREAKPOINT target for small (below-max) string limit validation.
+
+    Config requests MaxStringLength=10 (well within range). The input string is
+    100 chars, so a function-level capture that honors the config should truncate
+    to exactly 10 -- proving the function path respects user-supplied limits rather
+    than always using the maximum.
+    """
+    return len(small_limit_string)
+
+
 # ---------------------------------------------------------------------------
 # Mock DI API configuration
 # ---------------------------------------------------------------------------
@@ -221,6 +232,28 @@ BREAKPOINT_CONFIGS = [
             }
         },
     },
+    # Breakpoint for small (below-max) string limit validation (MaxStringLength=10).
+    # Verifies the function-level path honors a user-supplied limit instead of the maximum.
+    {
+        "InstrumentationType": "BREAKPOINT",
+        "SignalType": "SNAPSHOT",
+        "Location": {
+            "CodeLocation": {
+                "Language": "Python",
+                "CodeUnit": "di_flask_server",
+                "MethodName": "process_small_limit_string",
+                "FilePath": "di_flask_server.py",
+            }
+        },
+        "LocationHash": "aabb000000000009",
+        "CaptureConfiguration": {
+            "CodeCapture": {
+                "CaptureReturn": True,
+                "CaptureArguments": ["small_limit_string"],
+                "CaptureLimits": {"MaxStringLength": 10},
+            }
+        },
+    },
 ]
 
 PROBE_CONFIGS = [
@@ -336,6 +369,14 @@ def limits_collection_endpoint():
     large_list = list(range(1, 51))
     result = process_large_collection(large_list)
     return jsonify({"status": "ok", "size": result})
+
+
+@app.route("/limits-small-string")
+def limits_small_string_endpoint():
+    """Endpoint that triggers small (below-max) string limit validation."""
+    small_limit_string = "B" * 100
+    result = process_small_limit_string(small_limit_string)
+    return jsonify({"status": "ok", "length": result})
 
 
 @app.route("/error")

--- a/contract-tests/tests/test/amazon/di/flask_test.py
+++ b/contract-tests/tests/test/amazon/di/flask_test.py
@@ -459,3 +459,33 @@ class DIFlaskCaptureLimitsTest(DITestInfrastructure):
         size = large_list_arg.get("size")
         self.assertIsNotNone(size, "Captured collection should report original size")
         self.assertEqual(size, 50, "Original collection size should be 50")
+
+    def test_string_value_truncated_at_user_supplied_limit_below_maximum(self) -> None:
+        """Function-level capture must honor a user-supplied limit below the maximum.
+
+        The config requests MaxStringLength=10 (well within range) and the input is
+        100 chars. The captured value must be truncated to exactly 10 -- not the
+        maximum (255) -- proving the function path uses the per-config limit rather
+        than a fixed serializer.
+        """
+        self.send_request("GET", "limits-small-string")
+        logs = self.wait_for_snapshots(min_count=1)
+        log = self.logs_for_method(logs, "process_small_limit_string")[0]
+
+        body = self.body(log)
+        captures = body.get("captures", {})
+        entry = captures.get("entry", {})
+        arguments = entry.get("arguments", {})
+        small_string_arg = arguments.get("small_limit_string", {})
+
+        self.assertIsNotNone(small_string_arg, "Expected 'small_limit_string' argument to be captured")
+
+        captured_value = small_string_arg.get("value")
+        self.assertIsNotNone(captured_value, "Captured string value should not be None")
+        self.assertEqual(
+            len(captured_value),
+            10,
+            f"String should be truncated at the user-supplied limit of 10, but was {len(captured_value)}.",
+        )
+        self.assertTrue(small_string_arg.get("truncated", False), "Captured string should be marked as truncated")
+        self.assertEqual(small_string_arg.get("size"), 100, "Captured string should report original size of 100")


### PR DESCRIPTION
## Summary

Python Dynamic Instrumentation capture-limit defaults diverged from the other ADOT SDKs: `MaxStringLength` was 100 (vs 255) and `MaxCollectionWidth`/`MaxFieldsPerObject` were 10 (vs 20). The API model defines only min/max ranges (no defaults); Java and JS both default to 255/20/20, so the same instrumentation configuration captured visibly less data on Python.

## Changes

- Raise `DEFAULT_MAX_STRING_LENGTH` to 255 and `DEFAULT_MAX_COLLECTION_WIDTH` / `DEFAULT_MAX_FIELDS_PER_OBJECT` to 20 in `_data_models.py`. The validation ranges already matched these values and are unchanged.
- Replace the hardcoded None-config serializer fallbacks (literal `3`/`10`) in the function wrapper and both instrumentation engines with the named `DEFAULT_*` constants, so every capture path shares one source of truth.
- Refresh the stale `CaptureConfig` docstring to match its actual fields.

## Tests

- `test_data_models.py`: literal 255/20/20 assertions plus a `CaptureLimits`-omitted parity case.
- New `test_function_wrapper_capture_limits.py`: verifies the function-level path honors user-supplied limits and applies the parity defaults.
- New di-flask contract test: proves a below-max user limit (`MaxStringLength=10`) is honored end-to-end, truncating to exactly 10.

Verified unit and contract tests on Python 3.11 (bytecode injection engine) and 3.12 (sys.monitoring engine); lint clean.