### PR TITLE
feat(debugger): instrument FastAPI route handlers via route-table patching

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,4 @@
 [codespell]
 # skipping auto generated folders
 skip = ./.tox,./.mypy_cache,./target,*/LICENSE,./venv,*/sql_dialect_keywords.json,*/3rd.txt
-ignore-words-list = afterall,assertIn,crate,SEH
+ignore-words-list = afterall,assertIn,crate,SEH,dependant

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/debugger/_function_wrapper.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/debugger/_function_wrapper.py
@@ -794,6 +794,7 @@ class FunctionWrapper:
 
         Currently supports:
         - Flask: patches app.view_functions entries that reference the original function
+        - FastAPI: patches APIRoute.endpoint / APIRoute.dependant.call on app.router.routes
 
         Args:
             module: The module object containing the function
@@ -803,6 +804,8 @@ class FunctionWrapper:
         try:
             # Flask: patch view_functions on any Flask app instances in the module
             FunctionWrapper._patch_flask_view_functions(module, original_func, new_func)
+            # FastAPI: patch route table entries on any FastAPI app instances in the module
+            FunctionWrapper._patch_fastapi_routes(module, original_func, new_func)
         except Exception as exc:
             # Never let framework patching failures break instrumentation
             logger.debug("Framework reference patching encountered an error: %s", exc)
@@ -897,6 +900,131 @@ class FunctionWrapper:
             for ep in matching_endpoints:
                 view_functions[ep] = new_func
                 logger.debug("Patched Flask view_functions[%s] by name+module match", ep)
