### PR TITLE
serviceevents: remove adaptive sampling, default to always, cap call_path

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/collectors/incident_snapshot_collector.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/collectors/incident_snapshot_collector.py
@@ -35,11 +35,7 @@ from amazon.opentelemetry.distro.serviceevents.models import (
     ResourceAttributes,
     TelemetryCorrelation,
 )
-from amazon.opentelemetry.distro.serviceevents.python_monitor import (
-    _ServiceEventsMonitorState,
-    mark_operation_hot,
-    tick_hot_operations,
-)
+from amazon.opentelemetry.distro.serviceevents.python_monitor import _ServiceEventsMonitorState
 from amazon.opentelemetry.distro.serviceevents.utils import get_instance_id
 from opentelemetry import trace
 
@@ -348,13 +344,6 @@ class IncidentSnapshotCollector(BaseCollector):
         if trigger_type is None:
             return None
 
-        # Mark operation hot for adaptive sampling BEFORE dedup checks.
-        # This ensures the hot state is refreshed on every error occurrence,
-        # not just when a snapshot passes dedup. Without this, the hot state
-        # expires after ~16.7 min while dedup blocks snapshots for up to 60 min,
-        # causing the next allowed snapshot to be partial again.
-        mark_operation_hot(operation)
-
         # Generate error hash for deduplication
         error_hash = self._generate_error_hash(route, exception)
 
@@ -446,9 +435,6 @@ class IncidentSnapshotCollector(BaseCollector):
 
     def collect(self):
         """Collect pending snapshots and export to console."""
-        # Countdown hot operation cycles for adaptive sampling
-        tick_hot_operations()
-
         # Clear batch-level hashes for new collection cycle
         with self._error_hashes_lock:
             self._current_batch_hashes.clear()

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/config.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/config.py
@@ -207,19 +207,15 @@ class ServiceEventsConfig:
     # adds patterns to subtract from PACKAGES_INCLUDE.
     packages_exclude: List[str] = field(default_factory=list)  # OTEL_AWS_SERVICE_EVENTS_PACKAGES_EXCLUDE
 
-    # Sampling Mode: "adaptive" (hot endpoint), "auto" (tiered), "always" (100%), "never" (0%)
-    sampling_mode: str = "adaptive"  # OTEL_AWS_SERVICE_EVENTS_SAMPLING_MODE
+    # Sampling Mode: "auto" (tiered), "always" (100%), "never" (0%)
+    sampling_mode: str = "always"  # OTEL_AWS_SERVICE_EVENTS_SAMPLING_MODE
 
-    # Sampling Thresholds (for "auto" mode: 3-tier adaptive sampling). Internal: hardcoded, no env
+    # Sampling Thresholds (for "auto" mode: 3-tier sampling). Internal: hardcoded, no env
     # override (test hook may set them).
     sample_tier1_threshold: int = 100
     sample_tier2_threshold: int = 1000
     sample_tier2_rate: int = 10
     sample_tier3_rate: int = 100
-
-    # Adaptive sampling: number of collector flush cycles an endpoint stays "hot" after an incident.
-    # Internal: hardcoded, no env override.
-    hot_endpoint_cycles: int = 100
 
     # OTLP Export Settings. Empty here means "unset" — the 4316 default is applied
     # by the endpoint policy in aws_opentelemetry_configurator._init_serviceevents so it
@@ -405,7 +401,6 @@ class ServiceEventsConfig:
             sample_tier2_threshold=defaults.sample_tier2_threshold,
             sample_tier2_rate=defaults.sample_tier2_rate,
             sample_tier3_rate=defaults.sample_tier3_rate,
-            hot_endpoint_cycles=defaults.hot_endpoint_cycles,
             # OTLP Export Settings
             logs_endpoint=get_str("OTEL_AWS_OTLP_LOGS_ENDPOINT", defaults.logs_endpoint),
             metrics_endpoint=get_str("OTEL_AWS_OTLP_METRICS_ENDPOINT", defaults.metrics_endpoint),

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/instrumentation/fastapi_instrumentation.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/instrumentation/fastapi_instrumentation.py
@@ -108,12 +108,12 @@ def _resolve_route_template(scope) -> Optional[str]:
 
     At middleware entry ``scope["route"]`` is unset (routing happens inside the inner
     app), so the raw URL path is all that's available. But the per-request *operation*
