### PR TITLE
fix(dynamic-instrumentation): redirect `from module import func` aliases for method-level breakpoints

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/debugger/_function_wrapper.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/debugger/_function_wrapper.py
@@ -244,6 +244,9 @@ class FunctionWrapper:
                 # Restore framework-level references back to the original function
                 if wrapped_func is not None:
                     FunctionWrapper._patch_framework_references(module, wrapped_func, original_func)
+                    # Symmetrically restore any `from <module> import <func>` aliases we redirected
+                    # at install time, so deleting the breakpoint returns the app to its prior state.
+                    FunctionWrapper._patch_module_aliases(module, wrapped_func, original_func)
 
             return True
         except Exception as exception:
@@ -776,6 +779,17 @@ class FunctionWrapper:
                 # unwrapped function, bypassing DI instrumentation entirely.
                 if original_func is not None:
                     FunctionWrapper._patch_framework_references(module, original_func, new_func)
+                    # Also redirect plain `from <module> import <func>` aliases held in other
+                    # application modules (the bare-name call site keeps a reference to the
+                    # original function, which setattr on the defining module does not update).
+                    alias_count = FunctionWrapper._patch_module_aliases(module, original_func, new_func)
+                    if alias_count:
+                        logger.debug(
+                            "DI: redirected %d module-level alias(es) of %s.%s",
+                            alias_count,
+                            module_name,
+                            function_name,
+                        )
 
         except ImportError as exception:
             logger.error("Failed to import module '%s' for replacement: %s", module_name, exception)
@@ -822,6 +836,151 @@ class FunctionWrapper:
             FunctionWrapper._patch_fastapi_routes(module, original_func, new_func)
         except Exception as exc:  # pylint: disable=broad-exception-caught
             logger.debug("fastapi reference patching encountered an error: %s", exc)