+
+    @staticmethod
+    def _patch_fastapi_routes(module, original_func: Callable, new_func: Callable) -> None:
+        """
+        Patch FastAPI route table entries that reference the original function.
+
+        FastAPI's @app.get()/@app.post() decorators capture a direct reference to the
+        route handler at import time, storing it on each APIRoute as ``endpoint`` and
+        (via the pre-built Dependant) ``dependant.call``. The per-request dispatch path
+        invokes ``dependant.call``. Replacing the module-level name via setattr does NOT
+        update these references, so FastAPI keeps calling the original unwrapped handler.
+        This method finds and patches those references on any FastAPI app in the module.
+
+        Args:
+            module: The module object that may contain FastAPI app instances
+            original_func: The original function to find in the route table
+            new_func: The new wrapper function to replace it with
+        """
+        try:
+            try:
+                from fastapi import FastAPI  # pylint: disable=import-outside-toplevel
+            except ImportError:
+                return  # FastAPI not installed, nothing to patch
+
+            func_name = getattr(original_func, "__name__", "unknown")
+            func_module = getattr(original_func, "__module__", None)
+
+            # Scan module attributes for FastAPI app instances
+            for attr_name in dir(module):
+                try:
+                    attr = getattr(module, attr_name, None)
+                    if attr is None or not isinstance(attr, FastAPI):
+                        continue
+                    FunctionWrapper._patch_single_fastapi_app(
+                        attr, attr_name, original_func, new_func, func_name, func_module
+                    )
+                except Exception as exc:
+                    logger.warning("Error checking module attribute '%s' for FastAPI app: %s", attr_name, exc)
+                    continue
+
+        except Exception as exc:
+            logger.warning("Error patching FastAPI routes: %s", exc)
+
+    @staticmethod
+    def _patch_single_fastapi_app(  # pylint: disable=too-many-locals
+        fastapi_app, app_name, original_func, new_func, func_name, func_module=None
+    ):
+        """Patch route handler references in a single FastAPI app instance.
+
+        Rebinds both ``route.endpoint`` and ``route.dependant.call`` (the attribute the
+        dispatcher actually invokes). The pre-built Dependant remains valid because the
+        DI wrapper preserves the handler signature via functools.wraps, so no rebuild is
+        needed. ``app.include_router`` flattens sub-routers into ``app.router.routes``,
+        so iterating that list covers all routes.
+        """
+        router = getattr(fastapi_app, "router", None)
+        routes = getattr(router, "routes", None)
+        if not isinstance(routes, list):
+            logger.debug("FastAPI app '%s' has no router.routes list", app_name)
+            return
+
+        def _rebind(route) -> None:
+            route.endpoint = new_func
+            dependant = getattr(route, "dependant", None)
+            if dependant is not None and hasattr(dependant, "call"):
+                dependant.call = new_func
+
+        def _is_identity_match(route) -> bool:
+            if getattr(route, "endpoint", None) is original_func:
+                return True
+            dependant = getattr(route, "dependant", None)
+            return dependant is not None and getattr(dependant, "call", None) is original_func
+
+        # Identity match first. Guard each route independently so one bad route
+        # cannot abort patching of the others.
+        patched_count = 0
+        for route in routes:
+            try:
+                if getattr(route, "endpoint", None) is None:
+                    continue  # not an APIRoute (e.g. Mount/WebSocketRoute)
+                if _is_identity_match(route):
+                    _rebind(route)
+                    patched_count += 1
+                    logger.debug("Patched FastAPI route '%s' to use DI wrapper", getattr(route, "path", "?"))
+            except Exception as exc:
+                logger.warning("Error patching FastAPI route '%s': %s", getattr(route, "path", "?"), exc)
+                continue
+
+        if patched_count > 0:
+            logger.debug(
+                "Patched %d FastAPI route(s) for function '%s' on app '%s'",
+                patched_count,
+                func_name,
+                app_name,
+            )
+            return
+
+        # Identity check failed -- try name+module-based matching. functools.wraps
+        # (used by DI's own wrapper and by OTel instrumentation) preserves __module__,
+        # so requiring both name and module avoids patching a same-named handler from a
+        # different module. If the original has no __module__, fall back to name-only.
+        def _matches(endpoint):
+            if getattr(endpoint, "__name__", None) != func_name:
+                return False
+            if func_module is None:
+                return True
+            return getattr(endpoint, "__module__", None) == func_module
+
+        matching_routes = [r for r in routes if getattr(r, "endpoint", None) is not None and _matches(r.endpoint)]
+        if matching_routes:
+            logger.debug(
+                "FastAPI app '%s' has %d route(s) with name '%s' (module '%s') but identity "
+                "mismatch. Patching by name+module.",
+                app_name,
+                len(matching_routes),
+                func_name,
+                func_module,
+            )
+            for route in matching_routes:
+                try:
+                    _rebind(route)
+                    logger.debug("Patched FastAPI route '%s' by name+module match", getattr(route, "path", "?"))
+                except Exception as exc:
+                    logger.warning("Error patching FastAPI route '%s': %s", getattr(route, "path", "?"), exc)
+                    continue
 
     @staticmethod
     def _get_qualified_name(original_func: Callable) -> str:

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_function_wrapper_fastapi.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_function_wrapper_fastapi.py
@@ -1,0 +1,264 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for FastAPI route-table patching in _function_wrapper.py.
+
+Validates that _replace_function_in_module and restore_function correctly
+patch a FastAPI app's route table (APIRoute.endpoint and APIRoute.dependant.call)
+when instrumenting route handlers, mirroring the Flask view_functions patching.
+"""
+
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+from amazon.opentelemetry.distro.debugger._function_wrapper import FunctionWrapper
+
+
+def _make_module(name, **attrs):
+    """Create a fake module with given attributes."""
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    sys.modules[name] = mod
+    return mod
+
+
+def _remove_module(name):
+    sys.modules.pop(name, None)
+
+
+def _route_for(app, path):
+    """Return the APIRoute registered on `app` for `path`."""
+    for route in app.router.routes:
+        if getattr(route, "path", None) == path and getattr(route, "endpoint", None) is not None:
+            return route
+    raise AssertionError(f"No route found for path {path}")
+
+
+class TestFastAPIRoutesPatching(unittest.TestCase):
+    """Tests for _patch_fastapi_routes and its integration."""
+
+    def setUp(self):
+        self.module_name = "_test_fastapi_module"
+        _remove_module(self.module_name)
+
+    def tearDown(self):
+        _remove_module(self.module_name)
+
+    # ------------------------------------------------------------------
+    # _patch_fastapi_routes
+    # ------------------------------------------------------------------
+
+    def test_patch_fastapi_routes_identity_match(self):
+        """When route.endpoint is original_func, identity-based patching rebinds endpoint + dependant.call."""
+        try:
+            from fastapi import FastAPI
+        except ImportError:
+            self.skipTest("FastAPI not installed")
+
+        app = FastAPI()
+
+        @app.get("/orders")
+        def get_orders():
+            return "orders"
+
+        route = _route_for(app, "/orders")
+        original = route.endpoint  # the function object FastAPI captured
+        wrapper = lambda: "wrapper"  # noqa: E731
+
+        mod = _make_module(self.module_name, app=app, get_orders=original)
+
+        FunctionWrapper._patch_fastapi_routes(mod, original, wrapper)
+
+        self.assertIs(route.endpoint, wrapper)
+        self.assertIs(route.dependant.call, wrapper)
+
+    def test_patch_fastapi_routes_name_fallback(self):
+        """When identity doesn't match (e.g. external wrapping), name+module fallback rebinds the route."""
+        try:
+            from fastapi import FastAPI
+        except ImportError:
+            self.skipTest("FastAPI not installed")
+
+        app = FastAPI()
+
+        @app.get("/orders")
+        def get_orders():
+            return "orders"
+
+        route = _route_for(app, "/orders")
+        original = route.endpoint
+
+        # Simulate something having replaced the stored handler with a different-identity
+        # callable that preserves __name__/__module__ (as functools.wraps does).
+        def other_same_name():
+            return "other"
+
+        other_same_name.__name__ = original.__name__
+        other_same_name.__module__ = original.__module__
+        route.endpoint = other_same_name
+        route.dependant.call = other_same_name
+
+        di_wrapper = lambda: "di_wrapper"  # noqa: E731
+
+        mod = _make_module(self.module_name, app=app, get_orders=original)
+
+        FunctionWrapper._patch_fastapi_routes(mod, original, di_wrapper)
+
+        self.assertIs(route.endpoint, di_wrapper)
+        self.assertIs(route.dependant.call, di_wrapper)
+
+    def test_patch_fastapi_no_fastapi_installed(self):
+        """When FastAPI is not installed, patching is a no-op."""
+        original = lambda: None  # noqa: E731
+        wrapper = lambda: None  # noqa: E731
+        mod = _make_module(self.module_name, some_func=original)
+
+        with patch.dict(sys.modules, {"fastapi": None}):
+            # Should not raise
+            FunctionWrapper._patch_fastapi_routes(mod, original, wrapper)
+
+    def test_patch_fastapi_no_app_in_module(self):
+        """When module has no FastAPI app instances, patching is a no-op."""
+        try:
+            from fastapi import FastAPI  # noqa: F401
+        except ImportError:
+            self.skipTest("FastAPI not installed")
+
+        original = lambda: None  # noqa: E731
+        wrapper = lambda: None  # noqa: E731
+        mod = _make_module(self.module_name, some_func=original, x=42, y="hello")
+
+        # Should not raise
+        FunctionWrapper._patch_fastapi_routes(mod, original, wrapper)
+
+    def test_patch_fastapi_function_not_a_route(self):
+        """When the function is not a route handler, the route table is unchanged."""
+        try:
+            from fastapi import FastAPI
+        except ImportError:
+            self.skipTest("FastAPI not installed")
+
+        app = FastAPI()
+
+        @app.get("/other")
+        def other_view():
+            return "other"
+
+        route = _route_for(app, "/other")
+        other_endpoint = route.endpoint
+        other_call = route.dependant.call
+
+        original = lambda: None  # noqa: E731
+        original.__name__ = "helper_func"
+        wrapper = lambda: None  # noqa: E731
+
+        mod = _make_module(self.module_name, app=app, helper_func=original)
+
+        FunctionWrapper._patch_fastapi_routes(mod, original, wrapper)
+
+        # The unrelated route should be untouched.
+        self.assertIs(route.endpoint, other_endpoint)
+        self.assertIs(route.dependant.call, other_call)
+
+    # ------------------------------------------------------------------
+    # Integration: _replace_function_in_module with FastAPI patching
+    # ------------------------------------------------------------------
+
+    def test_replace_function_patches_fastapi_routes(self):
+        """_replace_function_in_module patches FastAPI route references."""
+        try:
+            from fastapi import FastAPI
+        except ImportError:
+            self.skipTest("FastAPI not installed")
+
+        app = FastAPI()
+
+        @app.get("/hello")
+        def my_route():
+            return "hello"
+
+        route = _route_for(app, "/hello")
+        original = route.endpoint
+
+        mod = _make_module(self.module_name, app=app, my_route=original)
+        wrapper = lambda: "wrapped"  # noqa: E731
+
+        with patch.object(FunctionWrapper, "_resolve_module", return_value=mod):
+            FunctionWrapper._replace_function_in_module(self.module_name, "my_route", wrapper)
+
+        # Module attribute replaced
+        self.assertIs(mod.my_route, wrapper)
+        # FastAPI route table also patched
+        self.assertIs(route.endpoint, wrapper)
+        self.assertIs(route.dependant.call, wrapper)
+
+    # ------------------------------------------------------------------
+    # Integration: restore_function with FastAPI patching
+    # ------------------------------------------------------------------
+
+    def test_restore_function_restores_fastapi_routes(self):
+        """restore_function restores FastAPI route references back to the original."""
+        try:
+            from fastapi import FastAPI
+        except ImportError:
+            self.skipTest("FastAPI not installed")
+
+        def original_route():
+            return "original"
+
+        def wrapped_route():
+            return "wrapped"
+
+        app = FastAPI()
+
+        @app.get("/hello")
+        def my_route():
+            return "hello"
+
+        route = _route_for(app, "/hello")
+        # Simulate: DI already wrapped the function and patched the route table.
+        route.endpoint = wrapped_route
+        route.dependant.call = wrapped_route
+
+        mod = _make_module(self.module_name, app=app, my_route=wrapped_route)
+
+        with patch.object(FunctionWrapper, "_resolve_module", return_value=mod):
+            result = FunctionWrapper.restore_function(self.module_name, "my_route", original_route)
+
+        self.assertTrue(result)
+        self.assertIs(mod.my_route, original_route)
+        # FastAPI route table restored
+        self.assertIs(route.endpoint, original_route)
+        self.assertIs(route.dependant.call, original_route)
+
+    # ------------------------------------------------------------------
+    # _patch_framework_references (dispatcher)
+    # ------------------------------------------------------------------
+
+    def test_patch_framework_references_calls_fastapi_patching(self):
+        """_patch_framework_references delegates to _patch_fastapi_routes."""
+        original = lambda: None  # noqa: E731
+        wrapper = lambda: None  # noqa: E731
+        mod = _make_module(self.module_name)
+
+        with patch.object(FunctionWrapper, "_patch_fastapi_routes") as mock_fastapi:
+            FunctionWrapper._patch_framework_references(mod, original, wrapper)
+            mock_fastapi.assert_called_once_with(mod, original, wrapper)
+
+    def test_patch_framework_references_swallows_fastapi_exceptions(self):
+        """_patch_framework_references never raises even if FastAPI patching fails."""
+        original = lambda: None  # noqa: E731
+        wrapper = lambda: None  # noqa: E731
+        mod = _make_module(self.module_name)
+
+        with patch.object(FunctionWrapper, "_patch_fastapi_routes", side_effect=RuntimeError("boom")):
+            # Should not raise
+            FunctionWrapper._patch_framework_references(mod, original, wrapper)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/contract-tests/images/applications/di-fastapi/Dockerfile
+++ b/contract-tests/images/applications/di-fastapi/Dockerfile
@@ -1,0 +1,12 @@
+ARG PYTHON_VERSION=3.12
+FROM python:${PYTHON_VERSION}
+WORKDIR /di-fastapi
+COPY ./dist/$DISTRO /di-fastapi
+COPY ./contract-tests/images/applications/di-fastapi /di-fastapi
+
+ENV PIP_ROOT_USER_ACTION=ignore
+ARG DISTRO
+RUN pip install --upgrade pip && pip install -r requirements.txt && pip install "${DISTRO}[debugger]" --force-reinstall
+RUN opentelemetry-bootstrap -a install
+
+CMD ["opentelemetry-instrument", "python", "-u", "./di_fastapi_server.py"]