-    (used for adaptive hot-endpoint sampling and incident correlation) and the endpoint
-    aggregation are both keyed on the route *template* (e.g. ``/users/{id}``). Without
-    resolving the template here, every distinct param value (``/users/1``, ``/users/2``)
-    would be a different operation, so adaptive sampling — which marks the *template*
-    hot — would never match, and FunctionCall sampling for param routes would silently
-    stay off.
+    (used for incident correlation) and the endpoint aggregation are both keyed on the
+    route *template* (e.g. ``/users/{id}``). Without resolving the template here, every
+    distinct param value (``/users/1``, ``/users/2``) would be a different operation, so
+    incident correlation and endpoint aggregation would shatter into per-value cardinality.
+    (Sampling does not depend on the operation: the default ``always`` mode samples every
+    call, and ``auto`` keys its tier counters on the function, not the route.)
 
     Starlette sets ``scope["app"]`` before the middleware stack runs, so its routes are
     available. We match the scope against them (the same matching the router does moments

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/python_monitor.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/python_monitor.py
@@ -27,12 +27,10 @@ from amazon.opentelemetry.distro.serviceevents.python_monitor_impl import (
     get_call_stack,
     get_current_operation,
     get_sampling_mode,
-    mark_operation_hot,
     reset_after_fork,
     set_current_operation,
     set_sampling_mode,
     set_sampling_thresholds,
-    tick_hot_operations,
 )
 
 # ============================================================================
@@ -54,7 +52,4 @@ __all__ = [
     # State management functions
     "reset_after_fork",
     "get_call_stack",
-    # Adaptive sampling functions
-    "mark_operation_hot",
-    "tick_hot_operations",
 ]

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/python_monitor_impl.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/python_monitor_impl.py
@@ -17,6 +17,16 @@ from typing import Dict, Optional
 
 from amazon.opentelemetry.distro.serviceevents.ast_transformation import get_function_info_unlocked
 
+# Hard cap on real call-path frames retained per request. The monitor records a frame for every
+# instrumented call (not just sampled ones), so under "auto"/"never" sampling a high-call-volume
+# request would otherwise grow this list without bound and could push a serialized IncidentSnapshot
+# past the 1 MB CloudWatch OTLP Logs limit. At ~150-250 B/frame, 1024 frames is ~256 KB — well under
+# the limit with room for the stack trace, yet far above any legitimate frame count. Java/JS match.
+_MAX_CALL_PATH_ENTRIES = 1024
+# Marker appended once when the cap is exceeded. duration_ns=0 also trips is_partial (computed from
+# timing in the incident collector).
+_CALL_PATH_TRUNCATION_SENTINEL = "<call_path_truncated>"
+
 # ============================================================================
 # Sampling Configuration
 # ============================================================================
@@ -25,18 +35,49 @@ _sample_tier1_threshold: int = 100
 _sample_tier2_threshold: int = 1000
 _sample_tier2_rate: int = 10
 _sample_tier3_rate: int = 100
-_HOT_ENDPOINT_CYCLES: int = 100
 
-_sampling_mode: str = "always"  # "auto", "always", "never", or "adaptive"
+_sampling_mode: str = "always"  # "auto", "always", or "never"
 _call_counters: Dict[str, int] = {}
 _call_counters_lock = threading.Lock()
 
+# Process-wide count of contexts with an active investigation. The monitor records a call_path
+# entry on EVERY instrumented function exit (not just sampled ones), which would otherwise pay a
+# ContextVar lookup on the hot path even when no incident investigation is in flight (the common
+# case). This counter lets record_call_path_entry skip that lookup when nothing is investigating —
+# mirroring the JS distro's _investigationActiveCount and the Java bridge's investigationActiveCount.
+# Reads on the hot path are lock-free (a plain int load is atomic under CPython); the infrequent
+# begin/clear writes take the lock to avoid lost updates. The counter is global (shared across
+# threads/contexts) while the investigation data itself is a per-context ContextVar, exactly like
+# JS's global counter + per-context AsyncLocalStorage: when ANY context is investigating, the hot
+# path does the ContextVar lookup and finds data only in the contexts that began one.
+_investigation_active_count: int = 0
+_investigation_active_lock = threading.Lock()
+
+
+def _increment_investigation_active() -> None:
+    """Increment the active-investigation count. Called only when begin_investigation actually
+    creates new data (so a double-begin in one context doesn't leak the count high)."""
+    global _investigation_active_count  # pylint: disable=global-statement
+    with _investigation_active_lock:
+        _investigation_active_count += 1
+
+
+def _decrement_investigation_active() -> None:
+    """Decrement the active-investigation count, clamped at zero. Clamping keeps an unbalanced clear
+    (e.g. a clear with no prior begin) from driving the count negative — a spuriously-high count
+    only costs an extra hot-path ContextVar lookup (degrades to pre-guard behavior), whereas a
+    negative count would wrongly disable call_path capture for a genuinely active investigation."""
+    global _investigation_active_count  # pylint: disable=global-statement
+    with _investigation_active_lock:
+        if _investigation_active_count > 0:
+            _investigation_active_count -= 1
+
 
 def set_sampling_mode(mode: str) -> None:
-    """Set sampling mode: 'always', 'never', 'auto', or 'adaptive'."""
+    """Set sampling mode: 'always', 'never', or 'auto'."""
     # Singleton module-level sampling state.
     global _sampling_mode  # pylint: disable=global-statement
-    if mode not in ("always", "never", "auto", "adaptive"):
+    if mode not in ("always", "never", "auto"):
         raise ValueError(f"Invalid sampling mode: '{mode}'")
     _sampling_mode = mode
 
@@ -51,17 +92,15 @@ def set_sampling_thresholds(
     tier2_threshold: int = 1000,
     tier2_rate: int = 10,
     tier3_rate: int = 100,
-    hot_endpoint_cycles: int = 100,
 ) -> None:
-    """Set sampling thresholds for auto/adaptive mode."""
+    """Set sampling thresholds for auto mode."""
     # Singleton module-level sampling state.
     global _sample_tier1_threshold, _sample_tier2_threshold  # pylint: disable=global-statement
-    global _sample_tier2_rate, _sample_tier3_rate, _HOT_ENDPOINT_CYCLES  # pylint: disable=global-statement
+    global _sample_tier2_rate, _sample_tier3_rate  # pylint: disable=global-statement
     _sample_tier1_threshold = tier1_threshold
     _sample_tier2_threshold = tier2_threshold
     _sample_tier2_rate = tier2_rate
     _sample_tier3_rate = tier3_rate
-    _HOT_ENDPOINT_CYCLES = hot_endpoint_cycles
 
 
 def _should_sample(total_calls: int) -> bool:  # pylint: disable=too-many-return-statements
@@ -70,16 +109,7 @@ def _should_sample(total_calls: int) -> bool:  # pylint: disable=too-many-return
         return True
     if _sampling_mode == "never":
         return False
-    if _sampling_mode == "adaptive":
-        # O(1) cached check - computed once per request, ~50ns per subsequent call
-        cached = _adaptive_sample_cache.get()
-        if cached is not None:
-            return cached
-        operation = _current_operation.get()
-        result = operation is not None and operation in _hot_operations
-        _adaptive_sample_cache.set(result)
-        return result
-    # AUTO: adaptive 3-tier sampling. Rates are "1-in-N"; a non-positive N is degenerate
+    # AUTO: 3-tier sampling. Rates are "1-in-N"; a non-positive N is degenerate
     # (it can only arrive via the internal test-config hook, which doesn't validate) and
     # would otherwise raise ZeroDivisionError on the modulo. Treat N <= 0 as "sample none
     # in this tier" so a misconfigured rate degrades gracefully instead of crashing the
@@ -117,10 +147,6 @@ _current_operation: ContextVar[Optional[str]] = ContextVar("serviceevents_operat
 def set_current_operation(operation: str):
     """Set the current operation (e.g., 'POST /users') for the request context."""
     _current_operation.set(operation)
-    # Reset adaptive sampling cache so it re-evaluates with the new operation.
-    # This prevents cache poisoning if _should_sample() was called before the
-    # operation was set (e.g., by monitored middleware running before before_request).
-    _adaptive_sample_cache.set(None)
 
 
 def get_current_operation() -> Optional[str]:
@@ -131,36 +157,6 @@ def get_current_operation() -> Optional[str]:
 def clear_current_operation():
     """Clear the current operation from the request context."""
     _current_operation.set(None)
-    _adaptive_sample_cache.set(None)
-
-
-# ============================================================================
-# Hot Operation Tracking (for "adaptive" sampling mode)
-# ============================================================================
-
-_hot_operations: Dict[str, int] = {}  # operation -> remaining flush cycles
-_hot_operations_lock = threading.Lock()
-
-# Per-request cache for adaptive sampling decision (cleared per request)
-_adaptive_sample_cache: ContextVar[Optional[bool]] = ContextVar("serviceevents_adaptive_cache", default=None)
-
-
-def mark_operation_hot(operation: str) -> None:
-    """Mark operation as hot after incident. Resets countdown to full cycle count."""
-    with _hot_operations_lock:
-        _hot_operations[operation] = _HOT_ENDPOINT_CYCLES
-
-
-def tick_hot_operations() -> None:
-    """Decrement hot operation counters. Called once per collector flush cycle."""
-    with _hot_operations_lock:
-        expired = []
-        for op in _hot_operations:
-            _hot_operations[op] -= 1
-            if _hot_operations[op] <= 0:
-                expired.append(op)
-        for op in expired:
-            del _hot_operations[op]
 
 
 def get_call_stack() -> list:
@@ -187,23 +183,24 @@ def reset_after_fork() -> None:
       re-wires.
     """
     # Singleton module-level sampling state.
-    global _sampling_mode  # pylint: disable=global-statement
+    global _sampling_mode, _investigation_active_count  # pylint: disable=global-statement
 
     # Reset sampling mode to default (always)
     _sampling_mode = "always"
+
+    # The child starts with no in-flight investigations; the singleton's investigation_data is
+    # cleared below, so the active count must drop to zero to match (avoids a leaked count
+    # forcing the post-fork hot path to keep doing ContextVar lookups for nothing).
+    with _investigation_active_lock:
+        _investigation_active_count = 0
 
     # Clear call counters
     with _call_counters_lock:
         _call_counters.clear()
 
-    # Clear hot operations
-    with _hot_operations_lock:
-        _hot_operations.clear()
-
     # Clear thread-local state
     _call_stack.set([])
     _current_operation.set(None)
-    _adaptive_sample_cache.set(None)
 
     # Clear the existing singleton's mutable state in place. The OTel
     # instrument (histogram) and its base attrs are intentionally left intact —
@@ -346,12 +343,19 @@ class _ServiceEventsMonitorState:
 
     def begin_investigation(self):
         """Start capturing investigation data for current request."""
+        # Increment the active count only when we actually create new data, so a re-entrant
+        # begin in the same context (the analogue of Java's nested servlet dispatch) doesn't
+        # leak the count high. Mirrors the Java bridge's create-only increment.
+        if self._investigation_data.get() is None:
+            _increment_investigation_active()
         self._investigation_data.set({"call_path": [], "exception": None, "start_time": time.time()})
 
     def get_investigation_data(self) -> Optional[dict]:
         """Get and clear investigation data."""
         data = self._investigation_data.get()
         self._investigation_data.set(None)
+        if data is not None:
+            _decrement_investigation_active()
         return data
 
     def peek_investigation_data(self) -> Optional[dict]:
@@ -369,6 +373,11 @@ class _ServiceEventsMonitorState:
         framework calls this unconditionally in its request-finalize path. Idempotent: a
         no-op when already cleared (e.g. an incident was collected this request).
         """
+        # Decrement only when data was actually present, so the unconditional finalize-path call
+        # (and the incident path, which already consumed via get_investigation_data) each net the
+        # count correctly — every begin pairs with exactly one decrement.
+        if self._investigation_data.get() is not None:
+            _decrement_investigation_active()
         self._investigation_data.set(None)
 
     def record_execution_flow(self, caller: Optional[str], callee: str):
@@ -391,15 +400,37 @@ class _ServiceEventsMonitorState:
             caller: Function name that called this one (None if entry point)
             duration_ns: Duration in nanoseconds
         """
+        # Hot-path gate: skip the ContextVar lookup entirely when no investigation is in flight
+        # anywhere (the common case). Mirrors the JS/Java active-count guards. A lock-free int read
+        # is enough — a stale 0 only happens in the instant before begin_investigation's locked
+        # increment publishes, which is the same context that hasn't recorded any frames yet.
+        if _investigation_active_count == 0:
+            return
         inv_data = self._investigation_data.get()
-        if inv_data is not None:
-            inv_data["call_path"].append(
+        if inv_data is None:
+            return
+        call_path = inv_data["call_path"]
+        size = len(call_path)
+        if size > _MAX_CALL_PATH_ENTRIES:
+            # Already at [MAX real frames + sentinel] — drop everything after.
+            return
+        if size == _MAX_CALL_PATH_ENTRIES:
+            # This frame overflows the cap: keep the first MAX, then a single truncation sentinel.
+            call_path.append(
                 {
-                    "function_name": function_name,
-                    "caller_function_name": caller,
-                    "duration_ns": duration_ns,
+                    "function_name": _CALL_PATH_TRUNCATION_SENTINEL,
+                    "caller_function_name": None,
+                    "duration_ns": 0,
                 }
             )
+            return
+        call_path.append(
+            {
+                "function_name": function_name,
+                "caller_function_name": caller,
+                "duration_ns": duration_ns,
+            }
+        )
 
 
 # ============================================================================
@@ -451,7 +482,7 @@ class PythonServiceEventsMonitor:
         """
         try:
             # The per-function call counter only drives AUTO-mode tiered sampling. Only AUTO
-            # reads it, so for every other mode (including the default "adaptive") skip the
+            # reads it, so for every other mode (including the default "always") skip the
             # lock acquisition and the unbounded counter-dict growth on this hot path.
             if _sampling_mode == "auto":
                 call_count = _increment_call_counter(self.function_name)

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/serviceevents_instrumentation.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/serviceevents_instrumentation.py
@@ -195,14 +195,28 @@ class ServiceEventsInstrumentation:
             self.monitor_state = _ServiceEventsMonitorState.get_instance()
             logger.debug("ServiceEvents monitor state initialized")
 
-            # Configure sampling mode from config
-            if self.config.sampling_mode != "auto":
-                # Lazy import to avoid import-time coupling with python_monitor.
-                # pylint: disable=import-outside-toplevel
-                from amazon.opentelemetry.distro.serviceevents.python_monitor import set_sampling_mode
+            # Configure sampling mode from config. Applied unconditionally: the module-level
+            # default is "always", so "auto" only takes effect if we actually call the setter
+            # (a prior `!= "auto"` guard left auto-mode inert). An unrecognized value — e.g. the
+            # removed "adaptive" left in a stale env var — is logged and left at the current
+            # default instead of aborting ServiceEvents init (mirrors the Java bridge, which
+            # silently retains the default on an invalid mode).
+            # Lazy import to avoid import-time coupling with python_monitor.
+            # pylint: disable=import-outside-toplevel
+            from amazon.opentelemetry.distro.serviceevents.python_monitor import (
+                get_sampling_mode,
+                set_sampling_mode,
+            )
 
+            try:
                 set_sampling_mode(self.config.sampling_mode)
-                logger.info("ServiceEvents sampling mode set to: %s", self.config.sampling_mode)
+            except ValueError:
+                logger.warning(
+                    "ServiceEvents: invalid sampling mode '%s'; falling back to '%s'",
+                    self.config.sampling_mode,
+                    get_sampling_mode(),
+                )
+            logger.info("ServiceEvents sampling mode set to: %s", get_sampling_mode())
 
             # Configure sampling thresholds from config
             # Lazy import to avoid import-time coupling with python_monitor.
@@ -214,7 +228,6 @@ class ServiceEventsInstrumentation:
                 tier2_threshold=self.config.sample_tier2_threshold,
                 tier2_rate=self.config.sample_tier2_rate,
                 tier3_rate=self.config.sample_tier3_rate,
-                hot_endpoint_cycles=self.config.hot_endpoint_cycles,
             )
 
             # Initialize OTLP emitter when either `output_file` (local-testing

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/serviceevents_instrumentation.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/serviceevents_instrumentation.py
@@ -203,10 +203,7 @@ class ServiceEventsInstrumentation:
             # silently retains the default on an invalid mode).
             # Lazy import to avoid import-time coupling with python_monitor.
             # pylint: disable=import-outside-toplevel
-            from amazon.opentelemetry.distro.serviceevents.python_monitor import (
-                get_sampling_mode,
-                set_sampling_mode,
-            )
+            from amazon.opentelemetry.distro.serviceevents.python_monitor import get_sampling_mode, set_sampling_mode
 
             try:
                 set_sampling_mode(self.config.sampling_mode)

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/test_python_monitor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/test_python_monitor.py
@@ -6,29 +6,27 @@ import time
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
+from amazon.opentelemetry.distro.serviceevents import python_monitor_impl as impl
 from amazon.opentelemetry.distro.serviceevents.python_monitor import (
     PythonServiceEventsMonitor,
     _ServiceEventsMonitorState,
 )
 from amazon.opentelemetry.distro.serviceevents.python_monitor_impl import (
-    _adaptive_sample_cache,
+    _CALL_PATH_TRUNCATION_SENTINEL,
+    _MAX_CALL_PATH_ENTRIES,
     _call_counters,
     _call_counters_lock,
     _call_stack,
     _current_operation,
-    _hot_operations,
-    _hot_operations_lock,
     _increment_call_counter,
     _should_sample,
     get_call_stack,
     get_current_operation,
     get_sampling_mode,
-    mark_operation_hot,
     reset_after_fork,
     set_current_operation,
     set_sampling_mode,
     set_sampling_thresholds,
-    tick_hot_operations,
 )
 
 
@@ -38,6 +36,9 @@ class TestServiceEventsMonitorState(TestCase):
     def setUp(self):
         """Reset the singleton instance before each test."""
         _ServiceEventsMonitorState._instance = None
+        # Reset the process-wide active-investigation count so a leaked begin from another test
+        # can't disable (or, when high, mask) the hot-path gate exercised below.
+        impl._investigation_active_count = 0
 
     def test_singleton_pattern(self):
         """Test that get_instance returns the same instance."""
@@ -113,6 +114,71 @@ class TestServiceEventsMonitorState(TestCase):
         state.clear_investigation_data()
         state.clear_investigation_data()
         self.assertIsNone(state.peek_investigation_data())
+
+    def test_call_path_capped_with_truncation_sentinel(self):
+        """record_call_path_entry caps the path and appends one sentinel on overflow (keep-first)."""
+        state = _ServiceEventsMonitorState.get_instance()
+        state.begin_investigation()
+
+        # Record well past the cap; every real frame has a non-zero duration so is_partial would be
+        # False if the cap never fired.
+        for i in range(_MAX_CALL_PATH_ENTRIES + 50):
+            caller = None if i == 0 else f"func-{i - 1}"
+            state.record_call_path_entry(f"func-{i}", caller, 1000)
+
+        inv_data = state.get_investigation_data()
+        self.assertIsNotNone(inv_data)
+        call_path = inv_data["call_path"]
+
+        # Keep-first: MAX real frames + exactly one sentinel, regardless of overflow size.
+        self.assertEqual(len(call_path), _MAX_CALL_PATH_ENTRIES + 1)
+
+        # A below-cap frame is a normal entry.
+        self.assertEqual(call_path[0]["function_name"], "func-0")
+        self.assertEqual(call_path[_MAX_CALL_PATH_ENTRIES - 1]["function_name"], f"func-{_MAX_CALL_PATH_ENTRIES - 1}")
+        self.assertEqual(call_path[_MAX_CALL_PATH_ENTRIES - 1]["duration_ns"], 1000)
+
+        # The overflow frame is the sentinel with duration_ns=0 (trips is_partial downstream).
+        sentinel = call_path[_MAX_CALL_PATH_ENTRIES]
+        self.assertEqual(sentinel["function_name"], _CALL_PATH_TRUNCATION_SENTINEL)
+        self.assertIsNone(sentinel["caller_function_name"])
+        self.assertEqual(sentinel["duration_ns"], 0)
+
+        # is_partial parity: at least one zero-duration frame is present.
+        self.assertTrue(any(e["duration_ns"] == 0 for e in call_path))
+
+    # ───── active-count gate on record_call_path_entry (JS/Java parity) ──
+
+    def test_record_call_path_entry_noop_when_no_investigation_active(self):
+        """With no begin_investigation(), the active-count gate keeps record_call_path_entry from
+        touching the ContextVar at all — it's a no-op and creates no data."""
+        state = _ServiceEventsMonitorState.get_instance()
+        # setUp reset the count to 0; no begin_investigation() here.
+        self.assertEqual(impl._investigation_active_count, 0)
+
+        state.record_call_path_entry("func-a", None, 1000)
+
+        self.assertIsNone(state.peek_investigation_data())
+
+    def test_begin_get_balance_active_count(self):
+        """begin_investigation increments and get/clear decrements, so the count nets to zero per
+        request — and a re-entrant begin in the same context doesn't double-count."""
+        state = _ServiceEventsMonitorState.get_instance()
+
+        state.begin_investigation()
+        self.assertEqual(impl._investigation_active_count, 1)
+
+        # Re-entrant begin (nested-dispatch analogue) must NOT increment again.
+        state.begin_investigation()
+        self.assertEqual(impl._investigation_active_count, 1)
+
+        # The single consume decrements back to zero.
+        state.get_investigation_data()
+        self.assertEqual(impl._investigation_active_count, 0)
+
+        # A redundant clear with nothing present is a no-op (clamped, never negative).
+        state.clear_investigation_data()
+        self.assertEqual(impl._investigation_active_count, 0)
 
 
 class TestPythonServiceEventsMonitor(TestCase):
@@ -289,7 +355,7 @@ class TestPythonServiceEventsMonitor(TestCase):
         with _call_counters_lock:
             _call_counters.clear()
 
-        for mode in ("always", "never", "adaptive"):
+        for mode in ("always", "never"):
             set_sampling_mode(mode)
             with PythonServiceEventsMonitor(f"skip_func_{mode}"):
                 pass
@@ -428,147 +494,28 @@ class TestCrashSafety(TestCase):
         self.assertEqual(_call_stack.get(), [])
 
 
-class TestAdaptiveSampling(TestCase):
-    """Test the adaptive sampling mode and hot operation tracking."""
+class TestSamplingModes(TestCase):
+    """Test the always/never/auto sampling modes and validation."""
 
     def setUp(self):
         """Reset state before each test."""
         _ServiceEventsMonitorState._instance = None
         _call_stack.set([])
         _current_operation.set(None)
-        _adaptive_sample_cache.set(None)
-        with _hot_operations_lock:
-            _hot_operations.clear()
         set_sampling_mode("always")
 
     def tearDown(self):
         """Restore sampling mode after each test."""
         set_sampling_mode("always")
         _current_operation.set(None)
-        _adaptive_sample_cache.set(None)
-        with _hot_operations_lock:
-            _hot_operations.clear()
-
-    def test_adaptive_no_sampling_for_cold_operation(self):
-        """In adaptive mode, non-hot operations should not be sampled."""
-        set_sampling_mode("adaptive")
-        _current_operation.set("endpoint-123")
-
-        self.assertFalse(_should_sample(1))
-
-    def test_adaptive_samples_hot_operation(self):
-        """In adaptive mode, hot operations should be sampled."""
-        set_sampling_mode("adaptive")
-        _current_operation.set("endpoint-123")
-        mark_operation_hot("endpoint-123")
-
-        self.assertTrue(_should_sample(1))
-
-    def test_adaptive_does_not_sample_different_operation(self):
-        """In adaptive mode, only the hot operation gets sampled."""
-        set_sampling_mode("adaptive")
-        mark_operation_hot("endpoint-123")
-        _current_operation.set("endpoint-456")
-
-        self.assertFalse(_should_sample(1))
-
-    def test_adaptive_caches_result_per_request(self):
-        """Second call should use cached result without checking hot operations."""
-        set_sampling_mode("adaptive")
-        _current_operation.set("endpoint-123")
-        mark_operation_hot("endpoint-123")
-
-        # First call: checks hot operations, caches True
-        self.assertTrue(_should_sample(1))
-
-        # Remove from hot operations (simulating expiry between calls)
-        with _hot_operations_lock:
-            _hot_operations.clear()
-
-        # Second call: returns cached True despite operation no longer being hot
-        self.assertTrue(_should_sample(2))
-
-    def test_adaptive_cache_cleared_with_operation(self):
-        """Cache should be cleared when operation context is cleared."""
-        set_sampling_mode("adaptive")
-        _current_operation.set("endpoint-123")
-        mark_operation_hot("endpoint-123")
-
-        self.assertTrue(_should_sample(1))
-
-        # Clear operation (simulating end of request)
-        from amazon.opentelemetry.distro.serviceevents.python_monitor_impl import clear_current_operation
-
-        clear_current_operation()
-
-        # Set new operation context (new request)
-        _current_operation.set("endpoint-456")
-        self.assertFalse(_should_sample(2))
-
-    def test_adaptive_no_operation_context(self):
-        """Without operation context, adaptive mode should not sample."""
-        set_sampling_mode("adaptive")
-        # No operation set
-        self.assertFalse(_should_sample(1))
-
-    def test_mark_operation_hot(self):
-        """Marking an operation hot should add it to the hot operations dict."""
-        mark_operation_hot("endpoint-123")
-        self.assertIn("endpoint-123", _hot_operations)
-        self.assertEqual(_hot_operations["endpoint-123"], 100)
-
-    def test_mark_operation_hot_resets_countdown(self):
-        """Re-marking a hot operation should reset the countdown."""
-        mark_operation_hot("endpoint-123")
-        # Simulate some ticks
-        for _ in range(50):
-            tick_hot_operations()
-        self.assertEqual(_hot_operations["endpoint-123"], 50)
-
-        # Re-mark should reset to full
-        mark_operation_hot("endpoint-123")
-        self.assertEqual(_hot_operations["endpoint-123"], 100)
-
-    def test_tick_hot_operations_decrements(self):
-        """Each tick should decrement the countdown."""
-        mark_operation_hot("endpoint-123")
-        tick_hot_operations()
-        self.assertEqual(_hot_operations["endpoint-123"], 99)
-
-    def test_tick_hot_operations_removes_expired(self):
-        """Operations should be removed after countdown reaches 0."""
-        mark_operation_hot("endpoint-123")
-        for _ in range(100):
-            tick_hot_operations()
-        self.assertNotIn("endpoint-123", _hot_operations)
-
-    def test_tick_hot_operations_multiple(self):
-        """Multiple hot operations should be tracked independently."""
-        mark_operation_hot("endpoint-A")
-        for _ in range(50):
-            tick_hot_operations()
-        mark_operation_hot("endpoint-B")
-
-        # A has 50 remaining, B has 100
-        self.assertEqual(_hot_operations["endpoint-A"], 50)
-        self.assertEqual(_hot_operations["endpoint-B"], 100)
-
-        for _ in range(50):
-            tick_hot_operations()
-
-        # A should be removed, B has 50 remaining
-        self.assertNotIn("endpoint-A", _hot_operations)
-        self.assertEqual(_hot_operations["endpoint-B"], 50)
 
     def test_existing_modes_unchanged(self):
         """Existing sampling modes should work as before."""
         _current_operation.set("endpoint-123")
-        mark_operation_hot("endpoint-123")
 
         set_sampling_mode("always")
         self.assertTrue(_should_sample(1))
 
-        _adaptive_sample_cache.set(None)  # Clear cache between mode switches
         set_sampling_mode("never")
         self.assertFalse(_should_sample(1))
 
@@ -577,68 +524,10 @@ class TestAdaptiveSampling(TestCase):
         with self.assertRaises(ValueError):
             set_sampling_mode("invalid")
 
-    @patch("amazon.opentelemetry.distro.serviceevents.python_monitor_impl.time.perf_counter_ns")
-    def test_adaptive_monitor_records_timing_for_hot_operation(self, mock_time):
-        """In adaptive mode, hot operations should have real duration in call_path."""
-        set_sampling_mode("adaptive")
-        _current_operation.set("endpoint-123")
-        mark_operation_hot("endpoint-123")
-        mock_time.side_effect = [1000000000, 1100000000]  # 100ms
-
-        state = _ServiceEventsMonitorState.get_instance()
-        state.begin_investigation()
-
-        with PythonServiceEventsMonitor("test_func"):
-            pass
-
-        inv_data = state.get_investigation_data()
-        self.assertIsNotNone(inv_data)
-        self.assertEqual(len(inv_data["call_path"]), 1)
-        entry = inv_data["call_path"][0]
-        self.assertEqual(entry["duration_ns"], 100_000_000)
-
-    def test_adaptive_monitor_no_timing_for_cold_operation(self):
-        """In adaptive mode, cold operations should have duration_ns=0 in call_path."""
-        set_sampling_mode("adaptive")
-        _current_operation.set("endpoint-cold")
-
-        state = _ServiceEventsMonitorState.get_instance()
-        state.begin_investigation()
-
-        with PythonServiceEventsMonitor("test_func"):
-            pass
-
-        inv_data = state.get_investigation_data()
-        self.assertIsNotNone(inv_data)
-        self.assertEqual(len(inv_data["call_path"]), 1)
-        entry = inv_data["call_path"][0]
-        self.assertEqual(entry["duration_ns"], 0)
-
-    @patch("amazon.opentelemetry.distro.serviceevents.python_monitor_impl.time.perf_counter_ns")
-    def test_adaptive_cache_reset_on_set_operation(self, mock_time):
-        """Setting operation resets adaptive cache to prevent cache poisoning.
-
-        Regression test: If a monitored function runs before the Flask before_request
-        hook sets the operation (e.g., WSGI middleware), _should_sample() caches
-        False (no operation -> not hot). Without cache reset, all subsequent functions
-        in the same request also get False even after the operation is set.
-        """
-        mock_time.side_effect = [1000, 2000]  # start, end times
-        set_sampling_mode("adaptive")
-        operation = "GET /endpoint-hot"
-        mark_operation_hot(operation)
-
-        # Simulate middleware running BEFORE operation is set
-        # _should_sample() caches False because operation is None
-        self.assertFalse(_should_sample(1))
-        self.assertFalse(_adaptive_sample_cache.get())  # Cache poisoned to False
-
-        # Simulate before_request hook setting operation
-        # This must reset the cache so _should_sample() re-evaluates
-        set_current_operation(operation)
-
-        # Now _should_sample() should re-evaluate and find the hot operation
-        self.assertTrue(_should_sample(1))
+    def test_removed_adaptive_mode_rejected(self):
+        """The removed 'adaptive' mode is no longer valid and must be rejected."""
+        with self.assertRaises(ValueError):
+            set_sampling_mode("adaptive")
 
 
 class TestSamplingThresholds(TestCase):
@@ -651,7 +540,6 @@ class TestSamplingThresholds(TestCase):
             tier2_threshold=1000,
             tier2_rate=10,
             tier3_rate=100,
-            hot_endpoint_cycles=100,
         )
         set_sampling_mode("auto")
 
