### PR TITLE
feat: support OTEL_TRACES_EXPORTER=otlp/sigv4 to opt in to the SigV4 OTLP span exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- feat: add `OTEL_TRACES_EXPORTER=otlp/sigv4` and `OTEL_EXPORTER_OTLP_TRACES_SIGV4_SERVICE` to opt in to the SigV4 OTLP exporter
+  ([#777](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/777))
 - Nightly dependency update: OpenTelemetry 1.42.1/0.63b1
   ([#762](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/762))
 - feat(agent-observability): add `AWS_AGENTIC_INSTRUMENTATION` (`auto`/`enabled`/`disabled`, case-insensitive) as an escape hatch over auto-detection when `AGENT_OBSERVABILITY_ENABLED=true`; the switch only governs AWS native instrumentors and never disables third-party ones

--- a/aws-opentelemetry-distro/pyproject.toml
+++ b/aws-opentelemetry-distro/pyproject.toml
@@ -105,6 +105,9 @@ patch = [
 ]
 test = []
 
+[project.entry-points.opentelemetry_traces_exporter]
+"otlp/sigv4" = "amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter:OTLPAwsSpanExporter"
+
 [project.entry-points.opentelemetry_configurator]
 aws_configurator = "amazon.opentelemetry.distro.aws_opentelemetry_configurator:AwsOpenTelemetryConfigurator"
 

--- a/aws-opentelemetry-distro/pyproject.toml
+++ b/aws-opentelemetry-distro/pyproject.toml
@@ -106,7 +106,7 @@ patch = [
 test = []
 
 [project.entry-points.opentelemetry_traces_exporter]
-"otlp/sigv4" = "amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter:OTLPAwsSpanExporter"
+"otlp/sigv4" = "amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter_auto:AutoOTLPAwsSpanExporter"
 
 [project.entry-points.opentelemetry_configurator]
 aws_configurator = "amazon.opentelemetry.distro.aws_opentelemetry_configurator:AwsOpenTelemetryConfigurator"

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_utils.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_utils.py
@@ -13,6 +13,7 @@ _logger: Logger = getLogger(__name__)
 AGENT_OBSERVABILITY_ENABLED = "AGENT_OBSERVABILITY_ENABLED"
 OTEL_METRICS_ADD_APPLICATION_SIGNALS_DIMENSIONS = "OTEL_METRICS_ADD_APPLICATION_SIGNALS_DIMENSIONS"
 AWS_GENAI_CONTENT_EXTRACTION_OPT_OUT = "AWS_GENAI_CONTENT_EXTRACTION_OPT_OUT"
+OTEL_EXPORTER_OTLP_TRACES_SIGV4_SERVICE = "OTEL_EXPORTER_OTLP_TRACES_SIGV4_SERVICE"
 
 
 def is_installed(req: str) -> bool:
@@ -38,6 +39,12 @@ def is_installed(req: str) -> bool:
 def is_agent_observability_enabled() -> bool:
     """Is the Agentic AI monitoring flag set to true?"""
     return os.environ.get(AGENT_OBSERVABILITY_ENABLED, "false").lower() == "true"
+
+
+def get_sigv4_traces_service() -> Optional[str]:
+    """Returns OTEL_EXPORTER_OTLP_TRACES_SIGV4_SERVICE value, or None if unset/blank."""
+    value = os.environ.get(OTEL_EXPORTER_OTLP_TRACES_SIGV4_SERVICE, "").strip()
+    return value or None
 
 
 def is_genai_content_extraction_opted_out() -> bool:

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
@@ -43,7 +43,7 @@ from amazon.opentelemetry.distro.sampler.aws_xray_remote_sampler import AwsXRayR
 from amazon.opentelemetry.distro.scope_based_exporter import ScopeBasedPeriodicExportingMetricReader
 from amazon.opentelemetry.distro.scope_based_filtering_view import ScopeBasedRetainingView
 from opentelemetry._events import set_event_logger_provider
-from opentelemetry._logs import get_logger_provider, set_logger_provider
+from opentelemetry._logs import set_logger_provider
 from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
 from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter as OTLPHttpOTLPMetricExporter
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
@@ -1029,20 +1029,12 @@ def _create_aws_otlp_exporter(endpoint: str, service: str, region: str):
         from amazon.opentelemetry.distro.exporter.otlp.aws.logs.otlp_aws_log_record_exporter import (
             OTLPAwsLogRecordExporter,
         )
-        from amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter import OTLPAwsSpanExporter
+        from amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter import (
+            create_aws_otlp_span_exporter,
+        )
 
         if service == XRAY_SERVICE:
-            if is_agent_observability_enabled():
-                # Span exporter needs an instance of logger provider in ai agent
-                # observability case because we need to split input/output prompts
-                # from span attributes and send them to the logs pipeline per
-                # the new Gen AI semantic convention from OTel
-                # ref: https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-events/
-                return OTLPAwsSpanExporter(
-                    session=session, endpoint=endpoint, aws_region=region, logger_provider=get_logger_provider()
-                )
-
-            return OTLPAwsSpanExporter(session=session, endpoint=endpoint, aws_region=region)
+            return create_aws_otlp_span_exporter(region=region, aws_service=service, endpoint=endpoint)
 
         if service == LOGS_SERIVCE:
             return OTLPAwsLogRecordExporter(session=session, aws_region=region)

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/exporter/otlp/aws/traces/otlp_aws_span_exporter.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/exporter/otlp/aws/traces/otlp_aws_span_exporter.py
@@ -7,9 +7,7 @@ from typing import Dict, Optional, Sequence
 from botocore.session import Session
 
 from amazon.opentelemetry.distro._utils import (
-    get_aws_region,
     get_aws_session,
-    get_sigv4_traces_service,
     is_agent_observability_enabled,
     is_genai_content_extraction_opted_out,
 )
@@ -37,8 +35,8 @@ class OTLPAwsSpanExporter(OTLPSpanExporter):
 
     def __init__(
         self,
-        aws_region: Optional[str] = None,
-        session: Optional[Session] = None,
+        aws_region: str,
+        session: Session,
         endpoint: Optional[str] = None,
         certificate_file: Optional[str] = None,
         client_key_file: Optional[str] = None,
@@ -49,14 +47,10 @@ class OTLPAwsSpanExporter(OTLPSpanExporter):
         logger_provider: Optional[LoggerProvider] = None,
         aws_service: Optional[str] = None,
     ):
-        # When instantiated by the OTel SDK via the "otlp/sigv4" entry point, no args are passed,
-        # so resolve region/session/service from the environment.
-        self._aws_region = aws_region or get_aws_region()
-        self._aws_service = aws_service or get_sigv4_traces_service() or "xray"
+        self._aws_region = aws_region
+        self._aws_service = aws_service or "xray"
         self._logger_provider = logger_provider
         self._llo_handler = None
-
-        session = session or get_aws_session()
 
         OTLPSpanExporter.__init__(
             self,
@@ -100,3 +94,28 @@ class OTLPAwsSpanExporter(OTLPSpanExporter):
             return SpanExportResult.FAILURE
 
         return super().export(spans)
+
+
+def create_aws_otlp_span_exporter(region: str, aws_service: str, endpoint: Optional[str] = None) -> OTLPSpanExporter:
+    """Create and configure the AWS OTLP span exporter."""
+    session = get_aws_session()
+    # Check if botocore is available before importing the AWS exporter
+    if not session:
+        _logger.warning("Sigv4 Auth requires botocore to be enabled")
+        return OTLPSpanExporter(endpoint=endpoint)
+
+    if is_agent_observability_enabled():
+        # Span exporter needs an instance of logger provider in ai agent
+        # observability case because we need to split input/output prompts
+        # from span attributes and send them to the logs pipeline per
+        # the new Gen AI semantic convention from OTel
+        # ref: https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-events/
+        return OTLPAwsSpanExporter(
+            session=session,
+            endpoint=endpoint,
+            aws_region=region,
+            aws_service=aws_service,
+            logger_provider=get_logger_provider(),
+        )
+
+    return OTLPAwsSpanExporter(session=session, endpoint=endpoint, aws_region=region, aws_service=aws_service)

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/exporter/otlp/aws/traces/otlp_aws_span_exporter.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/exporter/otlp/aws/traces/otlp_aws_span_exporter.py
@@ -6,7 +6,13 @@ from typing import Dict, Optional, Sequence
 
 from botocore.session import Session
 
-from amazon.opentelemetry.distro._utils import is_agent_observability_enabled, is_genai_content_extraction_opted_out
+from amazon.opentelemetry.distro._utils import (
+    get_aws_region,
+    get_aws_session,
+    get_sigv4_traces_service,
+    is_agent_observability_enabled,
+    is_genai_content_extraction_opted_out,
+)
 from amazon.opentelemetry.distro.exporter.otlp.aws.common._aws_http_headers import _OTLP_AWS_HTTP_HEADERS
 from amazon.opentelemetry.distro.exporter.otlp.aws.common.aws_auth_session import AwsAuthSession
 from amazon.opentelemetry.distro.llo_handler import LLOHandler
@@ -31,8 +37,8 @@ class OTLPAwsSpanExporter(OTLPSpanExporter):
 
     def __init__(
         self,
-        aws_region: str,
-        session: Session,
+        aws_region: Optional[str] = None,
+        session: Optional[Session] = None,
         endpoint: Optional[str] = None,
         certificate_file: Optional[str] = None,
         client_key_file: Optional[str] = None,
@@ -41,10 +47,16 @@ class OTLPAwsSpanExporter(OTLPSpanExporter):
         timeout: Optional[int] = None,
         compression: Optional[Compression] = None,
         logger_provider: Optional[LoggerProvider] = None,
+        aws_service: Optional[str] = None,
     ):
-        self._aws_region = aws_region
+        # When instantiated by the OTel SDK via the "otlp/sigv4" entry point, no args are passed,
+        # so resolve region/session/service from the environment.
+        self._aws_region = aws_region or get_aws_region()
+        self._aws_service = aws_service or get_sigv4_traces_service() or "xray"
         self._logger_provider = logger_provider
         self._llo_handler = None
+
+        session = session or get_aws_session()
 
         OTLPSpanExporter.__init__(
             self,
@@ -55,7 +67,7 @@ class OTLPAwsSpanExporter(OTLPSpanExporter):
             headers,
             timeout,
             compression,
-            session=AwsAuthSession(session=session, aws_region=self._aws_region, service="xray"),
+            session=AwsAuthSession(session=session, aws_region=self._aws_region, service=self._aws_service),
         )
         self._session.headers.update(_OTLP_AWS_HTTP_HEADERS)
 

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/exporter/otlp/aws/traces/otlp_aws_span_exporter_auto.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/exporter/otlp/aws/traces/otlp_aws_span_exporter_auto.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from amazon.opentelemetry.distro._utils import get_aws_region, get_sigv4_traces_service
+from amazon.opentelemetry.distro._utils import IS_BOTOCORE_INSTALLED, get_aws_region, get_sigv4_traces_service
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 
 _logger = logging.getLogger(__name__)
@@ -13,6 +13,14 @@ class AutoOTLPAwsSpanExporter(OTLPSpanExporter):
     """Entry point for ``OTEL_TRACES_EXPORTER=otlp/sigv4``."""
 
     def __new__(cls):
+        # SigV4 signing requires botocore, an optional dependency (the 'patch' extra).
+        if not IS_BOTOCORE_INSTALLED:
+            _logger.warning(
+                "OTEL_TRACES_EXPORTER=otlp/sigv4 requires botocore to be installed; "
+                "using the default OTLP span exporter without SigV4 signing."
+            )
+            return OTLPSpanExporter()
+
         region = get_aws_region()
         if region is None:
             _logger.warning(

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/exporter/otlp/aws/traces/otlp_aws_span_exporter_auto.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/exporter/otlp/aws/traces/otlp_aws_span_exporter_auto.py
@@ -1,28 +1,34 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
+
 from amazon.opentelemetry.distro._utils import get_aws_region, get_sigv4_traces_service
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 
+_logger = logging.getLogger(__name__)
+
 
 class AutoOTLPAwsSpanExporter(OTLPSpanExporter):
-    """Entry point for ``OTEL_TRACES_EXPORTER=otlp/sigv4``.
-
-    The OTel SDK constructs exporters from entry points with no arguments, so this resolves the AWS
-    region and SigV4 signing service from the environment (``OTEL_EXPORTER_OTLP_TRACES_SIGV4_SERVICE``,
-    defaulting to ``xray``) and returns a fully configured SigV4 span exporter.
-
-    ``create_aws_otlp_span_exporter`` is imported lazily so that merely loading this entry-point module
-    does not import botocore, which is an optional dependency (the 'patch' extra).
-    """
+    """Entry point for ``OTEL_TRACES_EXPORTER=otlp/sigv4``."""
 
     def __new__(cls):
+        region = get_aws_region()
+        if region is None:
+            _logger.warning(
+                "OTEL_TRACES_EXPORTER=otlp/sigv4 but no AWS region is set; "
+                "set AWS_REGION or AWS_DEFAULT_REGION. Using the default OTLP span exporter without SigV4 signing."
+            )
+            return OTLPSpanExporter()
+
+        service = get_sigv4_traces_service()
+        if service is None:
+            _logger.info("OTEL_EXPORTER_OTLP_TRACES_SIGV4_SERVICE is not set; defaulting to xray.")
+            service = "xray"
+
         # pylint: disable=import-outside-toplevel
         from amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter import (
             create_aws_otlp_span_exporter,
         )
 
-        return create_aws_otlp_span_exporter(
-            region=get_aws_region(),
-            aws_service=get_sigv4_traces_service() or "xray",
-        )
+        return create_aws_otlp_span_exporter(region=region, aws_service=service)

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/exporter/otlp/aws/traces/otlp_aws_span_exporter_auto.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/exporter/otlp/aws/traces/otlp_aws_span_exporter_auto.py
@@ -1,0 +1,28 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from amazon.opentelemetry.distro._utils import get_aws_region, get_sigv4_traces_service
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
+
+class AutoOTLPAwsSpanExporter(OTLPSpanExporter):
+    """Entry point for ``OTEL_TRACES_EXPORTER=otlp/sigv4``.
+
+    The OTel SDK constructs exporters from entry points with no arguments, so this resolves the AWS
+    region and SigV4 signing service from the environment (``OTEL_EXPORTER_OTLP_TRACES_SIGV4_SERVICE``,
+    defaulting to ``xray``) and returns a fully configured SigV4 span exporter.
+
+    ``create_aws_otlp_span_exporter`` is imported lazily so that merely loading this entry-point module
+    does not import botocore, which is an optional dependency (the 'patch' extra).
+    """
+
+    def __new__(cls):
+        # pylint: disable=import-outside-toplevel
+        from amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter import (
+            create_aws_otlp_span_exporter,
+        )
+
+        return create_aws_otlp_span_exporter(
+            region=get_aws_region(),
+            aws_service=get_sigv4_traces_service() or "xray",
+        )

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/exporter/otlp/aws/traces/test_otlp_aws_span_exporter.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/exporter/otlp/aws/traces/test_otlp_aws_span_exporter.py
@@ -66,9 +66,25 @@ class TestOTLPAwsSpanExporter(TestCase):
     )
     def test_auto_exporter_without_botocore_falls_back_to_unsigned(self, _mock_session):
         """botocore is optional; without a session the entry point yields an unsigned OTLP exporter, not a crash."""
-        exporter = AutoOTLPAwsSpanExporter()
+        os.environ["AWS_REGION"] = "us-east-1"
+        try:
+            exporter = AutoOTLPAwsSpanExporter()
+        finally:
+            os.environ.pop("AWS_REGION", None)
 
         # Falls back to the base OTLP exporter (not the SigV4 AwsAuthSession variant).
+        self.assertNotIsInstance(exporter, OTLPAwsSpanExporter)
+        self.assertIsInstance(exporter, OTLPSpanExporter)
+        self.assertNotEqual(type(exporter._session).__name__, "AwsAuthSession")
+
+    @patch(
+        "amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter_auto.get_aws_region",
+        return_value=None,
+    )
+    def test_auto_exporter_without_region_falls_back_to_unsigned(self, _mock_region):
+        """Without a resolvable AWS region the entry point yields an unsigned OTLP exporter, not a crash."""
+        exporter = AutoOTLPAwsSpanExporter()
+
         self.assertNotIsInstance(exporter, OTLPAwsSpanExporter)
         self.assertIsInstance(exporter, OTLPSpanExporter)
         self.assertNotEqual(type(exporter._session).__name__, "AwsAuthSession")

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/exporter/otlp/aws/traces/test_otlp_aws_span_exporter.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/exporter/otlp/aws/traces/test_otlp_aws_span_exporter.py
@@ -1,19 +1,63 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
-from amazon.opentelemetry.distro._utils import get_aws_session
+from amazon.opentelemetry.distro._utils import OTEL_EXPORTER_OTLP_TRACES_SIGV4_SERVICE, get_aws_session
 from amazon.opentelemetry.distro.exporter.otlp.aws.common._aws_http_headers import _OTLP_AWS_HTTP_HEADERS
 from amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter import OTLPAwsSpanExporter
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk._configuration import _import_exporters
 from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk.environment_variables import OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExportResult
 
+OTLP_TRACES_SIGV4_EXPORTER = "otlp/sigv4"
+
 
 class TestOTLPAwsSpanExporter(TestCase):
+    def test_import_exporters_resolves_otlp_sigv4_entry_point(self):
+        """Tests that the 'otlp/sigv4' entry point resolves to OTLPAwsSpanExporter."""
+        trace_exporters, _, _ = _import_exporters(
+            trace_exporter_names=[OTLP_TRACES_SIGV4_EXPORTER],
+            metric_exporter_names=[],
+            log_exporter_names=[],
+        )
+
+        self.assertIs(trace_exporters[OTLP_TRACES_SIGV4_EXPORTER], OTLPAwsSpanExporter)
+
+    def test_init_zero_arg_resolves_from_environment(self):
+        """OTel SDK instantiates the entry point with no args; region/service resolve from env."""
+        os.environ["AWS_REGION"] = "us-east-1"
+        os.environ[OTEL_EXPORTER_OTLP_TRACES_SIGV4_SERVICE] = "aps"
+        os.environ[OTEL_EXPORTER_OTLP_TRACES_ENDPOINT] = "https://collector.example.com/v1/traces"
+        try:
+            exporter = OTLPAwsSpanExporter()
+            self.assertEqual(exporter._aws_region, "us-east-1")
+            self.assertEqual(exporter._aws_service, "aps")
+            self.assertEqual(exporter._session._service, "aps")
+            self.assertEqual(exporter._session._aws_region, "us-east-1")
+        finally:
+            os.environ.pop("AWS_REGION", None)
+            os.environ.pop(OTEL_EXPORTER_OTLP_TRACES_SIGV4_SERVICE, None)
+            os.environ.pop(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, None)
+
+    def test_init_zero_arg_defaults_service_to_xray(self):
+        """Without OTEL_EXPORTER_OTLP_TRACES_SIGV4_SERVICE, the signing service defaults to xray."""
+        os.environ["AWS_REGION"] = "us-east-1"
+        os.environ[OTEL_EXPORTER_OTLP_TRACES_ENDPOINT] = "https://collector.example.com/v1/traces"
+        os.environ.pop(OTEL_EXPORTER_OTLP_TRACES_SIGV4_SERVICE, None)
+        try:
+            exporter = OTLPAwsSpanExporter()
+            self.assertEqual(exporter._aws_service, "xray")
+            self.assertEqual(exporter._session._service, "xray")
+        finally:
+            os.environ.pop("AWS_REGION", None)
+            os.environ.pop(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, None)
+
     def test_init_with_logger_provider(self):
         # Test initialization with logger_provider
         mock_logger_provider = MagicMock(spec=LoggerProvider)

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/exporter/otlp/aws/traces/test_otlp_aws_span_exporter.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/exporter/otlp/aws/traces/test_otlp_aws_span_exporter.py
@@ -61,22 +61,20 @@ class TestOTLPAwsSpanExporter(TestCase):
             os.environ.pop(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, None)
 
     @patch(
-        "amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.get_aws_session",
-        return_value=None,
+        "amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter_auto.IS_BOTOCORE_INSTALLED", False
     )
-    def test_auto_exporter_without_botocore_falls_back_to_unsigned(self, _mock_session):
-        """botocore is optional; without a session the entry point yields an unsigned OTLP exporter, not a crash."""
-        os.environ["AWS_REGION"] = "us-east-1"
-        try:
-            exporter = AutoOTLPAwsSpanExporter()
-        finally:
-            os.environ.pop("AWS_REGION", None)
+    def test_auto_exporter_without_botocore_falls_back_to_unsigned(self):
+        """botocore is optional; without it the entry point yields an unsigned OTLP exporter, not a crash."""
+        exporter = AutoOTLPAwsSpanExporter()
 
         # Falls back to the base OTLP exporter (not the SigV4 AwsAuthSession variant).
         self.assertNotIsInstance(exporter, OTLPAwsSpanExporter)
         self.assertIsInstance(exporter, OTLPSpanExporter)
         self.assertNotEqual(type(exporter._session).__name__, "AwsAuthSession")
 
+    @patch(
+        "amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter_auto.IS_BOTOCORE_INSTALLED", True
+    )
     @patch(
         "amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter_auto.get_aws_region",
         return_value=None,

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/exporter/otlp/aws/traces/test_otlp_aws_span_exporter.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/exporter/otlp/aws/traces/test_otlp_aws_span_exporter.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 from amazon.opentelemetry.distro._utils import OTEL_EXPORTER_OTLP_TRACES_SIGV4_SERVICE, get_aws_session
 from amazon.opentelemetry.distro.exporter.otlp.aws.common._aws_http_headers import _OTLP_AWS_HTTP_HEADERS
 from amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter import OTLPAwsSpanExporter
+from amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter_auto import AutoOTLPAwsSpanExporter
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk._configuration import _import_exporters
 from opentelemetry.sdk._logs import LoggerProvider
@@ -20,22 +21,23 @@ OTLP_TRACES_SIGV4_EXPORTER = "otlp/sigv4"
 
 class TestOTLPAwsSpanExporter(TestCase):
     def test_import_exporters_resolves_otlp_sigv4_entry_point(self):
-        """Tests that the 'otlp/sigv4' entry point resolves to OTLPAwsSpanExporter."""
+        """Tests that the 'otlp/sigv4' entry point resolves to AutoOTLPAwsSpanExporter."""
         trace_exporters, _, _ = _import_exporters(
             trace_exporter_names=[OTLP_TRACES_SIGV4_EXPORTER],
             metric_exporter_names=[],
             log_exporter_names=[],
         )
 
-        self.assertIs(trace_exporters[OTLP_TRACES_SIGV4_EXPORTER], OTLPAwsSpanExporter)
+        self.assertIs(trace_exporters[OTLP_TRACES_SIGV4_EXPORTER], AutoOTLPAwsSpanExporter)
 
-    def test_init_zero_arg_resolves_from_environment(self):
-        """OTel SDK instantiates the entry point with no args; region/service resolve from env."""
+    def test_auto_exporter_resolves_from_environment(self):
+        """The entry point is constructed with no args; region/service resolve from env into the SigV4 session."""
         os.environ["AWS_REGION"] = "us-east-1"
         os.environ[OTEL_EXPORTER_OTLP_TRACES_SIGV4_SERVICE] = "aps"
         os.environ[OTEL_EXPORTER_OTLP_TRACES_ENDPOINT] = "https://collector.example.com/v1/traces"
         try:
-            exporter = OTLPAwsSpanExporter()
+            exporter = AutoOTLPAwsSpanExporter()
+            self.assertIsInstance(exporter, OTLPAwsSpanExporter)
             self.assertEqual(exporter._aws_region, "us-east-1")
             self.assertEqual(exporter._aws_service, "aps")
             self.assertEqual(exporter._session._service, "aps")
@@ -45,18 +47,31 @@ class TestOTLPAwsSpanExporter(TestCase):
             os.environ.pop(OTEL_EXPORTER_OTLP_TRACES_SIGV4_SERVICE, None)
             os.environ.pop(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, None)
 
-    def test_init_zero_arg_defaults_service_to_xray(self):
+    def test_auto_exporter_defaults_service_to_xray(self):
         """Without OTEL_EXPORTER_OTLP_TRACES_SIGV4_SERVICE, the signing service defaults to xray."""
         os.environ["AWS_REGION"] = "us-east-1"
         os.environ[OTEL_EXPORTER_OTLP_TRACES_ENDPOINT] = "https://collector.example.com/v1/traces"
         os.environ.pop(OTEL_EXPORTER_OTLP_TRACES_SIGV4_SERVICE, None)
         try:
-            exporter = OTLPAwsSpanExporter()
+            exporter = AutoOTLPAwsSpanExporter()
             self.assertEqual(exporter._aws_service, "xray")
             self.assertEqual(exporter._session._service, "xray")
         finally:
             os.environ.pop("AWS_REGION", None)
             os.environ.pop(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, None)
+
+    @patch(
+        "amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.get_aws_session",
+        return_value=None,
+    )
+    def test_auto_exporter_without_botocore_falls_back_to_unsigned(self, _mock_session):
+        """botocore is optional; without a session the entry point yields an unsigned OTLP exporter, not a crash."""
+        exporter = AutoOTLPAwsSpanExporter()
+
+        # Falls back to the base OTLP exporter (not the SigV4 AwsAuthSession variant).
+        self.assertNotIsInstance(exporter, OTLPAwsSpanExporter)
+        self.assertIsInstance(exporter, OTLPSpanExporter)
+        self.assertNotEqual(type(exporter._session).__name__, "AwsAuthSession")
 
     def test_init_with_logger_provider(self):
         # Test initialization with logger_provider

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py
@@ -570,7 +570,7 @@ class TestAwsOpenTelemetryConfigurator(TestCase):
 
         mock_logger_provider = MagicMock()
         with patch(
-            "amazon.opentelemetry.distro.aws_opentelemetry_configurator.get_logger_provider",
+            "amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.get_logger_provider",
             return_value=mock_logger_provider,
         ):
             mock_exporter = MagicMock(spec=OTLPSpanExporter)
@@ -1259,10 +1259,10 @@ class TestAwsOpenTelemetryConfigurator(TestCase):
             "amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.OTLPAwsSpanExporter"
         ) as mock_aws_exporter:
             with patch(
-                "amazon.opentelemetry.distro.aws_opentelemetry_configurator.get_logger_provider"
+                "amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.get_logger_provider"
             ) as mock_logger_provider:
                 with patch(
-                    "amazon.opentelemetry.distro.aws_opentelemetry_configurator.get_aws_session"
+                    "amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.get_aws_session"
                 ) as mock_session:
                     mock_session.return_value = MagicMock()
                     os.environ["AGENT_OBSERVABILITY_ENABLED"] = "true"
@@ -1275,6 +1275,7 @@ class TestAwsOpenTelemetryConfigurator(TestCase):
                         session=mock_session.return_value,
                         endpoint="https://xray.us-east-1.amazonaws.com/v1/traces",
                         aws_region="us-east-1",
+                        aws_service="xray",
                         logger_provider=mock_logger_provider.return_value,
                     )
                     # Verify processor is added to tracer provider
@@ -1480,53 +1481,31 @@ class TestAwsOpenTelemetryConfigurator(TestCase):
         added_processor = mock_logger_provider.add_log_record_processor.call_args[0][0]
         self.assertIsInstance(added_processor, AwsCloudWatchOtlpBatchLogRecordProcessor)
 
-    @patch("amazon.opentelemetry.distro.aws_opentelemetry_configurator.get_logger_provider")
-    @patch("amazon.opentelemetry.distro.aws_opentelemetry_configurator.is_agent_observability_enabled")
     @patch("amazon.opentelemetry.distro.aws_opentelemetry_configurator.get_aws_session")
-    def test_create_aws_otlp_exporter(self, mock_get_session, mock_is_agent_enabled, mock_get_logger_provider):
+    def test_create_aws_otlp_exporter(self, mock_get_session):
         # Test when botocore is not installed
         mock_get_session.return_value = None
-        result = _create_aws_otlp_exporter("https://xray.us-east-1.amazonaws.com/v1/traces", "xray", "us-east-1")
+        result = _create_aws_otlp_exporter("https://logs.us-east-1.amazonaws.com/v1/logs", "logs", "us-east-1")
         self.assertIsNone(result)
 
         # Reset mock for subsequent tests
         mock_get_session.reset_mock()
         mock_get_session.return_value = MagicMock()
-        mock_get_logger_provider.return_value = MagicMock()
 
-        # Test xray service without agent observability
-        mock_is_agent_enabled.return_value = False
+        # Test xray service delegates to the shared span exporter factory
         with patch(
-            "amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.OTLPAwsSpanExporter"
-        ) as mock_span_exporter_class:
+            "amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.create_aws_otlp_span_exporter"
+        ) as mock_factory:
             mock_exporter_instance = MagicMock()
-            mock_span_exporter_class.return_value = mock_exporter_instance
+            mock_factory.return_value = mock_exporter_instance
 
             result = _create_aws_otlp_exporter("https://xray.us-east-1.amazonaws.com/v1/traces", "xray", "us-east-1")
             self.assertIsNotNone(result)
             self.assertEqual(result, mock_exporter_instance)
-            mock_span_exporter_class.assert_called_with(
-                session=mock_get_session.return_value,
+            mock_factory.assert_called_with(
+                region="us-east-1",
+                aws_service="xray",
                 endpoint="https://xray.us-east-1.amazonaws.com/v1/traces",
-                aws_region="us-east-1",
-            )
-
-        # Test xray service with agent observability
-        mock_is_agent_enabled.return_value = True
-        with patch(
-            "amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter.OTLPAwsSpanExporter"
-        ) as mock_span_exporter_class:
-            mock_exporter_instance = MagicMock()
-            mock_span_exporter_class.return_value = mock_exporter_instance
-
-            result = _create_aws_otlp_exporter("https://xray.us-east-1.amazonaws.com/v1/traces", "xray", "us-east-1")
-            self.assertIsNotNone(result)
-            self.assertEqual(result, mock_exporter_instance)
-            mock_span_exporter_class.assert_called_with(
-                session=mock_get_session.return_value,
-                endpoint="https://xray.us-east-1.amazonaws.com/v1/traces",
-                aws_region="us-east-1",
-                logger_provider=mock_get_logger_provider.return_value,
             )
 
         # Test logs service
@@ -1543,7 +1522,7 @@ class TestAwsOpenTelemetryConfigurator(TestCase):
 
         # Test exception handling
         mock_get_session.side_effect = Exception("Test exception")
-        result = _create_aws_otlp_exporter("https://xray.us-east-1.amazonaws.com/v1/traces", "xray", "us-east-1")
+        result = _create_aws_otlp_exporter("https://logs.us-east-1.amazonaws.com/v1/logs", "logs", "us-east-1")
         self.assertIsNone(result)
 
     @patch("amazon.opentelemetry.distro.aws_opentelemetry_configurator.is_agent_observability_enabled")


### PR DESCRIPTION
## Summary

Adds opt-in SigV4-signed OTLP **trace** export, selected via the standard OTel exporter config rather than a custom boolean flag:

- **`OTEL_TRACES_EXPORTER=otlp/sigv4`** — registered as an `opentelemetry_traces_exporter` entry point, so the OTel SDK natively constructs the AWS SigV4 span exporter. No env-var stripping, no interception in the configurator, no startup crash when the value is set.
- **`OTEL_EXPORTER_OTLP_TRACES_SIGV4_SERVICE`** — the SigV4 signing service name used when the endpoint is non-AWS (e.g. a collector fronting a non-xray service). Defaults to `xray` when unset.

This mirrors how `awsemf` is handled for metrics and keeps `OTLPAwsSpanExporter`'s public constructor unchanged.

### How it works
- `AutoOTLPAwsSpanExporter` (new, `otlp_aws_span_exporter_auto.py`) is the entry-point class. The SDK instantiates it with no args, so it resolves region + signing service from the environment and delegates to a shared factory.
- `create_aws_otlp_span_exporter()` (new, in `otlp_aws_span_exporter.py`) is the single factory shared by both the AWS xray-endpoint path (`_create_aws_otlp_exporter` in the configurator) and the `otlp/sigv4` entry point. It centralizes the SigV4 session + agent-observability `logger_provider` handling.
- **botocore is optional** (the `patch` extra). The entry-point module does not import botocore at module load, so resolving the entry point is import-safe without it. Fallbacks are checked in priority order, each logging the precise reason and degrading to the unsigned base `OTLPSpanExporter`:
  1. botocore not installed (`IS_BOTOCORE_INSTALLED`)
  2. no resolvable AWS region
  3. signing service unset → defaults to `xray`

### Scope
- Traces only. Logs/metrics behavior is unchanged.
- Also fixes the `LOGS_SERIVCE` -> `LOGS_SERVICE` typo touched along the way.

## Test plan
- [x] `test_import_exporters_resolves_otlp_sigv4_entry_point` — the `otlp/sigv4` entry point resolves to `AutoOTLPAwsSpanExporter`
- [x] `test_auto_exporter_resolves_from_environment` / `test_auto_exporter_defaults_service_to_xray` — region + service resolve from env into the SigV4 session
- [x] `test_auto_exporter_without_botocore_falls_back_to_unsigned` — no botocore -> unsigned `OTLPSpanExporter`, no crash
- [x] `test_auto_exporter_without_region_falls_back_to_unsigned` — no region -> unsigned fallback
- [x] Configurator tests updated for the shared-factory delegation
- [x] black / isort / flake8 / pylint clean
- [x] Verified end-to-end from a built wheel in a fresh venv (signed request credential scope confirmed; no-botocore degrades gracefully)