+
+    # Module name prefixes whose namespaces we never rewrite. Standard library and the
+    # ADOT/OpenTelemetry SDK itself must be left untouched (correctness + safety): we only
+    # ever redirect plain `from x import f` aliases that live in *application* code.
+    _ALIAS_SKIP_PREFIXES = (
+        "amazon.opentelemetry.",
+        "opentelemetry.",
+        "wrapt",
+        "_pytest",
+        "pytest",
+    )
+
+    @staticmethod
+    def _stdlib_lib_dirs() -> tuple:
+        """Realpath'd standard-library ``lib`` directories (computed once per alias scan).
+
+        Resolving ``sys.prefix``/``sys.base_prefix`` involves filesystem syscalls, so it is
+        hoisted out of the per-module loop in ``_patch_module_aliases`` and passed in.
+        """
+        dirs = []
+        for prefix in (sys.prefix, sys.base_prefix):
+            if not prefix:
+                continue
+            dirs.append(os.path.realpath(os.path.join(prefix, "lib")) + os.sep)
+        return tuple(dirs)
+
+    @staticmethod
+    def _is_application_module(module, stdlib_lib_dirs: tuple = ()) -> bool:
+        """
+        Heuristic: a module whose ``from x import f`` aliases we are willing to rewrite.
+
+        Excludes the standard library, site-packages / third-party dependencies, frozen and
+        built-in (C extension) modules, and the ADOT/OTel SDK itself. This bounds the alias
+        rebind to first-party application code — the only place a ``from x import f`` alias is a
+        legitimate, intended instrumentation target.
+
+        ``stdlib_lib_dirs`` is the precomputed result of ``_stdlib_lib_dirs()``; pass it from the
+        caller's loop to avoid repeating ``realpath(sys.prefix)`` syscalls per module. When empty
+        it is computed on demand (kept for standalone/test callers).
+
+        Note: apps installed under ``site-packages``/``dist-packages`` (e.g. ``pip install .`` or
+        copied into the image's site-packages) classify as non-application and are NOT rewritten,
+        so the alias redirect does not reach them. This is fail-safe (no rewrite, no crash) but is
+        a known coverage limitation.
+        """
+        try:
+            name = getattr(module, "__name__", "") or ""
+            for prefix in FunctionWrapper._ALIAS_SKIP_PREFIXES:
+                if name == prefix or name.startswith(prefix):
+                    return False
+
+            spec = getattr(module, "__spec__", None)
+            origin = getattr(spec, "origin", None) if spec is not None else getattr(module, "__file__", None)
+            # Built-in / frozen / namespace modules have no real file origin — skip them.
+            if not origin or origin in ("built-in", "frozen", "namespace"):
+                return False
+            origin = os.path.realpath(origin)
+
+            # Skip anything under installed packages.
+            for marker in ("site-packages", "dist-packages"):
+                if marker in origin:
+                    return False
+            # Skip the standard library (under sys.prefix/lib but not the app's own tree).
+            for libdir in stdlib_lib_dirs or FunctionWrapper._stdlib_lib_dirs():
+                if origin.startswith(libdir):
+                    return False
+            return True
+        except Exception:  # pylint: disable=broad-exception-caught
+            # If we cannot classify the module confidently, do NOT touch it.
+            return False
+
+    @staticmethod
+    def _patch_module_aliases(defining_module, original_func: Callable, new_func: Callable) -> int:
+        """
+        Redirect module-level references to ``original_func`` in OTHER application modules.
+
+        ``from module import func`` copies the function object into the importing module's own
+        namespace. A later ``setattr(module, name, wrapper)`` on the defining module does NOT update
+        those copies, so callers using the bare name keep invoking the original (un-instrumented)
+        function. Frameworks (Flask/Django/FastAPI) are handled by ``_patch_framework_references``;
+        this handles plain module-level references generically.
+
+        Scope of the rewrite (important): this redirects EVERY module-level attribute that *is*
+        (identity) ``original_func`` in an application module — which covers ``from x import f``
+        call-site aliases, but also any deliberate module-level re-export or sentinel that holds the
+        same object. While a breakpoint is active, an ``x is some_sentinel`` / ``x in some_set``
+        identity comparison in user code against such a re-export would observe the wrapper (a
+        different object that delegates to the original). This window is bounded to the breakpoint's
+        active lifetime and is fully reverted by ``restore_function``. Python provides no way to
+        distinguish a call-site alias from a stored reference at the namespace level, so identity
+        match is the safe, behavior-preserving choice.
+
+        Safety properties (deliberate — this is a SAFETY-critical agent):
+          * Identity match only (``attr is original_func``) — never name-based guessing here.
+          * Application modules only (``_is_application_module``) — never stdlib/site-packages/SDK.
+          * Module-level attributes only — never reaches into dicts/registries/containers.
+          * Snapshots ``sys.modules`` and each module's ``vars()`` before iterating (no
+            "dict changed size during iteration" if another thread imports concurrently).
+          * Every ``setattr`` is individually guarded; one failure never aborts the rest.
+          * Never raises — returns the count of references redirected (for the non-silent signal).
+
+        References captured into local variables, closures, default arguments, or data structures
+        cannot be rebound by any name-based approach; those remain out of scope (use a line-level
+        breakpoint, whose ``sys.monitoring`` engine binds the code object directly).
+
+        Returns:
+            The number of module-level references redirected to ``new_func``.
+        """
+        rebound = 0
+        try:
+            defining_name = getattr(defining_module, "__name__", None)
+            stdlib_lib_dirs = FunctionWrapper._stdlib_lib_dirs()  # computed once for the whole scan
+            classification: dict = {}  # memoize _is_application_module per module-id for this scan
+            # Snapshot the module list so concurrent imports can't mutate it under us.
+            for mod_name, module in list(sys.modules.items()):
+                if module is None or module is defining_module:
+                    continue
+                is_app = classification.get(id(module))
+                if is_app is None:
+                    is_app = FunctionWrapper._is_application_module(module, stdlib_lib_dirs)
+                    classification[id(module)] = is_app
+                if not is_app:
+                    continue
+                try:
+                    attrs = list(vars(module).items())  # snapshot this module's namespace
+                except Exception:  # pylint: disable=broad-exception-caught
+                    continue
+                for attr_name, attr_value in attrs:
+                    # Identity match against the exact original function object.
+                    if attr_value is not original_func:
+                        continue
+                    try:
+                        setattr(module, attr_name, new_func)
+                        rebound += 1
+                        logger.debug(
+                            "DI: redirected alias %s.%s -> wrapper (defined in %s)",
+                            mod_name,
+                            attr_name,
+                            defining_name,
+                        )
+                    except Exception as exc:  # pylint: disable=broad-exception-caught
+                        logger.debug("DI: could not rebind alias %s.%s: %s", mod_name, attr_name, exc)
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.debug("DI: module-alias patching encountered an error: %s", exc)
+        return rebound
 
     @staticmethod
     def _patch_flask_view_functions(module, original_func: Callable, new_func: Callable) -> None:

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/debugger/_function_wrapper.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/debugger/_function_wrapper.py
@@ -837,12 +837,19 @@ class FunctionWrapper:
         except Exception as exc:  # pylint: disable=broad-exception-caught
             logger.debug("fastapi reference patching encountered an error: %s", exc)
 