@@ -662,7 +550,6 @@ class TestSamplingThresholds(TestCase):
             tier2_threshold=1000,
             tier2_rate=10,
             tier3_rate=100,
-            hot_endpoint_cycles=100,
         )
         set_sampling_mode("always")
 
@@ -684,22 +571,22 @@ class TestSamplingThresholds(TestCase):
         self.assertTrue(_should_sample(100))
         self.assertFalse(_should_sample(101))
 
-    def test_set_sampling_thresholds_hot_endpoint_cycles(self):
-        """Test that custom hot_endpoint_cycles is applied when marking operations hot."""
-        set_sampling_thresholds(hot_endpoint_cycles=3)
-        mark_operation_hot("ep-123")
-        with _hot_operations_lock:
-            self.assertEqual(_hot_operations["ep-123"], 3)
+    def test_zero_rate_samples_none_in_tier_without_crashing(self):
+        """A non-positive tier rate (only reachable via the unvalidated test-config hook) must
+        degrade to 'sample none in this tier' rather than raise ZeroDivisionError. Mirrors Java/JS."""
+        set_sampling_thresholds(tier1_threshold=100, tier2_threshold=1000, tier2_rate=0, tier3_rate=0)
+        # tier1 unaffected by the rates.
+        self.assertTrue(_should_sample(1))
+        # tier2 (100 < n <= 1000) and tier3 (n > 1000): zero rate → no crash, sample none.
+        self.assertFalse(_should_sample(500))
+        self.assertFalse(_should_sample(5000))
 
     def test_default_thresholds_unchanged_without_call(self):
         """Test that defaults match the original hardcoded values."""
