### PR TITLE
fix(tests): repoint GenAI schema validation to relocated semantic-conventions repo

### DIFF
--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/conftest.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/conftest.py
@@ -7,7 +7,12 @@ import urllib.request
 
 os.environ.setdefault("CREWAI_DISABLE_TELEMETRY", "true")
 
-_OTEL_SCHEMA_BASE = "https://opentelemetry.io/docs/specs/semconv"
+# The OTel GenAI semantic conventions (and their JSON Schemas) moved out of
+# opentelemetry.io into the dedicated open-telemetry/semantic-conventions-genai
+# repository; the old opentelemetry.io/docs/specs/semconv/gen-ai/*.json URLs now
+# 404. The relocated repo does not yet publish tagged releases, so we pin to the
+# raw files on the default branch.
+_OTEL_SCHEMA_BASE = "https://raw.githubusercontent.com/open-telemetry/semantic-conventions-genai/main/docs"
 _SCHEMA_CACHE: dict = {}
 
 


### PR DESCRIPTION
## Summary

The langchain / crewai / llama-index instrumentation tests validate emitted `gen_ai.*.messages` span attributes against the OpenTelemetry GenAI JSON Schemas, which `conftest.py` fetches at runtime. OpenTelemetry relocated the GenAI semantic conventions (and their JSON Schemas) into the dedicated `open-telemetry/semantic-conventions-genai` repository, so the old `opentelemetry.io/docs/specs/semconv/gen-ai/*.json` URLs now return **404** — failing the schema-validation tests with `urllib.error.HTTPError: HTTP Error 404`.

These GenAI suites are part of the full unit-test tox matrix, which the `build` and `di-contract-tests` CI jobs run before building artifacts, so the 404 turns those jobs red on every PR.

## Change

Repoint `_OTEL_SCHEMA_BASE` in `conftest.py` to the relocated schemas. A single constant feeds all GenAI suites (langchain/crewai/llama-index, via `validate_otel_genai_schema`). The new repository does not yet publish tagged releases, so the URL pins to the raw files on the default branch (documented in a comment).

## Verification

- Confirmed the relocated schemas **accept the message shapes the instrumentors currently emit** (validated representative input/output/system-instruction payloads with `jsonschema`) — this is a real fix, not a 404 -> assertion-failure swap.
- All four affected suites pass: langchain-latest (32), langchain-oldest (32), crewai-latest (22), llama-index-latest (104).
- Lint env clean (10.00/10); codespell clean.

## Follow-up (not in this PR)

The schema is still fetched live over the network from a mutable default branch, so a future upstream schema change could break the tests again. A more durable fix would vendor the schema files locally or pin to a commit SHA once the relocated repo publishes tagged releases.