-    # Module name prefixes whose namespaces we never rewrite. Standard library and the
-    # ADOT/OpenTelemetry SDK itself must be left untouched (correctness + safety): we only
-    # ever redirect plain `from x import f` aliases that live in *application* code.
-    _ALIAS_SKIP_PREFIXES = (
+    # Dotted package-tree prefixes whose namespaces we never rewrite: the ADOT/OpenTelemetry SDK
+    # itself must be left untouched (correctness + safety). Matched with ``startswith`` so the
+    # whole subtree (``opentelemetry.trace`` etc.) is skipped. The trailing dot is required so a
+    # first-party app module merely *beginning* with these letters is not eaten.
+    _ALIAS_SKIP_PACKAGE_PREFIXES = (
         "amazon.opentelemetry.",
         "opentelemetry.",
+    )
+    # Top-level package names (and their subtrees) we never rewrite. Matched on the first dotted
+    # component so ``wrapt``/``wrapt.decorators`` are skipped but a first-party ``wraptools`` /
+    # ``pytest_fixtures`` is not. wrapt is the wrapper library DI builds on; pytest/_pytest are the
+    # test harness.
+    _ALIAS_SKIP_TOP_LEVEL = (
         "wrapt",
         "_pytest",
         "pytest",
@@ -876,28 +883,43 @@ class FunctionWrapper:
         caller's loop to avoid repeating ``realpath(sys.prefix)`` syscalls per module. When empty
         it is computed on demand (kept for standalone/test callers).
 
-        Note: apps installed under ``site-packages``/``dist-packages`` (e.g. ``pip install .`` or
-        copied into the image's site-packages) classify as non-application and are NOT rewritten,
-        so the alias redirect does not reach them. This is fail-safe (no rewrite, no crash) but is
-        a known coverage limitation.
+        Path matching is structural: ``site-packages``/``dist-packages`` are matched as real path
+        *components* (not substrings), so an app whose path merely contains that text (e.g.
+        ``/srv/my-site-packages/app.py``) is correctly treated as application code.
+
+        Known coverage limitation (fail-safe — no rewrite, no crash): apps genuinely installed
+        under ``site-packages``/``dist-packages`` (e.g. ``pip install .``) or laid out under
+        ``<sys.prefix>/lib`` (some embedded/PyInstaller images) classify as non-application and
+        are NOT rewritten, so the alias redirect does not reach them.
         """
         try:
             name = getattr(module, "__name__", "") or ""
-            for prefix in FunctionWrapper._ALIAS_SKIP_PREFIXES:
-                if name == prefix or name.startswith(prefix):
-                    return False
+            # Skip by name: the SDK's own dotted package trees (subtree match, trailing dot
+            # required), and wrapt / pytest / _pytest matched on the FIRST dotted component so a
+            # first-party module whose name merely begins with those letters (``wraptools``,
+            # ``pytest_fixtures``) is still treated as application code.
+            if (
+                name.startswith(FunctionWrapper._ALIAS_SKIP_PACKAGE_PREFIXES)
+                or name.split(".", 1)[0] in FunctionWrapper._ALIAS_SKIP_TOP_LEVEL
+            ):
+                return False
 
             spec = getattr(module, "__spec__", None)
-            origin = getattr(spec, "origin", None) if spec is not None else getattr(module, "__file__", None)
+            # Prefer the loader's spec.origin; fall back to __file__ when the spec is missing or its
+            # origin is None/unusable (some loaders, dynamically-created modules) but __file__ still
+            # points at a real source path.
+            origin = (getattr(spec, "origin", None) if spec is not None else None) or getattr(module, "__file__", None)
             # Built-in / frozen / namespace modules have no real file origin — skip them.
             if not origin or origin in ("built-in", "frozen", "namespace"):
                 return False
             origin = os.path.realpath(origin)
 
-            # Skip anything under installed packages.
-            for marker in ("site-packages", "dist-packages"):
-                if marker in origin:
-                    return False
+            # Skip anything under installed packages. Match a real path *component* (not a
+            # substring) so an app whose path merely contains the text (``/srv/my-site-packages/``)
+            # is not misclassified as a third-party dependency.
+            origin_parts = origin.split(os.sep)
+            if "site-packages" in origin_parts or "dist-packages" in origin_parts:
+                return False
             # Skip the standard library (under sys.prefix/lib but not the app's own tree).
             for libdir in stdlib_lib_dirs or FunctionWrapper._stdlib_lib_dirs():
                 if origin.startswith(libdir):

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_function_wrapper.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_function_wrapper.py
@@ -1090,5 +1090,85 @@ class TestModuleAliasRedirect(unittest.TestCase):
         self.assertGreaterEqual(rebound, 2)
 
 
+# ===========================================================================
+# _is_application_module classification (structural name/path matching)
+# ===========================================================================
+class TestIsApplicationModule(unittest.TestCase):
+    """Application-vs-non-application classification must be structural, not loose.
+
+    Regression guards for three false-negatives where legitimate first-party code was
+    misclassified as non-application (so its `from x import f` aliases were silently never
+    redirected): top-level name prefix matched as a bare string, ``site-packages`` matched as a
+    substring, and ``spec.origin`` taken without falling back to ``__file__``.
+    """
+
+    APP_ORIGIN = os.path.join(tempfile.gettempdir(), "di_isapp_unit", "server.py")
+
+    @staticmethod
+    def _module(name, *, spec_origin="__unset__", file_attr="__unset__"):
+        """Build a throwaway module with a controllable ``__spec__.origin`` and ``__file__``.
+
+        ``spec_origin``/``file_attr`` left at the sentinel mean "use APP_ORIGIN"; pass ``None`` to
+        omit/blank that attribute explicitly.
+        """
+        module = types.ModuleType(name)
+        file_attr = TestIsApplicationModule.APP_ORIGIN if file_attr == "__unset__" else file_attr
+        spec_origin = TestIsApplicationModule.APP_ORIGIN if spec_origin == "__unset__" else spec_origin
+        if file_attr is not None:
+            module.__file__ = file_attr
+        module.__spec__ = types.SimpleNamespace(origin=spec_origin, name=name)
+        return module
+
+    def _is_app(self, module):
+        return FunctionWrapper._is_application_module(module)
+
+    # --- Fix #3: top-level name matched on first dotted component, not bare prefix ----------
+    def test_app_names_beginning_with_skip_prefix_are_application(self):
+        for name in ("wraptools", "wrapt_helpers", "pytest_fixtures_local", "pytestutils"):
+            self.assertTrue(self._is_app(self._module(name)), f"{name} should be application code")
+
+    def test_skipped_packages_and_subtrees_still_excluded(self):
+        for name in (
+            "wrapt",
+            "wrapt.decorators",
+            "pytest",
+            "pytest.fixtures",
+            "_pytest",
+            "_pytest.config",
+            "opentelemetry.trace",
+            "amazon.opentelemetry.distro",
+        ):
+            self.assertFalse(self._is_app(self._module(name)), f"{name} must be excluded")
+
+    # --- Fix #1: site-packages/dist-packages matched as path components, not substrings -----
+    def test_app_path_containing_site_packages_substring_is_application(self):
+        for origin in (
+            os.path.join(tempfile.gettempdir(), "site-packages-demo", "myapp", "server.py"),
+            os.path.join(tempfile.gettempdir(), "my-site-packages", "app.py"),
+        ):
+            module = self._module("myapp", spec_origin=origin, file_attr=origin)
+            self.assertTrue(self._is_app(module), f"{origin} should be application code")
+
+    def test_real_site_and_dist_packages_components_still_excluded(self):
+        for origin in (
+            os.path.join(tempfile.gettempdir(), "venv", "lib", "python3.11", "site-packages", "foo", "__init__.py"),
+            os.path.join(tempfile.gettempdir(), "usr", "lib", "python3", "dist-packages", "bar.py"),
+        ):
+            module = self._module("foo", spec_origin=origin, file_attr=origin)
+            self.assertFalse(self._is_app(module), f"{origin} must be excluded")
+
+    # --- Fix #2b: fall back to __file__ when spec.origin is None ----------------------------
+    def test_falls_back_to_file_when_spec_origin_is_none(self):
+        module = self._module("myapp", spec_origin=None, file_attr=self.APP_ORIGIN)
+        self.assertTrue(
+            self._is_app(module),
+            "module with __spec__.origin=None but a valid __file__ should classify as application",
+        )
+
+    def test_no_usable_origin_anywhere_is_excluded(self):
+        module = self._module("myapp", spec_origin=None, file_attr=None)
+        self.assertFalse(self._is_app(module), "module with no usable origin must be excluded (fail-safe)")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_function_wrapper.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_function_wrapper.py
@@ -15,7 +15,9 @@ each test that needs module-level discovery.
 """
 
 import asyncio
+import os
 import sys
+import tempfile
 import threading
 import types
 import unittest
@@ -964,6 +966,128 @@ class TestClassMethodInstrumentation(_SnapshotEmitterFixture):
         self.assertIn("not found", str(caught.exception))
         self.assertIn("inherited from", str(caught.exception))
         self.assertNotIn("method", D.__dict__)
+
+
+# ===========================================================================
+# `from module import func` alias redirection (_patch_module_aliases)
+# ===========================================================================
+class TestModuleAliasRedirect(unittest.TestCase):
+    """Method-level install must redirect `from x import f` aliases in other app modules.
+
+    `from module import func` copies the function object into the importing module's
+    namespace; setattr on the defining module does not update that copy. These tests
+    verify the alias is redirected on install, restored on uninstall, and that the
+    scan is bounded (defining module, stdlib, and site-packages are never touched)
+    and never raises on an un-writable namespace.
+    """
+
+    @staticmethod
+    def _make_module(name, origin):
+        module = types.ModuleType(name)
+        module.__file__ = origin
+        module.__spec__ = types.SimpleNamespace(origin=origin, name=name)
+        sys.modules[name] = module
+        return module
+
+    def setUp(self):
+        # App-like file origins (outside stdlib / site-packages) so the modules
+        # classify as application code that the alias scan is willing to rewrite.
+        app_dir = os.path.join(tempfile.gettempdir(), "di_alias_unit_app")
+
+        def _orig(price_cents, discount_percent):
+            return price_cents - (price_cents * discount_percent // 100)
+
+        _orig.__module__ = "di_alias_defining_mod"
+        self.original = _orig
+
+        self.defining = self._make_module("di_alias_defining_mod", os.path.join(app_dir, "pricing.py"))
+        self.defining.apply_discount = _orig
+
+        # Consumer that did `from di_alias_defining_mod import apply_discount` (two aliases).
+        self.consumer = self._make_module("di_alias_consumer_mod", os.path.join(app_dir, "server.py"))
+        self.consumer.apply_discount = _orig
+        self.consumer.aliased_again = _orig
+
+        # A stdlib-like and a site-packages-like module that (pathologically) also
+        # reference the same object -- these must NOT be rewritten.
+        self.stdlike = self._make_module(
+            "di_alias_stdlike_mod", os.path.join(os.path.realpath(sys.prefix), "lib", "python3.x", "stdlike.py")
+        )
+        self.stdlike.apply_discount = _orig
+        self.sitelike = self._make_module(
+            "di_alias_sitelike_mod", os.path.join(app_dir, "site-packages", "third_party_pkg", "__init__.py")
+        )
+        self.sitelike.apply_discount = _orig
+
+        for name in (
+            "di_alias_defining_mod",
+            "di_alias_consumer_mod",
+            "di_alias_stdlike_mod",
+            "di_alias_sitelike_mod",
+        ):
+            self.addCleanup(lambda n=name: sys.modules.pop(n, None))
+
+    def test_install_redirects_alias_in_consumer_module(self):
+        def wrapper(*args, **kwargs):
+            return "wrapped"
+
+        rebound = FunctionWrapper._patch_module_aliases(self.defining, self.original, wrapper)
+
+        self.assertGreaterEqual(rebound, 2, "Both consumer aliases should be redirected")
+        self.assertIs(self.consumer.apply_discount, wrapper)
+        self.assertIs(self.consumer.aliased_again, wrapper)
+
+    def test_defining_module_is_not_rewritten(self):
+        def wrapper(*args, **kwargs):
+            return "wrapped"
+
+        FunctionWrapper._patch_module_aliases(self.defining, self.original, wrapper)
+        # The defining module's own attribute is owned by the caller (setattr happens
+        # separately); the alias scan must skip the defining module.
+        self.assertIs(self.defining.apply_discount, self.original)
+
+    def test_stdlib_and_site_packages_modules_are_not_touched(self):
+        def wrapper(*args, **kwargs):
+            return "wrapped"
+
+        FunctionWrapper._patch_module_aliases(self.defining, self.original, wrapper)
+        self.assertIs(self.stdlike.apply_discount, self.original, "stdlib-like module must be untouched")
+        self.assertIs(self.sitelike.apply_discount, self.original, "site-packages-like module must be untouched")
+
+    def test_restore_reverts_aliases(self):
+        def wrapper(*args, **kwargs):
+            return "wrapped"
+
+        FunctionWrapper._patch_module_aliases(self.defining, self.original, wrapper)
+        # Restore (swap args): redirect the wrapper references back to the original.
+        FunctionWrapper._patch_module_aliases(self.defining, wrapper, self.original)
+        self.assertIs(self.consumer.apply_discount, self.original)
+        self.assertIs(self.consumer.aliased_again, self.original)
+
+    def test_unwritable_namespace_does_not_raise(self):
+        class _Frozen(types.ModuleType):
+            def __setattr__(self, key, value):
+                if key == "apply_discount":
+                    raise RuntimeError("read-only")
+                super().__setattr__(key, value)
+
+        frozen = _Frozen("di_alias_frozen_mod")
+        object.__setattr__(frozen, "__file__", os.path.join(tempfile.gettempdir(), "di_alias_unit_app", "frozen.py"))
+        object.__setattr__(
+            frozen, "__spec__", types.SimpleNamespace(origin=frozen.__file__, name="di_alias_frozen_mod")
+        )
+        object.__setattr__(frozen, "apply_discount", self.original)
+        sys.modules["di_alias_frozen_mod"] = frozen
+        self.addCleanup(lambda: sys.modules.pop("di_alias_frozen_mod", None))
+
+        def wrapper(*args, **kwargs):
+            return "wrapped"
+
+        # Must not raise even though one module's setattr fails; other modules still rebind.
+        rebound = FunctionWrapper._patch_module_aliases(self.defining, self.original, wrapper)
+        self.assertIs(self.consumer.apply_discount, wrapper)
+        self.assertIs(frozen.apply_discount, self.original, "frozen module attribute should be unchanged")
+        self.assertGreaterEqual(rebound, 2)
 
 
 if __name__ == "__main__":

--- a/contract-tests/images/applications/di-flask/di_flask_server.py
+++ b/contract-tests/images/applications/di-flask/di_flask_server.py
@@ -105,6 +105,12 @@ def process_small_limit_string(small_limit_string):
 
 from mock_di_api import set_breakpoint_configs, set_probe_configs, start_mock_api  # noqa: E402
 
+# Import a target function via `from module import func` so the executing call site
+# (the /from-import route below) holds a bare-name alias in THIS module's namespace
+# rather than in the defining module. A method-level breakpoint on
+# pricing_service.apply_discount must redirect this alias for instrumentation to fire.
+from pricing_service import apply_discount  # noqa: E402
+
 BREAKPOINT_CONFIGS = [
     # Function-level breakpoint on process_data
     {
@@ -254,6 +260,31 @@ BREAKPOINT_CONFIGS = [
             }
         },
     },
+    # Function-level breakpoint on apply_discount, which is DEFINED in pricing_service
+    # but CALLED via a `from pricing_service import apply_discount` bare-name alias in
+    # di_flask_server. The call site resolves the importing module's alias, so a
+    # method-level install must redirect that alias (not just the defining module's
+    # attribute) for this snapshot to be produced. CodeUnit is the defining module.
+    {
+        "InstrumentationType": "BREAKPOINT",
+        "SignalType": "SNAPSHOT",
+        "Location": {
+            "CodeLocation": {
+                "Language": "Python",
+                "CodeUnit": "pricing_service",
+                "MethodName": "apply_discount",
+                "FilePath": "pricing_service.py",
+            }
+        },
+        "LocationHash": "aabb00000000000a",
+        "CaptureConfiguration": {
+            "CodeCapture": {
+                "CaptureReturn": True,
+                "CaptureArguments": ["price_cents", "discount_percent"],
+                "CaptureLimits": {"MaxStringLength": 255},
+            }
+        },
+    },
 ]
 
 PROBE_CONFIGS = [
@@ -375,6 +406,17 @@ def limits_small_string_endpoint():
     small_limit_string = "B" * 100
     result = process_small_limit_string(small_limit_string)
     return jsonify({"status": "ok", "length": result})
+
+
+@app.route("/from-import")
+def from_import_endpoint():
+    """Endpoint that calls a function reached via `from pricing_service import apply_discount`.
+
+    The call uses the bare imported name, so the method-level breakpoint on
+    pricing_service.apply_discount only fires if the alias in this module is redirected.
+    """
+    result = apply_discount(1999, 15)
+    return jsonify({"status": "ok", "final_cents": result})
 
 
 @app.route("/error")

--- a/contract-tests/images/applications/di-flask/pricing_service.py
+++ b/contract-tests/images/applications/di-flask/pricing_service.py
@@ -1,0 +1,18 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Service module for the DI Flask contract app.
+
+This module exists specifically to exercise the ``from module import func``
+aliasing case for method-level (function-level) breakpoints. ``di_flask_server``
+imports ``apply_discount`` via ``from pricing_service import apply_discount`` and
+calls it by its bare name, so the executing call site holds a reference in the
+*importing* module's namespace -- not in this defining module. A method-level
+breakpoint must redirect that alias for instrumentation to fire.
+"""
+
+
+def apply_discount(price_cents, discount_percent):
+    """Method-level BREAKPOINT target reached via a `from x import` alias."""
+    discount = price_cents * discount_percent // 100
+    final_cents = price_cents - discount
+    return final_cents

--- a/contract-tests/tests/test/amazon/di/flask_test.py
+++ b/contract-tests/tests/test/amazon/di/flask_test.py
@@ -89,6 +89,69 @@ class DIFlaskFunctionLevelTest(DITestInfrastructure):
 
 
 # =============================================================================
+# Function-level BREAKPOINT via `from module import func` alias
+# =============================================================================
+
+
+class DIFlaskFromImportAliasTest(DITestInfrastructure):
+    """Function-level breakpoint on a function reached via a `from x import f` alias.
+
+    ``apply_discount`` is DEFINED in ``pricing_service`` but CALLED via
+    ``from pricing_service import apply_discount`` (bare name) in ``di_flask_server``.
+    The executing call site therefore resolves the alias in the importing module's
+    namespace, not the defining module's attribute. A method-level install must
+    redirect that alias for the snapshot to be produced. This is a regression guard:
+    without the alias-redirect fix, instrumentation installs (config reports READY)
+    but never fires, so no snapshot is generated.
+    """
+
+    __test__ = True
+
+    @override
+    @staticmethod
+    def get_application_image_name() -> str:
+        return _APP_IMAGE
+
+    @override
+    def get_application_wait_pattern(self) -> str:
+        return "Ready"
+
+    def test_from_import_alias_snapshot_generated(self) -> None:
+        """A method-level snapshot is produced even though the call site uses a from-import alias."""
+        response = self.send_request("GET", "from-import")
+        self.assertEqual(200, response.status_code)
+
+        logs = self.wait_for_snapshots(min_count=1)
+        method_logs = self.logs_for_method(logs, "apply_discount")
+        self.assertGreater(
+            len(method_logs),
+            0,
+            "Expected a snapshot for apply_discount called via `from pricing_service import apply_discount`. "
+            "If absent, the method-level install did not redirect the importing module's alias.",
+        )
+
+        log = method_logs[0]
+        self.assert_snapshot_attr(log, "aws.di.instrumentation_level", "method")
+        self.assert_snapshot_attr(log, "aws.di.code_unit", "pricing_service")
+        self.assert_body_has_entry_or_return(log)
+
+    def test_from_import_alias_captures_arguments_and_return(self) -> None:
+        """The from-import alias snapshot captures the real entry args and return value."""
+        self.send_request("GET", "from-import")
+        logs = self.wait_for_snapshots(min_count=1)
+        log = self.logs_for_method(logs, "apply_discount")[0]
+
+        body = self.body(log)
+        captures = body.get("captures", {})
+        arguments = captures.get("entry", {}).get("arguments", {})
+        self.assertIn("price_cents", arguments, "Expected 'price_cents' argument to be captured")
+        self.assertIn("discount_percent", arguments, "Expected 'discount_percent' argument to be captured")
+        # apply_discount(1999, 15) -> 1999 - (1999*15//100=299) = 1700
+        return_value = captures.get("return", {}).get("return_value", {})
+        self.assertEqual(return_value.get("value"), "1700")
+
+
+# =============================================================================
 # PROBE instrumentation tests
 # =============================================================================
 


### PR DESCRIPTION
## Description

A method-level (function-level) Dynamic Instrumentation breakpoint installs its wrapper by `setattr`-ing the wrapper onto the **defining module's** attribute (plus patching Flask/Django/FastAPI route tables). When a caller imports the target with `from module import func` and then calls the **bare name**, that caller holds an *independent* reference in its own module namespace. `setattr` on the defining module does not update that copy, so the caller keeps invoking the original, un-instrumented function.

The result is a silent failure: the breakpoint reports **READY**, no error is logged, but it **never fires** and no snapshot is produced. `from module import func` is a common, PEP 8-sanctioned import style, so this affects a large class of real applications. (Line-level breakpoints are unaffected because the `sys.monitoring` engine binds the code object directly.)

## Fix

`FunctionWrapper` now redirects those module-level aliases on install (and restores them on uninstall) via a new `_patch_module_aliases` helper, generalizing the existing framework-reference patching to plain module-level references.

The scan is deliberately bounded for safety (this is a safety-critical agent — it must never break the user's application):

- **Application modules only.** `_is_application_module` excludes the standard library, `site-packages`/`dist-packages` (third-party deps), built-in/frozen/namespace modules, and the OpenTelemetry/ADOT SDK itself. Classification fails closed (when in doubt, don't touch).
- **Identity match only** (`attr is original_func`) — never name-based guessing.
- **Module-level attributes only** — never reaches into dicts/registries/containers.
- **`sys.modules` and each module's `vars()` are snapshotted** before iterating, so a concurrent import cannot cause "dictionary changed size during iteration."
- **Every `setattr` is individually guarded**, and the helper never raises — a failure to rewrite one reference never aborts the rest or the poller.
- **Symmetric on uninstall** — deleting the breakpoint restores the aliases to the original, returning the app to its prior state.

### Performance

The scan runs **once per method-level breakpoint install/uninstall, on the polling thread** — not on the application request path, and not per poll (gated by the manager's change detection). The per-call wrapper is unchanged, so steady-state cost of an active breakpoint is unaffected. `realpath()` of the stdlib prefixes is computed once per scan (not per module), and module classification is memoized per scan.

## Scope / known limitations

- References captured into **local variables, closures, default arguments, or data structures** cannot be reached by any name-based rebind; those remain out of scope (use a line-level breakpoint).
- Applications installed/run from **`site-packages`** (e.g. `pip install .`, or copied into the image's site-packages) classify as non-application and are not rewritten — fail-safe, but a coverage gap; a follow-up could key "application module" off the defining module's own package tree.
- This change is independent of and complementary to the FastAPI `Depends()` sub-dependency rebind (#785) — different reference location (route dependant tree vs. module namespace), no overlap.

## Testing

- **Unit tests** (`test_function_wrapper.py::TestModuleAliasRedirect`): alias redirected on install; defining module skipped; stdlib and site-packages modules untouched; restore reverts; an un-writable namespace does not raise. Full debugger unit suite: 550 passed.
- **Contract test** (`flask_test.py::DIFlaskFromImportAliasTest`): a new `pricing_service.apply_discount` target reached via `from pricing_service import apply_discount` in `di_flask_server`; asserts a method-level snapshot with the correct arguments and return value is produced through the alias. Verified as a genuine regression guard — it passes with the fix and fails without it (the breakpoint installs but never fires).
- Lint clean (black, isort, flake8) and pylint 10.00/10.