-        from amazon.opentelemetry.distro.serviceevents import python_monitor_impl as impl
-
         self.assertEqual(impl._sample_tier1_threshold, 100)
         self.assertEqual(impl._sample_tier2_threshold, 1000)
         self.assertEqual(impl._sample_tier2_rate, 10)
         self.assertEqual(impl._sample_tier3_rate, 100)
-        self.assertEqual(impl._HOT_ENDPOINT_CYCLES, 100)
 
 
 class TestHistogramWiringIntegration(TestCase):
@@ -897,7 +784,6 @@ class TestSamplingAwareHistogramWiring(TestCase):
         set_sampling_mode("always")
         _call_stack.set([])
         _current_operation.set(None)
-        _adaptive_sample_cache.set(None)
 
         from opentelemetry.sdk.metrics import MeterProvider
         from opentelemetry.sdk.metrics.export import InMemoryMetricReader
@@ -935,7 +821,6 @@ class TestSamplingAwareHistogramWiring(TestCase):
         self._meter_provider.shutdown()
         _ServiceEventsMonitorState._instance = None
         set_sampling_mode("always")
-        _adaptive_sample_cache.set(None)
 
     # ------------------------------------------------------------------
     # Helpers
@@ -1060,11 +945,8 @@ class TestModuleStateFunctions(TestCase):
         _ServiceEventsMonitorState._instance = None
         _call_stack.set([])
         _current_operation.set(None)
