### PR TITLE
refactor(debugger): remove unused instrumentation_name field from DI

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/debugger/_data_models.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/debugger/_data_models.py
@@ -178,7 +178,6 @@ class BreakpointConfiguration:
         capture_config: Configuration for data capture
         config_id: Unique identifier from API
         instrumentation_type: Type of instrumentation ("PROBE" or "BREAKPOINT")
-        instrumentation_name: Optional name for the instrumentation (defaults to "" if absent)
         expires_at: Optional expiration timestamp (ignored for PROBE)
         max_hits: Maximum hits before breakpoint is disabled (ignored for PROBE)
         attribute_filters: List of attribute filter objects
@@ -190,7 +189,6 @@ class BreakpointConfiguration:
     capture_config: CaptureConfig
     config_id: str
     instrumentation_type: str = "BREAKPOINT"  # "PROBE" or "BREAKPOINT"
-    instrumentation_name: Optional[str] = None
     expires_at: Optional[datetime] = None
     max_hits: int = DEFAULT_MAX_HITS
     attribute_filters: List[Dict[str, Any]] = field(default_factory=list)
@@ -363,8 +361,6 @@ class BreakpointConfiguration:
                 )
                 instrumentation_type = "BREAKPOINT"
 
-            instrumentation_name = breakpoint_config.get("InstrumentationName") or ""
-
             # Parse line number safely - 0 or missing means function-level only, >0 means line-level
             # For PROBE: Always force line_number to 0 (function-level only)
             line_number = safe_int(location.get("LineNumber"), 0)
@@ -497,7 +493,6 @@ class BreakpointConfiguration:
                 capture_config=capture_config,
                 config_id=config_id,
                 instrumentation_type=instrumentation_type,
-                instrumentation_name=instrumentation_name,
                 expires_at=expires_at,
                 max_hits=max_hits,
                 attribute_filters=attribute_filters,

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_data_models_branches.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_data_models_branches.py
@@ -6,8 +6,8 @@
 These complement test_data_models.py by feeding from_api_config the malformed
 and PROBE-specific inputs that exercise the remaining validation branches
 (bool line numbers, non-dict CodeLocation/CodeCapture, invalid InstrumentationType,
-PROBE rules around InstrumentationName / ExpiresAt / MaxHits, and CreatedAt
-parsing), plus the simple property accessors and the arg_mappings=None guard.
+PROBE rules around ExpiresAt / MaxHits, and CreatedAt parsing), plus the simple
+property accessors and the arg_mappings=None guard.
 """
 
 import unittest
@@ -122,23 +122,12 @@ class TestFromApiConfigInvalidInstrumentationType(unittest.TestCase):
 
 
 class TestFromApiConfigProbeRules(unittest.TestCase):
-    """Covers PROBE-specific branches: optional name, ExpiresAt ignored, MaxHits ignored."""
-
-    def test_probe_missing_instrumentation_name_defaults_to_empty(self):
-        api_config = {
-            "Location": _location(line_number=0),
-            "InstrumentationType": "PROBE",
-            "LocationHash": "h",
-        }
-        config = BreakpointConfiguration.from_api_config(api_config)
-        self.assertIsNotNone(config)
-        self.assertEqual(config.instrumentation_name, "")
+    """Covers PROBE-specific branches: ExpiresAt ignored, MaxHits ignored."""
 
     def test_probe_ignores_expires_at_and_max_hits(self):
         api_config = {
             "Location": _location(line_number=0),
             "InstrumentationType": "PROBE",
-            "InstrumentationName": "my-probe",
             "ExpiresAt": 1700000000,  # ignored for PROBE (line 456)
             "CaptureConfiguration": {"CodeCapture": {"CaptureLimits": {"MaxHits": 5}}},  # ignored for PROBE (line 483)
             "LocationHash": "h",

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_instrumentation_manager.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_instrumentation_manager.py
@@ -67,8 +67,6 @@ def _api_config(
         },
         "LocationHash": location_hash,
     }
-    if instrumentation_type == "PROBE":
-        item["InstrumentationName"] = "my-probe"
     return item
 
 

--- a/contract-tests/images/applications/di-flask/di_flask_server.py
+++ b/contract-tests/images/applications/di-flask/di_flask_server.py
@@ -227,7 +227,6 @@ PROBE_CONFIGS = [
     # PROBE on compute_total
     {
         "InstrumentationType": "PROBE",
-        "InstrumentationName": "compute-total-probe",
         "SignalType": "SNAPSHOT",
         "Location": {
             "CodeLocation": {
@@ -249,7 +248,6 @@ PROBE_CONFIGS = [
     # PROBE on shared_function (coexists with BREAKPOINT)
     {
         "InstrumentationType": "PROBE",
-        "InstrumentationName": "shared-function-probe",
         "SignalType": "SNAPSHOT",
         "Location": {
             "CodeLocation": {


### PR DESCRIPTION
## Summary

- Drop `instrumentation_name` from `BreakpointConfiguration` and its parsing in `from_api_config` — the field was parsed from the API response but never read by any consumer.
- Remove the `InstrumentationName` test fixture entry and the now-empty `test_probe_missing_instrumentation_name_defaults_to_empty` test; update the surrounding docstring/class docstring to drop the name reference.