--- a/contract-tests/images/applications/di-fastapi/di_fastapi_server.py
+++ b/contract-tests/images/applications/di-fastapi/di_fastapi_server.py
@@ -1,0 +1,513 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""FastAPI app for DI contract tests.
+
+Starts a mock DI API on port 3030, then runs the FastAPI app on port 8080.
+The DI poller will fetch breakpoint/probe configs from the mock API.
+
+Mirrors di_flask_server.py so the same DI assertions apply, and additionally
+exercises the async instrumentation path with `async def` target functions
+(process_data_async, compute_total_async) -- something a synchronous Flask app
+cannot cover.
+"""
+
+import inspect
+import logging
+import time
+
+import uvicorn
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse, PlainTextResponse
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Target functions (defined before configs so we can inspect line numbers)
+# ---------------------------------------------------------------------------
+
+
+def process_data(value):
+    """Target function for BREAKPOINT instrumentation (function-level)."""
+    result = value * 2
+    time.sleep(0.01)
+    return result
+
+
+def compute_total(items):
+    """Target function for PROBE instrumentation (method-level only)."""
+    total = 0
+    for item in items:
+        total += item
+    return total
+
+
+def calculate_sum(a, b):
+    result = a + b  # line-level breakpoint target
+    return result
+
+
+# Resolve the actual line number for the line-level breakpoint dynamically.
+# This avoids hardcoding a line number that breaks when the file is edited.
+_CALCULATE_SUM_LINE = None
+_src_lines, _start = inspect.getsourcelines(calculate_sum)
+for _i, _line in enumerate(_src_lines):
+    if "result = a + b" in _line:
+        _CALCULATE_SUM_LINE = _start + _i
+        break
+assert _CALCULATE_SUM_LINE is not None, "Could not find 'result = a + b' in calculate_sum"
+
+
+def limited_function(x):
+    """Target function with hit limit (MaxHits=3).
+
+    MaxHits=3 means: allow 2 snapshots, disable at 3rd hit.
+    (The check is hit_count >= max_hits, so hit 1&2 pass, hit 3 is blocked.)
+    """
+    return x * 10
+
+
+def shared_function(data):
+    """Target function with BOTH PROBE and BREAKPOINT instrumentation.
+
+    Tests that both instrumentation types can coexist on the same function.
+    """
+    processed = data.upper() if isinstance(data, str) else str(data)
+    return processed
+
+
+def process_long_string(long_string):
+    """BREAKPOINT target for string truncation limit validation.
+
+    Config requests MaxStringLength=9999 which gets clamped to 255.
+    The input string is 500 chars, so the captured value should be truncated at 255.
+    """
+    return len(long_string)
+
+
+def process_large_collection(large_list):
+    """BREAKPOINT target for collection width limit validation.
+
+    Config requests MaxCollectionWidth=9999 which gets clamped to 20.
+    The input list has 50 elements, so only the first 20 should be captured.
+    """
+    return len(large_list)
+
+
+async def process_data_async(value):
+    """Async target for function-level BREAKPOINT instrumentation.
+
+    Verifies DI correctly wraps an `async def` coroutine (awaits it and
+    returns the awaited result) rather than capturing an unawaited coroutine.
+    """
+    result = value * 2
+    return result
+
+
+async def compute_total_async(items):
+    """Async target for PROBE instrumentation (method-level only)."""
+    total = 0
+    for item in items:
+        total += item
+    return total
+
+
+# ---------------------------------------------------------------------------
+# Mock DI API configuration
+# ---------------------------------------------------------------------------
+
+from mock_di_api import set_breakpoint_configs, set_probe_configs, start_mock_api  # noqa: E402
+
+BREAKPOINT_CONFIGS = [
+    # Function-level breakpoint on process_data
+    {
+        "InstrumentationType": "BREAKPOINT",
+        "SignalType": "SNAPSHOT",
+        "Location": {
+            "CodeLocation": {
+                "Language": "Python",
+                "CodeUnit": "di_fastapi_server",
+                "MethodName": "process_data",
+                "FilePath": "di_fastapi_server.py",
+            }
+        },
+        "LocationHash": "aabb000000000001",
+        "CaptureConfiguration": {
+            "CodeCapture": {
+                "CaptureReturn": True,
+                "CaptureArguments": ["value"],
+                "CaptureLimits": {"MaxStringLength": 255},
+            }
+        },
+    },
+    # Line-level breakpoint on calculate_sum (captures locals at specific line)
+    {
+        "InstrumentationType": "BREAKPOINT",
+        "SignalType": "SNAPSHOT",
+        "Location": {
+            "CodeLocation": {
+                "Language": "Python",
+                "CodeUnit": "di_fastapi_server",
+                "MethodName": "calculate_sum",
+                "FilePath": "di_fastapi_server.py",
+                "LineNumber": _CALCULATE_SUM_LINE,
+            }
+        },
+        "LocationHash": "aabb000000000003",
+        "CaptureConfiguration": {
+            "CodeCapture": {
+                "CaptureLocals": True,
+                "CaptureLimits": {"MaxStringLength": 255},
+            }
+        },
+    },
+    # Breakpoint with low hit limit on limited_function
+    {
+        "InstrumentationType": "BREAKPOINT",
+        "SignalType": "SNAPSHOT",
+        "Location": {
+            "CodeLocation": {
+                "Language": "Python",
+                "CodeUnit": "di_fastapi_server",
+                "MethodName": "limited_function",
+                "FilePath": "di_fastapi_server.py",
+            }
+        },
+        "LocationHash": "aabb000000000004",
+        "CaptureConfiguration": {
+            "CodeCapture": {
+                "CaptureReturn": True,
+                "CaptureArguments": ["x"],
+                "CaptureLimits": {"MaxStringLength": 255, "MaxHits": 3},
+            }
+        },
+    },
+    # Breakpoint on shared_function (coexists with PROBE)
+    {
+        "InstrumentationType": "BREAKPOINT",
+        "SignalType": "SNAPSHOT",
+        "Location": {
+            "CodeLocation": {
+                "Language": "Python",
+                "CodeUnit": "di_fastapi_server",
+                "MethodName": "shared_function",
+                "FilePath": "di_fastapi_server.py",
+            }
+        },
+        "LocationHash": "aabb000000000005",
+        "CaptureConfiguration": {
+            "CodeCapture": {
+                "CaptureReturn": True,
+                "CaptureArguments": ["data"],
+                "CaptureLimits": {"MaxStringLength": 255},
+            }
+        },
+    },
+    # Breakpoint for string truncation limit validation (MaxStringLength=9999 -> clamped to 255)
+    {
+        "InstrumentationType": "BREAKPOINT",
+        "SignalType": "SNAPSHOT",
+        "Location": {
+            "CodeLocation": {
+                "Language": "Python",
+                "CodeUnit": "di_fastapi_server",
+                "MethodName": "process_long_string",
+                "FilePath": "di_fastapi_server.py",
+            }
+        },
+        "LocationHash": "aabb000000000007",
+        "CaptureConfiguration": {
+            "CodeCapture": {
+                "CaptureReturn": True,
+                "CaptureArguments": ["long_string"],
+                "CaptureLimits": {"MaxStringLength": 9999},
+            }
+        },
+    },
+    # Breakpoint for collection width limit validation (MaxCollectionWidth=9999 -> clamped to 20)
+    {
+        "InstrumentationType": "BREAKPOINT",
+        "SignalType": "SNAPSHOT",
+        "Location": {
+            "CodeLocation": {
+                "Language": "Python",
+                "CodeUnit": "di_fastapi_server",
+                "MethodName": "process_large_collection",
+                "FilePath": "di_fastapi_server.py",
+            }
+        },
+        "LocationHash": "aabb000000000008",
+        "CaptureConfiguration": {
+            "CodeCapture": {
+                "CaptureReturn": True,
+                "CaptureArguments": ["large_list"],
+                "CaptureLimits": {"MaxCollectionWidth": 9999},
+            }
+        },
+    },
+    # Function-level breakpoint on the async target process_data_async
+    {
+        "InstrumentationType": "BREAKPOINT",
+        "SignalType": "SNAPSHOT",
+        "Location": {
+            "CodeLocation": {
+                "Language": "Python",
+                "CodeUnit": "di_fastapi_server",
+                "MethodName": "process_data_async",
+                "FilePath": "di_fastapi_server.py",
+            }
+        },
+        "LocationHash": "aabb000000000009",
+        "CaptureConfiguration": {
+            "CodeCapture": {
+                "CaptureReturn": True,
+                "CaptureArguments": ["value"],
+                "CaptureLimits": {"MaxStringLength": 255},
+            }
+        },
+    },
+    # Breakpoint targeting a FastAPI ROUTE HANDLER directly.
+    # FastAPI captures a direct reference to the handler in its route table
+    # (APIRoute.endpoint / APIRoute.dependant.call) at decoration time, so
+    # replacing only the module-level name would not reach it. DI patches the
+    # FastAPI route table (mirroring its Flask app.view_functions patch), so a
+    # request routed by FastAPI now dispatches through the wrapper and a snapshot
+    # IS produced for this handler.
+    {
+        "InstrumentationType": "BREAKPOINT",
+        "SignalType": "SNAPSHOT",
+        "Location": {
+            "CodeLocation": {
+                "Language": "Python",
+                "CodeUnit": "di_fastapi_server",
+                "MethodName": "route_handler_target",
+                "FilePath": "di_fastapi_server.py",
+            }
+        },
+        "LocationHash": "aabb00000000000b",
+        "CaptureConfiguration": {
+            "CodeCapture": {
+                "CaptureReturn": True,
+                "CaptureArguments": ["multiplier"],
+                "CaptureLimits": {"MaxStringLength": 255},
+            }
+        },
+    },
+    # Breakpoint targeting a SYNC FastAPI route handler (isolation: sync vs async dispatch).
+    {
+        "InstrumentationType": "BREAKPOINT",
+        "SignalType": "SNAPSHOT",
+        "Location": {
+            "CodeLocation": {
+                "Language": "Python",
+                "CodeUnit": "di_fastapi_server",
+                "MethodName": "route_handler_target_sync",
+                "FilePath": "di_fastapi_server.py",
+            }
+        },
+        "LocationHash": "aabb00000000000c",
+        "CaptureConfiguration": {
+            "CodeCapture": {
+                "CaptureReturn": True,
+                "CaptureArguments": ["multiplier"],
+                "CaptureLimits": {"MaxStringLength": 255},
+            }
+        },
+    },
+]
+
+PROBE_CONFIGS = [
+    # PROBE on compute_total
+    {
+        "InstrumentationType": "PROBE",
+        "InstrumentationName": "compute-total-probe",
+        "SignalType": "SNAPSHOT",
+        "Location": {
+            "CodeLocation": {
+                "Language": "Python",
+                "CodeUnit": "di_fastapi_server",
+                "MethodName": "compute_total",
+                "FilePath": "di_fastapi_server.py",
+            }
+        },
+        "LocationHash": "aabb000000000002",
+        "CaptureConfiguration": {
+            "CodeCapture": {
+                "CaptureReturn": True,
+                "CaptureArguments": ["items"],
+                "CaptureLimits": {"MaxStringLength": 255},
+            }
+        },
+    },
+    # PROBE on shared_function (coexists with BREAKPOINT)
+    {
+        "InstrumentationType": "PROBE",
+        "InstrumentationName": "shared-function-probe",
+        "SignalType": "SNAPSHOT",
+        "Location": {
+            "CodeLocation": {
+                "Language": "Python",
+                "CodeUnit": "di_fastapi_server",
+                "MethodName": "shared_function",
+                "FilePath": "di_fastapi_server.py",
+            }
+        },
+        "LocationHash": "aabb000000000006",
+        "CaptureConfiguration": {
+            "CodeCapture": {
+                "CaptureReturn": True,
+                "CaptureArguments": ["data"],
+                "CaptureLimits": {"MaxStringLength": 255},
+            }
+        },
+    },
+    # PROBE on the async target compute_total_async
+    {
+        "InstrumentationType": "PROBE",
+        "InstrumentationName": "compute-total-async-probe",
+        "SignalType": "SNAPSHOT",
+        "Location": {
+            "CodeLocation": {
+                "Language": "Python",
+                "CodeUnit": "di_fastapi_server",
+                "MethodName": "compute_total_async",
+                "FilePath": "di_fastapi_server.py",
+            }
+        },
+        "LocationHash": "aabb00000000000a",
+        "CaptureConfiguration": {
+            "CodeCapture": {
+                "CaptureReturn": True,
+                "CaptureArguments": ["items"],
+                "CaptureLimits": {"MaxStringLength": 255},
+            }
+        },
+    },
+]
+
+set_breakpoint_configs(BREAKPOINT_CONFIGS)
+set_probe_configs(PROBE_CONFIGS)
+start_mock_api(port=3030)
+logger.info("Mock DI API started on port 3030 (line-level target line: %d)", _CALCULATE_SUM_LINE)
+
+
+# ---------------------------------------------------------------------------
+# FastAPI application
+# ---------------------------------------------------------------------------
+
+app = FastAPI()
+
+
+@app.get("/health")
+async def health():
+    return PlainTextResponse("Ready")
+
+
+@app.get("/success")
+async def success():
+    result = process_data(42)
+    return {"status": "ok", "result": result}
+
+
+@app.get("/probe")
+async def probe_endpoint():
+    """Endpoint that triggers PROBE-instrumented function."""
+    total = compute_total([10, 20, 30])
+    return {"status": "ok", "total": total}
+
+
+@app.get("/line-level")
+async def line_level_endpoint():
+    """Endpoint that triggers line-level BREAKPOINT instrumented function."""
+    result = calculate_sum(5, 7)
+    return {"status": "ok", "sum": result}
+
+
+@app.get("/limited")
+async def limited_endpoint():
+    """Endpoint that triggers hit-limited BREAKPOINT instrumented function."""
+    result = limited_function(3)
+    return {"status": "ok", "result": result}
+
+
+@app.get("/shared")
+async def shared_endpoint():
+    """Endpoint that triggers function with both PROBE and BREAKPOINT."""
+    result = shared_function("hello")
+    return {"status": "ok", "result": result}
+
+
+@app.get("/limits-string")
+async def limits_string_endpoint():
+    """Endpoint that triggers string truncation limit validation."""
+    long_string = "A" * 500
+    result = process_long_string(long_string)
+    return {"status": "ok", "length": result}
+
+
+@app.get("/limits-collection")
+async def limits_collection_endpoint():
+    """Endpoint that triggers collection width limit validation."""
+    large_list = list(range(1, 51))
+    result = process_large_collection(large_list)
+    return {"status": "ok", "size": result}
+
+
+@app.get("/success-async")
+async def success_async_endpoint():
+    """Endpoint that triggers an async BREAKPOINT-instrumented function."""
+    result = await process_data_async(42)
+    return {"status": "ok", "result": result}
+
+
+@app.get("/probe-async")
+async def probe_async_endpoint():
+    """Endpoint that triggers an async PROBE-instrumented function."""
+    total = await compute_total_async([10, 20, 30])
+    return {"status": "ok", "total": total}
+
+
+@app.get("/route-handler-target")
+async def route_handler_target(multiplier: int = 2):
+    """Async route handler that is ITSELF a DI BREAKPOINT target.
+
+    DI is configured (LocationHash aabb00000000000b) to instrument this very
+    handler. FastAPI holds its own reference to the handler in the route table
+    (APIRoute.endpoint / APIRoute.dependant.call) captured at decoration time;
+    DI patches that route table, so the wrapper is invoked when FastAPI routes
+    the request and a snapshot IS produced. The body is fully self-contained
+    (it does not call any other instrumented function) so a snapshot attributed
+    to "route_handler_target" unambiguously came from instrumenting the handler.
+    """
+    result = multiplier * 21
+    return {"status": "ok", "result": result}
+
+
+@app.get("/route-handler-target-sync")
+def route_handler_target_sync(multiplier: int = 2):
+    """SYNC route handler that is itself a DI BREAKPOINT target.
+
+    FastAPI runs sync handlers in a threadpool (vs async handlers on the event
+    loop), so this exercises a different dispatch path than the async route
+    handler above while using the same DI route-table patch. A snapshot IS
+    produced for this handler.
+    """
+    result = multiplier * 21
+    return {"status": "ok", "result": result}
+
+
+@app.get("/error")
+async def error():
+    return JSONResponse(status_code=400, content={"error": "bad request"})
+
+
+@app.get("/fault")
+async def fault():
+    process_data(-1)
+    raise RuntimeError("Intentional fault")
+
+
+if __name__ == "__main__":
+    print("Ready", flush=True)
+    uvicorn.run(app, host="0.0.0.0", port=8080, log_level="info")

--- a/contract-tests/images/applications/di-fastapi/mock_di_api.py
+++ b/contract-tests/images/applications/di-fastapi/mock_di_api.py
@@ -1,0 +1,85 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Mock DI API server that serves instrumentation configurations.
+
+Runs alongside the FastAPI app inside the same container, providing
+/list-instrumentation-configurations and /report-instrumentation-configuration-status
+endpoints that the DI poller calls.
+"""
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+PROBE_CONFIGS = []
+BREAKPOINT_CONFIGS = []
+STATUS_REPORTS = []
+
+
+def set_probe_configs(configs):
+    global PROBE_CONFIGS
+    PROBE_CONFIGS = configs
+
+
+def set_breakpoint_configs(configs):
+    global BREAKPOINT_CONFIGS
+    BREAKPOINT_CONFIGS = configs
+
+
+def set_configs(configs):
+    """Legacy: set all configs (treated as breakpoints for backward compatibility)."""
+    set_breakpoint_configs(configs)
+
+
+class MockDIHandler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        content_length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(content_length) if content_length else b""
+
+        if self.path == "/list-instrumentation-configurations":
+            self._handle_list(body)
+        elif self.path == "/report-instrumentation-configuration-status":
+            self._handle_status_report(body)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def _handle_list(self, body):
+        payload = json.loads(body) if body else {}
+        instrumentation_type = payload.get("InstrumentationType", "BREAKPOINT")
+
+        if instrumentation_type == "PROBE":
+            configs = PROBE_CONFIGS
+        else:
+            configs = BREAKPOINT_CONFIGS
+
+        response = {
+            "Changed": True,
+            "Service": payload.get("Service", ""),
+            "Environment": payload.get("Environment", ""),
+            "LatestConfigurations": configs,
+            "NextToken": None,
+            "SyncInterval": 10,
+        }
+        self._send_json(200, response)
+
+    def _handle_status_report(self, body):
+        if body:
+            STATUS_REPORTS.append(json.loads(body))
+        self._send_json(200, {"message": "ok"})
+
+    def _send_json(self, code, data):
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(data).encode())
+
+    def log_message(self, format, *args):
+        pass  # Suppress request logs
+
+
+def start_mock_api(port=3030):
+    server = HTTPServer(("0.0.0.0", port), MockDIHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server

--- a/contract-tests/images/applications/di-fastapi/requirements.txt
+++ b/contract-tests/images/applications/di-fastapi/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/contract-tests/tests/test/amazon/di/di_contract_test_base.py
+++ b/contract-tests/tests/test/amazon/di/di_contract_test_base.py
@@ -200,6 +200,29 @@ class DITestInfrastructure(TestCase):
             self.fail(f"Timed out waiting for {min_count} snapshot(s). Found {len(logs)} after {timeout}s.")
         return logs
 
+    def wait_for_method_snapshots(self, method_name: str, min_count: int = 1, timeout: float = DI_WAIT_TIMEOUT) -> List:
+        """Poll until at least min_count snapshots for a specific method are present.
+
+        Unlike wait_for_snapshots (which returns as soon as ANY snapshot arrives),
+        this waits for the named method's snapshots specifically. Necessary because
+        the OTLP logs use a batch processor, so a given function's snapshot may flush
+        slightly later than another's.
+        """
+        start = time.time()
+        method_logs: List = []
+        while time.time() - start < timeout:
+            method_logs = self.logs_for_method(self._peek_snapshots(), method_name)
+            if len(method_logs) >= min_count:
+                return method_logs
+            time.sleep(DI_POLL_SLEEP)
+        method_logs = self.logs_for_method(self._peek_snapshots(), method_name)
+        if len(method_logs) < min_count:
+            self.fail(
+                f"Timed out waiting for {min_count} snapshot(s) for method '{method_name}'. "
+                f"Found {len(method_logs)} after {timeout}s."
+            )
+        return method_logs
+
     def logs_for_method(self, logs: List, method_name: str) -> List:
         """Filter snapshot LogRecords by aws.di.method_name attribute."""
         return [log for log in logs if self.attrs(log).get("aws.di.method_name") == method_name]

--- a/contract-tests/tests/test/amazon/di/fastapi_test.py
+++ b/contract-tests/tests/test/amazon/di/fastapi_test.py
@@ -1,0 +1,655 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""DI contract tests for FastAPI application.
+
+Mirrors flask_test.py to verify that DI instruments functions in a FastAPI
+process, emits snapshots as OTLP LogRecords to the mock collector, and that
+attributes/body/trace context are populated.
+
+In addition to the synchronous targets shared with the Flask suite, this file
+adds DIFastAPIAsyncTest, which verifies the async instrumentation path:
+DI must correctly wrap `async def` targets (await the coroutine and capture the
+awaited result) -- something the synchronous Flask app cannot exercise.
+
+All test classes follow the same OTLP-based pattern as the trace/metrics tests:
+- Snapshots are OTLP LogRecords queried from the mock collector via gRPC
+- Flat attributes (aws.di.*) are used for filtering and queryable assertions
+- Structured body (captures, stack) is used for data content assertions
+"""
+
+import time
+from typing import Dict
+
+from typing_extensions import override
+
+from amazon.di.di_contract_test_base import DITestInfrastructure
+
+_APP_IMAGE = "aws-application-signals-tests-di-fastapi-app"
+_CODE_UNIT = "di_fastapi_server"
+
+
+# =============================================================================
+# Function-level BREAKPOINT tests
+# =============================================================================
+
+
+class DIFastAPIFunctionLevelTest(DITestInfrastructure):
+    """Function-level breakpoint (line=0) produces a method-level snapshot."""
+
+    __test__ = True
+
+    @override
+    @staticmethod
+    def get_application_image_name() -> str:
+        return _APP_IMAGE
+
+    @override
+    def get_application_wait_pattern(self) -> str:
+        return "Ready"
+
+    def test_function_level_snapshot_generated(self) -> None:
+        """Function-level breakpoint generates snapshot with captures.entry/return in body."""
+        response = self.send_request("GET", "success")
+        self.assertEqual(200, response.status_code)
+
+        logs = self.wait_for_snapshots(min_count=1)
+        method_logs = self.logs_for_method(logs, "process_data")
+        self.assertGreater(len(method_logs), 0, "Expected OTLP snapshot for process_data")
+
+        log = method_logs[0]
+        self.assert_snapshot_attr(log, "aws.di.instrumentation_level", "method")
+        self.assert_body_has_entry_or_return(log)
+
+    def test_snapshot_has_trace_context(self) -> None:
+        """LogRecord should carry trace_id/span_id from the active OTel span."""
+        self.send_request("GET", "success")
+        logs = self.wait_for_snapshots(min_count=1)
+        self.assert_has_trace_context(logs[0])
+
+    def test_snapshot_has_instrumentation_location(self) -> None:
+        """Snapshot attributes should carry location info."""
+        self.send_request("GET", "success")
+        logs = self.wait_for_snapshots(min_count=1)
+        self.assert_snapshot_has_attr(logs[0], "aws.di.method_name")
+        self.assert_snapshot_has_attr(logs[0], "aws.di.code_unit")
+        self.assert_snapshot_has_attr(logs[0], "aws.di.snapshot_id")
+
+    def test_snapshot_has_stack_frames(self) -> None:
+        """Snapshot body should carry stack frames."""
+        self.send_request("GET", "success")
+        logs = self.wait_for_snapshots(min_count=1)
+        self.assert_body_has_stack(logs[0])
+
+    def test_snapshot_event_name(self) -> None:
+        """event.name attribute must be 'aws.dynamic_instrumentation.snapshot'."""
+        self.send_request("GET", "success")
+        logs = self.wait_for_snapshots(min_count=1)
+        self.assert_snapshot_attr(logs[0], "event.name", "aws.dynamic_instrumentation.snapshot")
+
+    def test_multiple_requests_generate_multiple_snapshots(self) -> None:
+        """Multiple requests should generate multiple snapshots (up to rate limit)."""
+        for _ in range(3):
+            self.send_request("GET", "success")
+
+        logs = self.wait_for_snapshots(min_count=3)
+        method_logs = self.logs_for_method(logs, "process_data")
+        self.assertGreaterEqual(len(method_logs), 3)
+
+
+# =============================================================================
+# PROBE instrumentation tests
+# =============================================================================
+
+
+class DIFastAPIProbeTest(DITestInfrastructure):
+    """Test PROBE instrumentation (permanent, method-level only, no hit limit)."""
+
+    __test__ = True
+
+    @override
+    @staticmethod
+    def get_application_image_name() -> str:
+        return _APP_IMAGE
+
+    @override
+    def get_application_wait_pattern(self) -> str:
+        return "Ready"
+
+    def test_probe_creates_snapshot(self) -> None:
+        """PROBE instrumentation creates a method-level snapshot with entry/return captures."""
+        response = self.send_request("GET", "probe")
+        self.assertEqual(200, response.status_code)
+
+        logs = self.wait_for_snapshots(min_count=1)
+        probe_logs = self.logs_for_method(logs, "compute_total")
+        self.assertGreater(len(probe_logs), 0, "Expected snapshot for compute_total (PROBE)")
+
+        log = probe_logs[0]
+        self.assert_snapshot_attr(log, "aws.di.instrumentation_level", "method")
+        self.assert_body_has_entry_or_return(log)
+
+    def test_probe_snapshot_has_location(self) -> None:
+        """PROBE snapshot has correct instrumentation location attributes."""
+        self.send_request("GET", "probe")
+        logs = self.wait_for_snapshots(min_count=1)
+        log = self.logs_for_method(logs, "compute_total")[0]
+
+        self.assert_snapshot_attr(log, "aws.di.code_unit", _CODE_UNIT)
+        self.assert_snapshot_attr(log, "aws.di.method_name", "compute_total")
+
+    def test_probe_snapshot_has_trace_context(self) -> None:
+        """PROBE snapshot includes trace context."""
+        self.send_request("GET", "probe")
+        logs = self.wait_for_snapshots(min_count=1)
+        self.assert_has_trace_context(self.logs_for_method(logs, "compute_total")[0])
+
+    def test_probe_captures_arguments(self) -> None:
+        """PROBE snapshot captures function arguments."""
+        self.send_request("GET", "probe")
+        logs = self.wait_for_snapshots(min_count=1)
+        log = self.logs_for_method(logs, "compute_total")[0]
+
+        body = self.body(log)
+        captures = body.get("captures", {})
+        entry = captures.get("entry", {})
+        arguments = entry.get("arguments", {})
+        self.assertIn("items", arguments, "Expected 'items' argument to be captured")
+
+    def test_probe_captures_return_value(self) -> None:
+        """PROBE snapshot captures return value."""
+        self.send_request("GET", "probe")
+        logs = self.wait_for_snapshots(min_count=1)
+        log = self.logs_for_method(logs, "compute_total")[0]
+
+        body = self.body(log)
+        captures = body.get("captures", {})
+        return_ctx = captures.get("return", {})
+        return_value = return_ctx.get("return_value", {})
+        self.assertEqual(return_value.get("type"), "int")
+        self.assertEqual(return_value.get("value"), "60")
+
+    def test_probe_and_breakpoint_coexist_on_different_functions(self) -> None:
+        """PROBE and BREAKPOINT generate snapshots for different functions."""
+        self.send_request("GET", "success")  # triggers BREAKPOINT on process_data
+        self.send_request("GET", "probe")  # triggers PROBE on compute_total
+
+        logs = self.wait_for_snapshots(min_count=2)
+        breakpoint_logs = self.logs_for_method(logs, "process_data")
+        probe_logs = self.logs_for_method(logs, "compute_total")
+
+        self.assertGreater(len(breakpoint_logs), 0, "Expected BREAKPOINT snapshot for process_data")
+        self.assertGreater(len(probe_logs), 0, "Expected PROBE snapshot for compute_total")
+
+    def test_probe_no_hit_limit(self) -> None:
+        """PROBE generates snapshots on multiple invocations (no hit limit)."""
+        for _ in range(5):
+            self.send_request("GET", "probe")
+            time.sleep(0.2)
+
+        logs = self.wait_for_snapshots(min_count=5)
+        probe_logs = self.logs_for_method(logs, "compute_total")
+        self.assertGreaterEqual(len(probe_logs), 5, "PROBE should have no hit limit")
+
+
+# =============================================================================
+# Line-level BREAKPOINT tests
+# =============================================================================
+
+
+class DIFastAPILineLevelTest(DITestInfrastructure):
+    """Test line-level BREAKPOINT instrumentation (lineNumber > 0).
+
+    Line-level breakpoints capture local variables at a specific line,
+    rather than entry/return captures for function-level breakpoints.
+    """
+
+    __test__ = True
+
+    @override
+    @staticmethod
+    def get_application_image_name() -> str:
+        return _APP_IMAGE
+
+    @override
+    def get_application_wait_pattern(self) -> str:
+        return "Ready"
+
+    def test_line_level_snapshot_generated(self) -> None:
+        """Line-level breakpoint generates snapshot with instrumentation_level=line."""
+        response = self.send_request("GET", "line-level")
+        self.assertEqual(200, response.status_code)
+
+        logs = self.wait_for_snapshots(min_count=1)
+        line_logs = self.logs_for_method(logs, "calculate_sum")
+        self.assertGreater(len(line_logs), 0, "Expected snapshot for calculate_sum")
+
+        log = line_logs[0]
+        self.assert_snapshot_attr(log, "aws.di.instrumentation_level", "line")
+        self.assert_snapshot_has_attr(log, "aws.di.line_number")
+
+    def test_line_level_snapshot_has_captures_lines(self) -> None:
+        """Line-level snapshot has captures.lines with local variables."""
+        self.send_request("GET", "line-level")
+        logs = self.wait_for_snapshots(min_count=1)
+        log = self.logs_for_method(logs, "calculate_sum")[0]
+        self.assert_body_has_lines_capture(log)
+
+    def test_line_level_captures_locals(self) -> None:
+        """Line-level snapshot captures local variables at the breakpoint line."""
+        self.send_request("GET", "line-level")
+        logs = self.wait_for_snapshots(min_count=1)
+        log = self.logs_for_method(logs, "calculate_sum")[0]
+
+        body = self.body(log)
+        captures = body.get("captures", {})
+        lines = captures.get("lines", {})
+        # Get the first (and only) line capture
+        line_key = list(lines.keys())[0]
+        line_capture = lines[line_key]
+        locals_captured = line_capture.get("locals", {})
+        # At minimum, function arguments should be available as locals
+        self.assertTrue(
+            "a" in locals_captured or "b" in locals_captured or "result" in locals_captured,
+            f"Expected local variables (a, b, or result), got: {list(locals_captured.keys())}",
+        )
+
+    def test_line_level_differs_from_function_level(self) -> None:
+        """Line-level and function-level snapshots have different capture structures."""
+        self.send_request("GET", "success")  # function-level
+        self.send_request("GET", "line-level")  # line-level
+
+        logs = self.wait_for_snapshots(min_count=2)
+        func_logs = self.logs_for_method(logs, "process_data")
+        line_logs = self.logs_for_method(logs, "calculate_sum")
+
+        self.assertGreater(len(func_logs), 0)
+        self.assertGreater(len(line_logs), 0)
+
+        self.assert_snapshot_attr(func_logs[0], "aws.di.instrumentation_level", "method")
+        self.assert_snapshot_attr(line_logs[0], "aws.di.instrumentation_level", "line")
+
+
+# =============================================================================
+# Hit limit tests
+# =============================================================================
+
+
+class DIFastAPIHitLimitTest(DITestInfrastructure):
+    """Test BREAKPOINT hit limit behavior.
+
+    BREAKPOINTs have a max_hits limit. With MaxHits=3, the check is
+    hit_count >= max_hits, so hits 1 and 2 generate snapshots, hit 3 is blocked.
+    """
+
+    __test__ = True
+
+    @override
+    @staticmethod
+    def get_application_image_name() -> str:
+        return _APP_IMAGE
+
+    @override
+    def get_application_wait_pattern(self) -> str:
+        return "Ready"
+
+    def test_breakpoint_generates_snapshots_up_to_limit(self) -> None:
+        """BREAKPOINT generates snapshots up to (max_hits - 1)."""
+        # limited_function has MaxHits=3, so 2 snapshots should be generated
+        self.send_request("GET", "limited")
+        self.send_request("GET", "limited")
+
+        logs = self.wait_for_snapshots(min_count=2)
+        limited_logs = self.logs_for_method(logs, "limited_function")
+        self.assertEqual(len(limited_logs), 2, "Expected exactly 2 snapshots (MaxHits=3 allows 2)")
+
+    def test_breakpoint_disabled_after_hit_limit(self) -> None:
+        """BREAKPOINT stops generating snapshots after hit limit is reached."""
+        # First 2 calls generate snapshots (hits 1 and 2)
+        self.send_request("GET", "limited")
+        self.send_request("GET", "limited")
+
+        logs = self.wait_for_snapshots(min_count=2)
+        initial_count = len(self.logs_for_method(logs, "limited_function"))
+        self.assertEqual(initial_count, 2)
+
+        # 3rd and 4th calls hit the limit -- no new snapshots
+        self.send_request("GET", "limited")
+        self.send_request("GET", "limited")
+        time.sleep(2)
+
+        final_logs = self._peek_snapshots()
+        final_count = len(self.logs_for_method(final_logs, "limited_function"))
+        self.assertEqual(
+            final_count,
+            2,
+            f"Expected 2 snapshots (MaxHits=3), but got {final_count}. "
+            "BREAKPOINT should be disabled after hitting limit.",
+        )
+
+
+# =============================================================================
+# PROBE + BREAKPOINT coexistence on same function
+# =============================================================================
+
+
+class DIFastAPICoexistenceTest(DITestInfrastructure):
+    """Test PROBE and BREAKPOINT coexistence on the same function.
+
+    Current DI merges PROBE+BREAKPOINT on the same function into a single
+    wrapper that generates one snapshot per invocation. This tests that both
+    config types are accepted and the function works correctly.
+    """
+
+    __test__ = True
+
+    @override
+    @staticmethod
+    def get_application_image_name() -> str:
+        return _APP_IMAGE
+
+    @override
+    def get_application_wait_pattern(self) -> str:
+        return "Ready"
+
+    def test_shared_function_is_instrumented(self) -> None:
+        """Function with both PROBE and BREAKPOINT configs generates snapshots."""
+        response = self.send_request("GET", "shared")
+        self.assertEqual(200, response.status_code)
+
+        logs = self.wait_for_snapshots(min_count=1)
+        shared_logs = self.logs_for_method(logs, "shared_function")
+        self.assertGreaterEqual(len(shared_logs), 1, "Expected snapshot for shared_function")
+
+    def test_shared_function_has_location_hash(self) -> None:
+        """Snapshot from shared function has a valid locationHash."""
+        self.send_request("GET", "shared")
+        logs = self.wait_for_snapshots(min_count=1)
+        log = self.logs_for_method(logs, "shared_function")[0]
+
+        self.assert_snapshot_has_attr(log, "aws.di.location_hash")
+        location_hash = self.attrs(log).get("aws.di.location_hash")
+        self.assertIn(
+            location_hash,
+            ["aabb000000000005", "aabb000000000006"],
+            f"locationHash should be from PROBE or BREAKPOINT config, got: {location_hash}",
+        )
+
+    def test_shared_function_multiple_invocations(self) -> None:
+        """Shared function generates snapshots on multiple invocations."""
+        for _ in range(3):
+            self.send_request("GET", "shared")
+            time.sleep(0.2)
+
+        logs = self.wait_for_snapshots(min_count=3)
+        shared_logs = self.logs_for_method(logs, "shared_function")
+        self.assertGreaterEqual(len(shared_logs), 3, f"Expected 3+ snapshots, got {len(shared_logs)}")
+
+
+# =============================================================================
+# Capture limit tests
+# =============================================================================
+
+
+class DIFastAPICaptureLimitsTest(DITestInfrastructure):
+    """Tests that DI capture limits are enforced correctly.
+
+    The breakpoint configs intentionally request limits above the allowed maximum
+    (e.g., MaxStringLength=9999, MaxCollectionWidth=9999). The agent must clamp these
+    to the enforced maximums.
+
+    Current enforced maximums (from _data_models.py):
+        MAX_MAX_STRING_LENGTH = 255
+        MAX_MAX_COLLECTION_WIDTH = 20
+    """
+
+    __test__ = True
+
+    # Enforced maximums -- update these if CaptureConfig limits change
+    ENFORCED_MAX_STRING_LENGTH = 255
+    ENFORCED_MAX_COLLECTION_WIDTH = 20
+
+    @override
+    @staticmethod
+    def get_application_image_name() -> str:
+        return _APP_IMAGE
+
+    @override
+    def get_application_wait_pattern(self) -> str:
+        return "Ready"
+
+    def test_string_value_truncated_at_enforced_maximum(self) -> None:
+        """String argument should be truncated at ENFORCED_MAX_STRING_LENGTH (255)."""
+        self.send_request("GET", "limits-string")
+        logs = self.wait_for_snapshots(min_count=1)
+        log = self.logs_for_method(logs, "process_long_string")[0]
+
+        body = self.body(log)
+        captures = body.get("captures", {})
+        entry = captures.get("entry", {})
+        arguments = entry.get("arguments", {})
+        long_string_arg = arguments.get("long_string", {})
+
+        self.assertIsNotNone(long_string_arg, "Expected 'long_string' argument to be captured")
+
+        captured_value = long_string_arg.get("value")
+        self.assertIsNotNone(captured_value, "Captured string value should not be None")
+        self.assertEqual(
+            len(captured_value),
+            self.ENFORCED_MAX_STRING_LENGTH,
+            f"String should be truncated at enforced max {self.ENFORCED_MAX_STRING_LENGTH}, "
+            f"but was {len(captured_value)}.",
+        )
+        self.assertTrue(long_string_arg.get("truncated", False), "Captured string should be marked as truncated")
+
+    def test_collection_elements_capped_at_enforced_maximum(self) -> None:
+        """Collection argument should be capped at ENFORCED_MAX_COLLECTION_WIDTH (20) elements."""
+        self.send_request("GET", "limits-collection")
+        logs = self.wait_for_snapshots(min_count=1)
+        log = self.logs_for_method(logs, "process_large_collection")[0]
+
+        body = self.body(log)
+        captures = body.get("captures", {})
+        entry = captures.get("entry", {})
+        arguments = entry.get("arguments", {})
+        large_list_arg = arguments.get("large_list", {})
+
+        self.assertIsNotNone(large_list_arg, "Expected 'large_list' argument to be captured")
+
+        elements = large_list_arg.get("elements", [])
+        self.assertIsNotNone(elements, "Captured collection should have 'elements'")
+        self.assertEqual(
+            len(elements),
+            self.ENFORCED_MAX_COLLECTION_WIDTH,
+            f"Collection should be capped at enforced max {self.ENFORCED_MAX_COLLECTION_WIDTH} elements, "
+            f"but had {len(elements)}.",
+        )
+
+        size = large_list_arg.get("size")
+        self.assertIsNotNone(size, "Captured collection should report original size")
+        self.assertEqual(size, 50, "Original collection size should be 50")
+
+
+# =============================================================================
+# Async function instrumentation tests (FastAPI-specific coverage)
+# =============================================================================
+
+
+class DIFastAPIAsyncTest(DITestInfrastructure):
+    """Test DI instrumentation of `async def` target functions.
+
+    This is the coverage that Flask cannot provide: DI must wrap an async
+    function such that it awaits the coroutine and captures the awaited result,
+    rather than capturing an unawaited coroutine object. Both an async
+    function-level BREAKPOINT (process_data_async) and an async PROBE
+    (compute_total_async) are exercised.
+    """
+
+    __test__ = True
+
+    @override
+    @staticmethod
+    def get_application_image_name() -> str:
+        return _APP_IMAGE
+
+    @override
+    def get_application_wait_pattern(self) -> str:
+        return "Ready"
+
+    def test_async_function_level_snapshot_generated(self) -> None:
+        """Async function-level BREAKPOINT generates a method-level snapshot with captures."""
+        response = self.send_request("GET", "success-async")
+        self.assertEqual(200, response.status_code)
+        # The wrapper must await the coroutine and return the real result.
+        self.assertEqual(response.json().get("result"), 84)
+
+        logs = self.wait_for_snapshots(min_count=1)
+        method_logs = self.logs_for_method(logs, "process_data_async")
+        self.assertGreater(len(method_logs), 0, "Expected snapshot for process_data_async (async BREAKPOINT)")
+
+        log = method_logs[0]
+        self.assert_snapshot_attr(log, "aws.di.instrumentation_level", "method")
+        self.assert_snapshot_attr(log, "aws.di.code_unit", _CODE_UNIT)
+        self.assert_body_has_entry_or_return(log)
+
+    def test_async_probe_creates_snapshot(self) -> None:
+        """Async PROBE captures arguments and the awaited return value."""
+        response = self.send_request("GET", "probe-async")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(response.json().get("total"), 60)
+
+        logs = self.wait_for_snapshots(min_count=1)
+        probe_logs = self.logs_for_method(logs, "compute_total_async")
+        self.assertGreater(len(probe_logs), 0, "Expected snapshot for compute_total_async (async PROBE)")
+
+        log = probe_logs[0]
+        self.assert_snapshot_attr(log, "aws.di.instrumentation_level", "method")
+
+        body = self.body(log)
+        captures = body.get("captures", {})
+        entry = captures.get("entry", {})
+        arguments = entry.get("arguments", {})
+        self.assertIn("items", arguments, "Expected 'items' argument to be captured")
+
+        # The awaited result (not a coroutine object) should be captured.
+        return_value = captures.get("return", {}).get("return_value", {})
+        self.assertEqual(return_value.get("type"), "int")
+        self.assertEqual(return_value.get("value"), "60")
+
+    def test_async_snapshot_has_trace_context(self) -> None:
+        """Async snapshot carries trace context propagated through the async wrapper."""
+        self.send_request("GET", "success-async")
+        logs = self.wait_for_snapshots(min_count=1)
+        log = self.logs_for_method(logs, "process_data_async")[0]
+        self.assert_has_trace_context(log)
+
+
+# =============================================================================
+# Route-handler instrumentation (DI patches FastAPI's route table)
+# =============================================================================
+
+
+class DIFastAPIRouteHandlerTest(DITestInfrastructure):
+    """Verifies that DI instruments FastAPI route handlers directly.
+
+    FastAPI captures a direct reference to each route handler in its route table
+    (APIRoute.endpoint, and the dispatched APIRoute.dependant.call) when the
+    @app.get(...) decorator runs at import time. Replacing only the module-level
+    name would not reach those references, so DI also patches the FastAPI route
+    table (mirroring its Flask app.view_functions patch). As a result, a request
+    routed by FastAPI now goes through the DI wrapper and a snapshot is produced.
+
+    Traces are enabled here (OTLP gRPC to the mock collector) so the route-handler
+    SERVER span is observable during the run; the assertion itself is snapshot-based.
+    """
+
+    __test__ = True
+
+    @override
+    @staticmethod
+    def get_application_image_name() -> str:
+        return _APP_IMAGE
+
+    @override
+    def get_application_wait_pattern(self) -> str:
+        return "Ready"
+
+    @override
+    def get_application_extra_environment_variables(self) -> Dict[str, str]:
+        # Enable the OTel traces exporter so FastAPI per-request SERVER spans are
+        # exported to the mock collector (gRPC 4315). This makes the route-handler
+        # span observable; the test assertion remains snapshot-based.
+        return {
+            "OTEL_TRACES_EXPORTER": "otlp",
+            "OTEL_EXPORTER_OTLP_PROTOCOL": "grpc",
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://collector:4315",
+        }
+
+    def test_route_handler_produces_snapshot(self) -> None:
+        """A route handler configured as a DI target produces a snapshot when hit via FastAPI."""
+        # Control: a plain (non-route-handler) instrumented function works, proving DI
+        # is active in this app/process and the mock collector is receiving snapshots.
+        control = self.send_request("GET", "success")
+        self.assertEqual(200, control.status_code)
+        self.wait_for_snapshots(min_count=1)
+
+        # Hit the route handler that is itself a DI target.
+        response = self.send_request("GET", "route-handler-target", params={"multiplier": 2})
+        self.assertEqual(200, response.status_code)
+        # The handler still runs normally (DI must never break the application).
+        self.assertEqual(response.json().get("result"), 42)
+
+        # Wait for the handler's own snapshot specifically (the OTLP batch processor may
+        # flush it slightly after the control function's snapshot).
+        handler_logs = self.wait_for_method_snapshots("route_handler_target", min_count=1)
+        self.assertGreater(
+            len(handler_logs),
+            0,
+            "Expected a snapshot for the FastAPI route handler 'route_handler_target' "
+            "(DI now patches FastAPI's route table).",
+        )
+
+        log = handler_logs[0]
+        self.assert_snapshot_attr(log, "aws.di.instrumentation_level", "method")
+        self.assert_snapshot_attr(log, "aws.di.code_unit", _CODE_UNIT)
+        self.assert_body_has_entry_or_return(log)
+
+        # The handler's argument should be captured.
+        body = self.body(log)
+        captures = body.get("captures", {})
+        entry = captures.get("entry", {})
+        arguments = entry.get("arguments", {})
+        self.assertIn("multiplier", arguments, "Expected 'multiplier' argument to be captured")
+
+
+class DIFastAPISyncRouteHandlerTest(DITestInfrastructure):
+    """Verifies DI instruments a SYNCHRONOUS FastAPI route handler.
+
+    FastAPI runs sync route handlers in a threadpool (vs async handlers on the
+    event loop), so this exercises a different dispatch path than the async
+    route-handler test while using the same route-table patch.
+    """
+
+    __test__ = True
+
+    @override
+    @staticmethod
+    def get_application_image_name() -> str:
+        return _APP_IMAGE
+
+    @override
+    def get_application_wait_pattern(self) -> str:
+        return "Ready"
+
+    def test_sync_route_handler_produces_snapshot(self) -> None:
+        resp = self.send_request("GET", "route-handler-target-sync", params={"multiplier": 2})
+        self.assertEqual(200, resp.status_code)
+        # The handler still runs normally (DI must never break the application).
+        self.assertEqual(resp.json().get("result"), 42)
+
+        handler_logs = self.wait_for_method_snapshots("route_handler_target_sync", min_count=1)
+        self.assertGreater(len(handler_logs), 0, "Expected a snapshot for the sync route handler")
+
+        log = handler_logs[0]
+        self.assert_snapshot_attr(log, "aws.di.instrumentation_level", "method")
+        self.assert_snapshot_attr(log, "aws.di.code_unit", _CODE_UNIT)
+        self.assert_body_has_entry_or_return(log)


### PR DESCRIPTION
## Problem

Dynamic Instrumentation (DI) instruments a function by rebinding the module-level name (`setattr(module, name, wrapper)`). That reaches callers who look the function up by name at call time, but **not** web-framework route handlers: when `@app.get(...)` runs at import time, FastAPI captures a direct reference to the handler in its route table (`APIRoute.endpoint`, and the dispatched `APIRoute.dependant.call`). The module-level rebind never reaches those references, so requests routed by FastAPI call the original unwrapped handler and **no snapshot is produced**.

DI already solves this for Flask by patching `app.view_functions`, but had no FastAPI equivalent.

## Fix

Add `_patch_fastapi_routes` / `_patch_single_fastapi_app`, dispatched from the existing `_patch_framework_references` (so both install **and** restore are symmetric — `restore_function` reuses the same path with swapped args).

For each `APIRoute` whose handler matches the target (identity match first, then a name+`__module__` fallback, mirroring the Flask precedent), rebind **both** `route.endpoint` and `route.dependant.call` (the attribute the dispatcher actually invokes). The already-built `Dependant` stays valid because the DI wrapper preserves the handler signature via `functools.wraps`, so no rebuild is needed. Per-route errors are isolated so patching can never break the application (SAFETY).

Works for both **sync** route handlers (run by FastAPI in a threadpool) and **async** handlers (event loop) — DI's existing sync/async wrapper selection composes with the route patch.

## Tests

- **Unit tests** (`test_function_wrapper_fastapi.py`) mirroring the Flask coverage: identity match, name+module fallback, no-op when FastAPI absent / no app / not-a-route, and integration via `_replace_function_in_module` and `restore_function`.
- **New `di-fastapi` contract-test app + suite** mirroring the Flask DI suite (function-level, probe, line-level, hit-limit, coexistence, capture-limits) plus async-function tests and **sync + async route-handler tests** that assert a snapshot is produced.
- Added `wait_for_method_snapshots(method_name, ...)` to the DI contract base to wait for a specific method's snapshot (avoids a batch-flush race where another function's snapshot arrives first).

## Verification

- Distro unit tests: 18/18 wrapper tests (9 FastAPI + 9 Flask) + 92 other wrapper tests pass; pylint 10.00/10; black clean.
- FastAPI DI contract suite: 29 passed.
- Flask DI contract suite (rebuilt on the patched wheel): 24 passed — no regression on the shared dispatch path.