-        _adaptive_sample_cache.set(None)
         with _call_counters_lock:
             _call_counters.clear()
-        with _hot_operations_lock:
-            _hot_operations.clear()
         set_sampling_mode("always")
 
     def tearDown(self):
@@ -1072,11 +954,8 @@ class TestModuleStateFunctions(TestCase):
         set_sampling_mode("always")
         _call_stack.set([])
         _current_operation.set(None)
-        _adaptive_sample_cache.set(None)
         with _call_counters_lock:
             _call_counters.clear()
-        with _hot_operations_lock:
-            _hot_operations.clear()
 
     def test_get_sampling_mode_returns_current_mode(self):
         """get_sampling_mode reflects the mode set via set_sampling_mode."""
@@ -1109,10 +988,8 @@ class TestModuleStateFunctions(TestCase):
         set_sampling_mode("never")
         with _call_counters_lock:
             _call_counters["fork_func"] = 7
-        mark_operation_hot("fork-op")
         _call_stack.set(["frame"])
         _current_operation.set("GET /forked")
-        _adaptive_sample_cache.set(True)
 
         state = _ServiceEventsMonitorState.get_instance()
         state.begin_investigation()
@@ -1122,15 +999,12 @@ class TestModuleStateFunctions(TestCase):
 
         # Sampling mode falls back to the default "always".
         self.assertEqual(get_sampling_mode(), "always")
