### PR TITLE
ci(di-contract-tests): add Python 3.10 to test matrix

### DIFF
--- a/.github/workflows/di-contract-tests.yml
+++ b/.github/workflows/di-contract-tests.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
## Summary

- Extend the DI contract-tests matrix from `[3.11, 3.12]` to `[3.10, 3.11, 3.12]` so the bytecode-injection engine path on 3.10 is covered end-to-end alongside 3.11 and 3.12 (sys.monitoring).