-        # Counters and hot operations are emptied.
+        # Counters are emptied.
         with _call_counters_lock:
             self.assertEqual(_call_counters, {})
-        with _hot_operations_lock:
-            self.assertEqual(_hot_operations, {})
         # Thread-local state is reset.
         self.assertEqual(_call_stack.get(), [])
         self.assertIsNone(_current_operation.get())
-        self.assertIsNone(_adaptive_sample_cache.get())
         # The singleton's identity is preserved, only its investigation data cleared.
         self.assertIs(_ServiceEventsMonitorState.get_instance(), state)
         self.assertIsNone(state.peek_investigation_data())
@@ -1154,7 +1028,6 @@ class TestMonitorEdgeBranches(TestCase):
         _ServiceEventsMonitorState._instance = None
         _call_stack.set([])
         _current_operation.set(None)
-        _adaptive_sample_cache.set(None)
         set_sampling_mode("always")
 
     def tearDown(self):

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/test_serviceevents_config.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/test_serviceevents_config.py
@@ -127,7 +127,6 @@ class TestServiceEventsConfig(TestCase):
         self.assertEqual(config.sample_tier2_threshold, 1000)
         self.assertEqual(config.sample_tier2_rate, 10)
         self.assertEqual(config.sample_tier3_rate, 100)
-        self.assertEqual(config.hot_endpoint_cycles, 100)
 
     @patch.dict(
         os.environ,
@@ -136,7 +135,6 @@ class TestServiceEventsConfig(TestCase):
             "OTEL_AWS_SERVICE_EVENTS_SAMPLE_TIER2_THRESHOLD": "500",
             "OTEL_AWS_SERVICE_EVENTS_SAMPLE_TIER2_RATE": "5",
             "OTEL_AWS_SERVICE_EVENTS_SAMPLE_TIER3_RATE": "50",
-            "OTEL_AWS_SERVICE_EVENTS_HOT_ENDPOINT_CYCLES": "200",
         },
     )
     def test_sampling_thresholds_env_is_ignored(self):
@@ -146,7 +144,6 @@ class TestServiceEventsConfig(TestCase):
         self.assertEqual(config.sample_tier2_threshold, 1000)
         self.assertEqual(config.sample_tier2_rate, 10)
         self.assertEqual(config.sample_tier3_rate, 100)
-        self.assertEqual(config.hot_endpoint_cycles, 100)
 
     # ─── Internal test-config hook (DEBUG_SE_TEST_CONFIG) ──
 

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/test_serviceevents_instrumentation.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/test_serviceevents_instrumentation.py
@@ -375,6 +375,63 @@ class TestServiceEventsModes(TestCase):
         inst.shutdown()
 
 
+class TestSamplingModeActivation(TestCase):
+    """Verify startup applies the configured sampling mode through ServiceEventsInstrumentation.
+
+    Regression coverage for two bugs: (1) a `!= "auto"` guard that left auto mode inert because
+    the module default is "always", and (2) an invalid mode (e.g. the removed "adaptive" left in
+    a stale env var) aborting all of ServiceEvents init instead of falling back to the default.
+    """
+
+    def setUp(self):
+        # Neutralize atexit registration (see TestServiceEventsInstrumentation.setUp).
+        patcher = patch("amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation.atexit")
+        self.mock_atexit = patcher.start()
+        self.addCleanup(patcher.stop)
+        # Restore the module-level sampling mode after each test so state doesn't leak.
+        from amazon.opentelemetry.distro.serviceevents.python_monitor import set_sampling_mode
+
+        self.addCleanup(set_sampling_mode, "always")
+
+    def _init_with_mode(self, mode):
+        config = ServiceEventsConfig(
+            enabled=True,
+            function_instrument_enabled=True,
+            logs_endpoint="http://localhost:4318/v1/logs",
+            sampling_mode=mode,
+        )
+        inst = ServiceEventsInstrumentation(config)
+        inst.initialize()
+        return inst
+
+    def test_auto_mode_actually_activates(self):
+        """sampling_mode='auto' must reach the monitor — not be skipped by a guard."""
+        from amazon.opentelemetry.distro.serviceevents.python_monitor import get_sampling_mode
+
+        inst = self._init_with_mode("auto")
+        self.assertTrue(inst._initialized)
+        self.assertEqual(get_sampling_mode(), "auto")
+        inst.shutdown()
+
+    def test_never_mode_activates(self):
+        from amazon.opentelemetry.distro.serviceevents.python_monitor import get_sampling_mode
+
+        inst = self._init_with_mode("never")
+        self.assertEqual(get_sampling_mode(), "never")
+        inst.shutdown()
+
+    def test_invalid_mode_falls_back_without_aborting_init(self):
+        """A stale/removed mode (e.g. 'adaptive') logs a warning and leaves the default in place,
+        rather than raising and aborting the whole ServiceEvents init."""
+        from amazon.opentelemetry.distro.serviceevents.python_monitor import get_sampling_mode
+
+        inst = self._init_with_mode("adaptive")
+        # Init must still complete (collectors/emitter wired), unlike the old ValueError abort.
+        self.assertTrue(inst._initialized)
+        self.assertEqual(get_sampling_mode(), "always")
+        inst.shutdown()
+
+
 class TestGetServiceEventsInstrumentation(TestCase):
     """Test the get_serviceevents_instrumentation singleton accessor."""
 


### PR DESCRIPTION
## Description

Hard-removes the **adaptive** ServiceEvents sampling mode and its hot-endpoint
tracking, flips the default sampling mode to **always** (100%), bounds
per-request `call_path` growth, and brings the `is_partial` wire signal into
parity with the Python/JS distros.

### Sampling
- Modes are now **always / auto / never**; an invalid mode (incl. `adaptive`) raises `ValueError`, caught at init which logs and falls back to the current mode.
- `auto` tier rates guard against a non-positive 1-in-N rate (treated as "sample none in this tier") so a misconfigured rate degrades gracefully instead of raising ZeroDivisionError on the hot path.

### call_path cap
- `record_call_path_entry` caps the call path at `_MAX_CALL_PATH_ENTRIES` (1024) and appends a single `<call_path_truncated>` sentinel (`duration_ns=0`) on overflow, keeping the first 1024 frames. Bounds a serialized IncidentSnapshot well under the 1 MB CloudWatch OTLP Logs limit.

### Active-count guard
- A process-wide `_investigation_active_count` (int + `threading.Lock`) gates the `ContextVar` lookup in `record_call_path_entry` so the common case (no investigation in flight) skips it. Create-only increment, decrement only when data was present, clamped at zero (drifts high → degrades to the old lookup; never low).
- `call_path` entries are now recorded for **every** call (not just sampled), so incident snapshots capture who-called-whom under `auto`/`never`; only the duration metric stays sampling-gated.

### is_partial parity
- `is_partial` is computed as `any(durationNs == 0)` over the call path (empty → `false`) instead of hardcoded `true`, and zero durations are stripped from serialized frames on a partial snapshot. A fully-timed `always`-mode snapshot now reports `is_partial=false` with all timings intact — matching the Python/JS distros and the OTLP signals spec.

## Testing
- full `serviceevents` suite — **714 passed** (pytest).
- `black` + `isort` clean.
