### PR TITLE
fix(dynamic-instrumentation): bind FastAPI sub-dependencies, Starlette/aiohttp & functools.partial handlers, and surface non-bindable line breakpoints

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/debugger/_function_wrapper.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/debugger/_function_wrapper.py
@@ -1415,20 +1415,30 @@ class FunctionWrapper:
                     if endpoint is None or not _matches(endpoint):
                         continue
                     # Starlette applies per-route middleware INTO route.app at construction
-                    # time (and keeps no `middleware` attribute), so a plain route's app is the
-                    # ``request_response`` closure while a middleware-wrapped route's app is the
-                    # outermost middleware instance. Only rebuild when route.app is recognizably
-                    # the plain request_response closure — otherwise rebuilding would silently
-                    # drop the middleware stack. Skipping is a safe no-op (DI won't instrument
-                    # this particular handler), never a correctness change to the app.
-                    current_app = getattr(route, "app", None)
-                    is_plain_request_response = getattr(
-                        current_app, "__module__", None
-                    ) == "starlette.routing" and getattr(current_app, "__qualname__", "").startswith("request_response")
-                    if not is_plain_request_response:
-                        logger.debug(
-                            "Starlette route '%s' has a non-plain app (likely per-route middleware); "
-                            "skipping rebuild to avoid dropping it (DI will not instrument this handler).",
+                    # time (and keeps no `middleware` attribute): a plain route's app is the
+                    # ``request_response`` closure that directly captures the endpoint, while a
+                    # middleware-wrapped route's app is the outermost middleware instance. We
+                    # only rebuild when route.app is the plain closure over THIS endpoint —
+                    # otherwise rebuilding would silently drop the middleware stack. Skipping is
+                    # a safe no-op (DI won't instrument this handler), never a correctness change.
+                    #
+                    # Detect structurally (not by the closure's function name, which a future
+                    # Starlette could rename): is the route's live function captured in
+                    # route.app's closure cells — directly (async endpoints) or inside a
+                    # functools.partial's args (sync endpoints wrapped via run_in_threadpool)?
+                    # That is the condition under which `request_response(new_func)` is a
+                    # faithful rebuild. Accept either the matched endpoint or original_func: in
+                    # the name+module fallback path route.endpoint may have been externally
+                    # swapped while route.app still closes over original_func.
+                    route_app = getattr(route, "app", None)
+                    if not (
+                        FunctionWrapper._starlette_app_wraps_endpoint(route_app, endpoint)
+                        or FunctionWrapper._starlette_app_wraps_endpoint(route_app, original_func)
+                    ):
+                        logger.warning(
+                            "Starlette route '%s' app does not plainly wrap the endpoint (per-route "
+                            "middleware, or an unrecognized Starlette internal); skipping rebuild to "
+                            "avoid dropping it. DI will not instrument this handler.",
                             getattr(route, "path", "?"),
                         )
                         continue
@@ -1444,6 +1454,33 @@ class FunctionWrapper:
         patched = _walk(routes)
         if patched:
             logger.debug("Patched %d Starlette route(s) for function '%s' on app '%s'", patched, func_name, app_name)
+
+    @staticmethod
+    def _starlette_app_wraps_endpoint(route_app, endpoint) -> bool:
+        """Return True iff ``route_app`` is the plain Starlette request_response closure
+        that captures ``endpoint`` — so rebuilding via request_response(new_func) is faithful.
+
+        Detection is structural, not name-based, so a future Starlette rename of the inner
+        closure does not silently classify every plain route as "non-plain" (which would
+        re-introduce the never-fires bug). Starlette's ``request_response`` closes over the
+        endpoint: directly for async endpoints, and inside a ``functools.partial`` (the
+        run_in_threadpool wrapper) for sync endpoints. A middleware-wrapped route.app is a
+        middleware instance with no ``__closure__`` and so returns False.
+        """
+        closure = getattr(route_app, "__closure__", None)
+        if not closure:
+            return False
+        for cell in closure:
+            try:
+                value = cell.cell_contents
+            except Exception:  # pylint: disable=broad-exception-caught
+                continue
+            if value is endpoint:
+                return True
+            # Sync endpoints are wrapped in functools.partial(run_in_threadpool, endpoint).
+            if isinstance(value, functools.partial) and endpoint in value.args:
+                return True
+        return False
 
     @staticmethod
     def _patch_aiohttp_routes(module, original_func: Callable, new_func: Callable) -> None:
@@ -1489,9 +1526,10 @@ class FunctionWrapper:
     ):
         """Rebind the stored handler on matching aiohttp routes for one Application.
 
-        Iterates ``app.router.routes()`` and rebinds each route's handler (``_handler``,
-        accessed via the public ``route.handler`` property) when it matches by identity,
-        then by name+module (mirroring the other framework patchers).
+        Iterates ``app.router.routes()`` and, when a route matches by identity then by
+        name+module (mirroring the other framework patchers), rebinds its handler. The match
+        reads the public read-only ``route.handler`` property; the rebind writes the backing
+        ``route._handler`` attribute directly because aiohttp exposes no public setter.
         """
         router = getattr(aiohttp_app, "router", None)
         if router is None:
@@ -1519,11 +1557,22 @@ class FunctionWrapper:
                 handler = getattr(route, "handler", None)
                 if handler is None or not _matches(handler):
                     continue
-                # The route stores the handler on its resource entry as ``_handler``.
+                # Asymmetry by necessity: aiohttp exposes the handler read-only via the public
+                # ``route.handler`` property (used above to match), but provides no public setter,
+                # so the rebind must write the backing ``_handler`` attribute directly. If a future
+                # aiohttp renames that backing attribute, the match would succeed but the write
+                # target would be missing — warn (instead of silently no-op'ing) so that becomes
+                # observable rather than a silent never-fires.
                 if hasattr(route, "_handler"):
                     route._handler = new_func  # pylint: disable=protected-access
                     patched += 1
                     logger.debug("Patched aiohttp route handler '%s' to use DI wrapper", func_name)
+                else:
+                    logger.warning(
+                        "aiohttp route matched handler '%s' but has no writable `_handler` attribute "
+                        "(aiohttp internals may have changed); DI will not instrument this handler.",
+                        func_name,
+                    )
             except Exception as exc:  # pylint: disable=broad-exception-caught
                 logger.warning("Error patching aiohttp route for '%s': %s", func_name, exc)
                 continue

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/debugger/_function_wrapper.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/debugger/_function_wrapper.py
@@ -168,8 +168,15 @@ class FunctionWrapper:
                 # Regular function
                 original_func = discovered
 
-            # Create the instrumented wrapper
-            instrumented_func = self._create_wrapper(original_func, capture_config, module_name, location_hash, manager)
+            # Create the instrumented wrapper. Pass the configured function_name so the
+            # wrapper's runtime _active_functions lookup uses the SAME key the manager
+            # registered under (module.function_name). Without this, a target whose
+            # runtime __qualname__/__name__ differs from the configured name — e.g. a
+            # functools.partial, whose _get_qualified_name() yields "<anonymous>" — would
+            # compute a mismatched key, miss its breakpoint set, and silently never fire.
+            instrumented_func = self._create_wrapper(
+                original_func, capture_config, module_name, location_hash, manager, function_name
+            )
 
             # Re-apply the descriptor type so instance access binds correctly.
             if method_type == MethodType.STATIC:
@@ -440,6 +447,7 @@ class FunctionWrapper:
         module_name: str,
         location_hash: Optional[str] = None,
         manager=None,
+        function_name: Optional[str] = None,
     ) -> Callable:
         """
         Create instrumented wrapper that handles both sync and async functions.
@@ -450,13 +458,21 @@ class FunctionWrapper:
             module_name: Module name for snapshot metadata
             location_hash: Optional location hash for instrumentation ID
             manager: Optional InstrumentationManager for hit count checking
+            function_name: The configured target name (module-relative, e.g. "my_fn"
+                or "MyClass.method"). Used to build the runtime _active_functions key so
+                it matches the manager's registration key even when the target's runtime
+                __qualname__/__name__ differs (e.g. functools.partial → "<anonymous>").
 
         Returns:
             Instrumented wrapper function
         """
         if inspect.iscoroutinefunction(original_func):
-            return self._create_async_wrapper(original_func, capture_config, module_name, location_hash, manager)
-        return self._create_sync_wrapper(original_func, capture_config, module_name, location_hash, manager)
+            return self._create_async_wrapper(
+                original_func, capture_config, module_name, location_hash, manager, function_name
+            )
+        return self._create_sync_wrapper(
+            original_func, capture_config, module_name, location_hash, manager, function_name
+        )
 
     def _create_sync_wrapper(  # pylint: disable=too-many-arguments,too-many-statements
         self,
@@ -465,6 +481,7 @@ class FunctionWrapper:
         module_name: str,
         location_hash: Optional[str] = None,
         manager=None,
+        function_name: Optional[str] = None,
     ) -> Callable:
         """Create synchronous wrapper that produces Snapshots instead of Spans."""
         wrapper_self = self
@@ -477,7 +494,11 @@ class FunctionWrapper:
             # Check if all temporary breakpoints are disabled
             line0_breakpoint_key = None
             instr_type = None
-            qualified_name = FunctionWrapper._get_qualified_name(original_func)
+            # Prefer the configured target name for keying/snapshot metadata; fall back to
+            # runtime introspection. This keeps the _active_functions lookup key aligned
+            # with the manager's registration key for targets whose runtime name differs
+            # (e.g. functools.partial → "<anonymous>").
+            qualified_name = function_name or FunctionWrapper._get_qualified_name(original_func)
             # Defensive local snapshot of manager for clarity. The actual safety
             # against shutdown races is provided by the try/except below.
             mgr = manager
@@ -582,6 +603,7 @@ class FunctionWrapper:
         module_name: str,
         location_hash: Optional[str] = None,
         manager=None,
+        function_name: Optional[str] = None,
     ) -> Callable:
         """Create asynchronous wrapper that produces Snapshots instead of Spans."""
         wrapper_self = self
@@ -596,7 +618,10 @@ class FunctionWrapper:
             # Check if all temporary breakpoints are disabled
             line0_breakpoint_key = None
             instr_type = None
-            qualified_name = FunctionWrapper._get_qualified_name(original_func)
+            # As in the sync wrapper: prefer the configured name so the lookup key
+            # matches the manager's registration key for partials and other callables
+            # whose runtime __qualname__/__name__ is not the configured name.
+            qualified_name = function_name or FunctionWrapper._get_qualified_name(original_func)
             # Defensive local snapshot of manager for clarity. The actual safety
             # against shutdown races is provided by the try/except below.
             mgr = manager
@@ -799,6 +824,8 @@ class FunctionWrapper:
         - Django: patches URLPattern.callback entries (incl. include()-nested resolvers)
           that reference the original function
         - FastAPI: patches APIRoute.endpoint / APIRoute.dependant.call on app.router.routes
+        - Starlette (pure, non-FastAPI): rebuilds Route.app from new_func (FastAPI is skipped)
+        - aiohttp: rebinds the stored handler on app.router routes
 
         Args:
             module: The module object containing the function
@@ -822,6 +849,18 @@ class FunctionWrapper:
             FunctionWrapper._patch_fastapi_routes(module, original_func, new_func)
         except Exception as exc:  # pylint: disable=broad-exception-caught
             logger.debug("fastapi reference patching encountered an error: %s", exc)
+        try:
+            # Starlette (pure, non-FastAPI): patch Route.app on any Starlette app instances.
+            # FastAPI subclasses Starlette and is handled by _patch_fastapi_routes above, so
+            # this patcher explicitly skips FastAPI instances to avoid double-patching.
+            FunctionWrapper._patch_starlette_routes(module, original_func, new_func)
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.debug("starlette reference patching encountered an error: %s", exc)
+        try:
+            # aiohttp: patch the stored handler on any aiohttp.web.Application instances.
+            FunctionWrapper._patch_aiohttp_routes(module, original_func, new_func)
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.debug("aiohttp reference patching encountered an error: %s", exc)
 
     @staticmethod
     def _patch_flask_view_functions(module, original_func: Callable, new_func: Callable) -> None:
@@ -1282,6 +1321,215 @@ class FunctionWrapper:
                 func_name,
                 func_module,
             )
+
+    @staticmethod
+    def _patch_starlette_routes(module, original_func: Callable, new_func: Callable) -> None:
+        """
+        Patch Starlette route handlers that reference the original function.
+
+        Starlette's ``Route(path, endpoint)`` builds ``route.app = request_response(endpoint)``
+        at construction (import) time, capturing the ORIGINAL endpoint in a closure. The
+        per-request path invokes ``route.app`` — never ``route.endpoint`` — so replacing the
+        module-level name via setattr (or even rebinding ``route.endpoint``) does NOT reach the
+        live handler. To actually instrument it we must rebuild ``route.app`` from new_func.
+
+        FastAPI subclasses Starlette and is handled by ``_patch_fastapi_routes``; this method
+        explicitly SKIPS FastAPI instances so a working FastAPI app is never double-patched.
+
+        Args:
+            module: The module object that may contain Starlette app instances
+            original_func: The original function to find on route endpoints
+            new_func: The new wrapper function to rebuild the route app from
+        """
+        try:
+            try:
+                from starlette.applications import Starlette  # pylint: disable=import-outside-toplevel
+                from starlette.routing import Route, request_response  # pylint: disable=import-outside-toplevel
+            except ImportError:
+                return  # Starlette not installed, nothing to patch
+
+            # FastAPI is a Starlette subclass handled by its own patcher; skip it here.
+            try:
+                from fastapi import FastAPI  # pylint: disable=import-outside-toplevel
+            except ImportError:
+                FastAPI = None  # noqa: N806 — sentinel; not installed
+
+            func_name = getattr(original_func, "__name__", "unknown")
+            func_module = getattr(original_func, "__module__", None)
+
+            for attr_name in dir(module):
+                try:
+                    attr = getattr(module, attr_name, None)
+                    if attr is None or not isinstance(attr, Starlette):
+                        continue
+                    if FastAPI is not None and isinstance(attr, FastAPI):
+                        continue  # handled by _patch_fastapi_routes
+                    FunctionWrapper._patch_single_starlette_app(
+                        attr, attr_name, original_func, new_func, func_name, func_module, Route, request_response
+                    )
+                except Exception as exc:  # pylint: disable=broad-exception-caught
+                    logger.warning("Error checking module attribute '%s' for Starlette app: %s", attr_name, exc)
+                    continue
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.warning("Error patching Starlette routes: %s", exc)
+
+    @staticmethod
+    def _patch_single_starlette_app(  # pylint: disable=too-many-arguments,too-many-locals
+        starlette_app, app_name, original_func, new_func, func_name, func_module, route_cls, request_response
+    ):
+        """Rebuild ``route.app`` for any Route whose endpoint matches, on one Starlette app.
+
+        Matches by identity first, then by name+module (mirroring the Flask/FastAPI/Django
+        patchers). Only function/method endpoints are rebuilt; class (ASGI) endpoints and
+        routes that carry per-route middleware are left untouched (rebuilding their ``app``
+        could drop the middleware stack — a deliberate safe no-op, logged at debug).
+        ``Mount``/sub-router routes are descended into recursively.
+        """
+        router = getattr(starlette_app, "router", None)
+        routes = getattr(router, "routes", None)
+        if not isinstance(routes, list):
+            logger.debug("Starlette app '%s' has no router.routes list", app_name)
+            return
+
+        def _matches(endpoint) -> bool:
+            if endpoint is original_func:
+                return True
+            if getattr(endpoint, "__name__", None) != func_name:
+                return False
+            if func_module is not None and getattr(endpoint, "__module__", None) != func_module:
+                return False
+            return True
+
+        def _walk(route_list, depth=0):
+            count = 0
+            if depth > 20:  # defensive: avoid pathological/cyclic mount nesting
+                return count
+            for route in route_list:
+                try:
+                    # Descend into Mount / sub-router routes.
+                    sub = getattr(getattr(route, "app", None), "routes", None) or getattr(route, "routes", None)
+                    if sub and not isinstance(route, route_cls):
+                        count += _walk(sub, depth + 1)
+                        continue
+                    endpoint = getattr(route, "endpoint", None)
+                    if endpoint is None or not _matches(endpoint):
+                        continue
+                    # Starlette applies per-route middleware INTO route.app at construction
+                    # time (and keeps no `middleware` attribute), so a plain route's app is the
+                    # ``request_response`` closure while a middleware-wrapped route's app is the
+                    # outermost middleware instance. Only rebuild when route.app is recognizably
+                    # the plain request_response closure — otherwise rebuilding would silently
+                    # drop the middleware stack. Skipping is a safe no-op (DI won't instrument
+                    # this particular handler), never a correctness change to the app.
+                    current_app = getattr(route, "app", None)
+                    is_plain_request_response = getattr(
+                        current_app, "__module__", None
+                    ) == "starlette.routing" and getattr(current_app, "__qualname__", "").startswith("request_response")
+                    if not is_plain_request_response:
+                        logger.debug(
+                            "Starlette route '%s' has a non-plain app (likely per-route middleware); "
+                            "skipping rebuild to avoid dropping it (DI will not instrument this handler).",
+                            getattr(route, "path", "?"),
+                        )
+                        continue
+                    route.endpoint = new_func
+                    route.app = request_response(new_func)
+                    count += 1
+                    logger.debug("Patched Starlette route '%s' to use DI wrapper", getattr(route, "path", "?"))
+                except Exception as exc:  # pylint: disable=broad-exception-caught
+                    logger.warning("Error patching Starlette route '%s': %s", getattr(route, "path", "?"), exc)
+                    continue
+            return count
+
+        patched = _walk(routes)
+        if patched:
+            logger.debug("Patched %d Starlette route(s) for function '%s' on app '%s'", patched, func_name, app_name)
+
+    @staticmethod
+    def _patch_aiohttp_routes(module, original_func: Callable, new_func: Callable) -> None:
+        """
+        Patch aiohttp route handlers that reference the original function.
+
+        aiohttp's ``app.router.add_get(path, handler)`` (and ``@routes.get`` decorators)
+        store the handler on each resource's route as ``_handler``; the per-request path
+        invokes that stored handler, not the module-level name. Replacing the module name
+        via setattr does not reach it, so we rebind the stored handler directly.
+
+        Args:
+            module: The module object that may contain aiohttp Application instances
+            original_func: The original handler to find in the route table
+            new_func: The new wrapper function to rebind to
+        """
+        try:
+            try:
+                from aiohttp import web  # pylint: disable=import-outside-toplevel
+            except ImportError:
+                return  # aiohttp not installed, nothing to patch
+
+            func_name = getattr(original_func, "__name__", "unknown")
+            func_module = getattr(original_func, "__module__", None)
+
+            for attr_name in dir(module):
+                try:
+                    attr = getattr(module, attr_name, None)
+                    if attr is None or not isinstance(attr, web.Application):
+                        continue
+                    FunctionWrapper._patch_single_aiohttp_app(
+                        attr, attr_name, original_func, new_func, func_name, func_module
+                    )
+                except Exception as exc:  # pylint: disable=broad-exception-caught
+                    logger.warning("Error checking module attribute '%s' for aiohttp app: %s", attr_name, exc)
+                    continue
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.warning("Error patching aiohttp routes: %s", exc)
+
+    @staticmethod
+    def _patch_single_aiohttp_app(  # pylint: disable=too-many-arguments,too-many-locals
+        aiohttp_app, app_name, original_func, new_func, func_name, func_module
+    ):
+        """Rebind the stored handler on matching aiohttp routes for one Application.
+
+        Iterates ``app.router.routes()`` and rebinds each route's handler (``_handler``,
+        accessed via the public ``route.handler`` property) when it matches by identity,
+        then by name+module (mirroring the other framework patchers).
+        """
+        router = getattr(aiohttp_app, "router", None)
+        if router is None:
+            logger.debug("aiohttp app '%s' has no router", app_name)
+            return
+
+        try:
+            routes = list(router.routes())
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.debug("aiohttp app '%s' router.routes() not iterable: %s", app_name, exc)
+            return
+
+        def _matches(handler) -> bool:
+            if handler is original_func:
+                return True
+            if getattr(handler, "__name__", None) != func_name:
+                return False
+            if func_module is not None and getattr(handler, "__module__", None) != func_module:
+                return False
+            return True
+
+        patched = 0
+        for route in routes:
+            try:
+                handler = getattr(route, "handler", None)
+                if handler is None or not _matches(handler):
+                    continue
+                # The route stores the handler on its resource entry as ``_handler``.
+                if hasattr(route, "_handler"):
+                    route._handler = new_func  # pylint: disable=protected-access
+                    patched += 1
+                    logger.debug("Patched aiohttp route handler '%s' to use DI wrapper", func_name)
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                logger.warning("Error patching aiohttp route for '%s': %s", func_name, exc)
+                continue
+
+        if patched:
+            logger.debug("Patched %d aiohttp route(s) for function '%s' on app '%s'", patched, func_name, app_name)
 
     @staticmethod
     def _get_qualified_name(original_func: Callable) -> str:

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/debugger/_status_reporter.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/debugger/_status_reporter.py
@@ -147,6 +147,10 @@ class StatusReporter:
         """
         with self._manager._lock:
             bp_sets_snapshot = list(self._manager._active_functions.values())
+            # Location hashes the manager could not bind (e.g. a line-level breakpoint on a
+            # target with no __code__). Their ERROR is reported immediately by the manager; the
+            # periodic/initial sweep must not promote them to READY (which would mask the error).
+            failed_config_ids = set(getattr(self._manager, "_failed_configs", {}))
 
         with self._lock:
             ready_entries = []
@@ -188,8 +192,9 @@ class StatusReporter:
                                 )
                             )
 
-                    # Report Ready once (only in initial reports, only if never hit)
-                    if state.hit_count == 0 and is_initial_report:
+                    # Report Ready once (only in initial reports, only if never hit, and only if
+                    # the config bound successfully — a failed config keeps its ERROR status).
+                    if state.hit_count == 0 and is_initial_report and state.location_hash not in failed_config_ids:
                         config_key = StatusReporter._get_config_key(
                             "SNAPSHOT", state.location_hash, ConfigurationStatus.READY
                         )

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/debugger/instrumentation_manager.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/debugger/instrumentation_manager.py
@@ -451,6 +451,29 @@ class InstrumentationManager:
                     "Function wrapping will work, but line breakpoints will not.",
                     bp_set.function_key,
                 )
+            elif self._engine and bp_set.line_numbers and bp_set.code_object is None:
+                # The target resolved to a callable with no __code__ (e.g. a callable-class
+                # instance or a functools.partial used as the target), so the line engine
+                # cannot be armed. Previously this was skipped silently and the config still
+                # reported READY -- indistinguishable from "waiting for traffic". Surface a
+                # non-silent error for the LINE-level configs so the misconfiguration is
+                # visible. A co-located function-level (line 0) breakpoint, if any, is left to
+                # proceed below; only the line-level configs are marked errored.
+                for line_num, bp_config in bp_set.breakpoints.items():
+                    if line_num > 0 and bp_config.config_id:
+                        self._failed_configs[bp_config.config_id] = ErrorCause.LINE_NOT_EXECUTABLE
+                        self._report_immediate(
+                            bp_config.config_id,
+                            bp_config.instrumentation_type,
+                            ConfigurationStatus.ERROR,
+                            ErrorCause.LINE_NOT_EXECUTABLE,
+                        )
+                logger.warning(
+                    "Cannot set line breakpoints for %s: target has no __code__ object "
+                    "(e.g. a callable-class instance or functools.partial). Reported "
+                    "LINE_NOT_EXECUTABLE for the line-level configuration(s).",
+                    bp_set.function_key,
+                )
 
             # Restore/create states for each breakpoint (including function-level line 0)
             for line_num in bp_set.breakpoints.keys():
@@ -785,9 +808,12 @@ class InstrumentationManager:
                             succeeded.append(func_key)
                             logger.debug("Successfully updated function %s", func_key)
 
-                            # Report READY immediately for each config in the updated function
+                            # Report READY immediately for each config in the updated function.
+                            # Skip configs that _apply_function already marked failed (e.g. a
+                            # line-level breakpoint on a target with no __code__), so the ERROR
+                            # status it reported is not overwritten by a misleading READY.
                             for bp in new_bp_set.breakpoints.values():
-                                if bp.config_id:
+                                if bp.config_id and bp.config_id not in self._failed_configs:
                                     self._report_immediate(
                                         bp.config_id, bp.instrumentation_type, ConfigurationStatus.READY
                                     )
@@ -799,9 +825,10 @@ class InstrumentationManager:
                             succeeded.append(func_key)
                             logger.debug("Successfully added function %s", func_key)
 
-                            # Report READY immediately for each config in the new function
+                            # Report READY immediately for each config in the new function.
+                            # Skip configs that _apply_function already marked failed (see above).
                             for bp in new_bp_set.breakpoints.values():
-                                if bp.config_id:
+                                if bp.config_id and bp.config_id not in self._failed_configs:
                                     self._report_immediate(
                                         bp.config_id, bp.instrumentation_type, ConfigurationStatus.READY
                                     )

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/debugger/instrumentation_manager.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/debugger/instrumentation_manager.py
@@ -72,7 +72,7 @@ class InstrumentationManager:
         # Failed configuration tracking: location_hash -> error_cause
         # Prevents retrying the same broken config on every poll cycle.
         # Entries are cleared when the config is removed from the incoming list.
-        self._failed_configs: Dict[str, str] = {}
+        self._failed_configs: Dict[str, ErrorCause] = {}
 
         # Thread safety
         self._lock = RLock()

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_function_wrapper.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_function_wrapper.py
@@ -529,9 +529,10 @@ class TestSyncWrapper(_SnapshotEmitterFixture):
     def _instrument(self, func, *, increment_result=True, has_line0=True, disabled=False, capture_config=None):
         func_name = func.__name__
         module = _register_module(self.module_name, **{func_name: func})
-        # The wrapper keys breakpoint sets by the function's __qualname__, so the
-        # FunctionBreakpointSet must be registered under the same key.
-        func_key = f"{self.module_name}.{FunctionWrapper._get_qualified_name(func)}"
+        # The manager registers breakpoint sets under config.function_key == module.function_name
+        # (the CONFIGURED target name), and the wrapper now keys its lookup the same way,
+        # so register under module.func_name — not the runtime __qualname__.
+        func_key = f"{self.module_name}.{func_name}"
         bp_set = _make_function_bp_set(func_key, self.module_name, func_name, has_line0=has_line0, disabled=disabled)
         manager = _FakeManager({func_key: bp_set}, increment_result=increment_result)
         capture_config = capture_config if capture_config is not None else CaptureConfig(capture_return=True)
@@ -549,6 +550,42 @@ class TestSyncWrapper(_SnapshotEmitterFixture):
         self.assertEqual(result, 7)
         self.assertIs(original, add)
         self.emitter.emit_snapshot.assert_called_once()
+        self.assertEqual(manager.increment_calls, [f"{func_key}:0"])
+
+    def test_partial_target_fires_via_configured_name_key(self):
+        """Regression: a functools.partial has no __qualname__/__name__, so the
+        wrapper's old runtime-name key ("<module>.<anonymous>") missed the breakpoint set
+        the manager registered under "<module>.<function_name>", and the partial silently
+        never fired. The wrapper must key off the CONFIGURED function_name instead."""
+        import functools
+
+        def _base(prefix, value):
+            return prefix + str(value)
+
+        # Module-level name bound to a partial — the case that regressed.
+        add_hello = functools.partial(_base, "hello:")
+        # Sanity: a partial really has neither __qualname__ nor __name__.
+        self.assertFalse(hasattr(add_hello, "__qualname__"))
+        self.assertFalse(hasattr(add_hello, "__name__"))
+
+        func_name = "add_hello"
+        module = _register_module(self.module_name, **{func_name: add_hello})
+        # Manager registers under the CONFIGURED key (module.function_name), as production does.
+        func_key = f"{self.module_name}.{func_name}"
+        bp_set = _make_function_bp_set(func_key, self.module_name, func_name)
+        manager = _FakeManager({func_key: bp_set})
+
+        original, _instrumented = self.wrapper.instrument_function(
+            self.module_name,
+            func_name,
+            capture_config=CaptureConfig(capture_return=True),
+            location_hash="loc-hash-1",
+            manager=manager,
+        )
+
+        result = module.add_hello(9)
+        self.assertEqual(result, "hello:9")  # behavior preserved
+        self.emitter.emit_snapshot.assert_called_once()  # THE FIX: it fires (was 0 before)
         self.assertEqual(manager.increment_calls, [f"{func_key}:0"])
 
     def test_wrapped_reraises_user_exception_and_still_emits(self):
@@ -584,7 +621,7 @@ class TestSyncWrapper(_SnapshotEmitterFixture):
 
         func_name = func.__name__
         module = _register_module(self.module_name, **{func_name: func})
-        func_key = f"{self.module_name}.{FunctionWrapper._get_qualified_name(func)}"
+        func_key = f"{self.module_name}.{func_name}"
         # Build a set with a disabled state but NO line-0 breakpoint registered.
         bp_set = FunctionBreakpointSet(function_key=func_key, module=self.module_name, function_name=func_name)
         bp_set.states[f"{func_key}:5"] = BreakpointState(breakpoint_key=f"{func_key}:5", is_disabled=True)
@@ -675,7 +712,7 @@ class TestAsyncWrapper(_SnapshotEmitterFixture):
         func_name = func.__name__
         module = _register_module(self.module_name, **{func_name: func})
         # The wrapper keys breakpoint sets by the function's __qualname__.
-        func_key = f"{self.module_name}.{FunctionWrapper._get_qualified_name(func)}"
+        func_key = f"{self.module_name}.{func_name}"
         bp_set = _make_function_bp_set(func_key, self.module_name, func_name, has_line0=has_line0, disabled=disabled)
         manager = _FakeManager({func_key: bp_set}, increment_result=increment_result)
         capture_config = capture_config if capture_config is not None else CaptureConfig(capture_return=True)
@@ -721,7 +758,7 @@ class TestAsyncWrapper(_SnapshotEmitterFixture):
 
         func_name = func.__name__
         module = _register_module(self.module_name, **{func_name: func})
-        func_key = f"{self.module_name}.{FunctionWrapper._get_qualified_name(func)}"
+        func_key = f"{self.module_name}.{func_name}"
         bp_set = FunctionBreakpointSet(function_key=func_key, module=self.module_name, function_name=func_name)
         bp_set.states[f"{func_key}:5"] = BreakpointState(breakpoint_key=f"{func_key}:5", is_disabled=True)
         manager = _FakeManager({func_key: bp_set})
@@ -856,7 +893,7 @@ class TestClassMethodInstrumentation(_SnapshotEmitterFixture):
         Service = type("Service", (_Service,), {"handle": _Service.handle})
         _register_module(self.module_name, Service=Service)
         # The wrapper keys by the bound method's __qualname__.
-        func_key = f"{self.module_name}.{FunctionWrapper._get_qualified_name(Service.handle)}"
+        func_key = f"{self.module_name}.Service.handle"
         bp_set = _make_function_bp_set(func_key, self.module_name, "Service.handle")
         manager = _FakeManager({func_key: bp_set})
 

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_function_wrapper_aiohttp.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_function_wrapper_aiohttp.py
@@ -1,0 +1,141 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for aiohttp route-handler patching in _function_wrapper.py.
+
+aiohttp stores the route handler on each route (``route.handler`` / the resource's
+``_handler``) at registration time; the per-request path invokes that stored handler,
+not the module-level name. A module-level setattr doesn't reach it, so a function-level
+breakpoint on an aiohttp handler silently never fires. The fix rebinds the stored handler.
+"""
+
+import sys
+import types
+import unittest
+
+from amazon.opentelemetry.distro.debugger._function_wrapper import FunctionWrapper
+
+
+def _make_module(name, **attrs):
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    sys.modules[name] = mod
+    return mod
+
+
+def _remove_module(name):
+    sys.modules.pop(name, None)
+
+
+class TestAiohttpRoutesPatching(unittest.TestCase):
+    def setUp(self):
+        self.module_name = "_test_aiohttp_module"
+        _remove_module(self.module_name)
+
+    def tearDown(self):
+        _remove_module(self.module_name)
+
+    def _route_handlers(self, app):
+        return [getattr(r, "handler", None) for r in app.router.routes()]
+
+    def test_patch_aiohttp_route_handler_identity(self):
+        """A handler registered via add_get is rebound to the wrapper by identity."""
+        try:
+            from aiohttp import web
+        except ImportError:
+            self.skipTest("aiohttp not installed")
+
+        async def handler(request):
+            return web.json_response({"v": 1})
+
+        app = web.Application()
+        app.router.add_get("/h", handler)
+
+        # Precondition: the route stores the original handler.
+        self.assertIn(handler, self._route_handlers(app))
+
+        async def wrapper(request):
+            return web.json_response({"v": "wrapped"})
+
+        wrapper.__name__ = handler.__name__
+        wrapper.__module__ = handler.__module__
+
+        mod = _make_module(self.module_name, app=app, handler=handler)
+        FunctionWrapper._patch_aiohttp_routes(mod, handler, wrapper)
+
+        handlers = self._route_handlers(app)
+        self.assertIn(wrapper, handlers)
+        self.assertNotIn(handler, handlers)
+
+    def test_patch_aiohttp_name_module_fallback(self):
+        """When identity doesn't match, name+module fallback rebinds the handler."""
+        try:
+            from aiohttp import web
+        except ImportError:
+            self.skipTest("aiohttp not installed")
+
+        async def handler(request):
+            return web.json_response({})
+
+        app = web.Application()
+        app.router.add_get("/h", handler)
+
+        # Force a different-identity callable with the same name+module onto the route.
+        async def other_same_name(request):
+            return web.json_response({})
+
+        other_same_name.__name__ = handler.__name__
+        other_same_name.__module__ = handler.__module__
+        route = next(iter(app.router.routes()))
+        route._handler = other_same_name  # pylint: disable=protected-access
+
+        async def di_wrapper(request):
+            return web.json_response({})
+
+        di_wrapper.__name__ = handler.__name__
+        di_wrapper.__module__ = handler.__module__
+
+        mod = _make_module(self.module_name, app=app, handler=handler)
+        FunctionWrapper._patch_aiohttp_routes(mod, handler, di_wrapper)
+        self.assertIn(di_wrapper, self._route_handlers(app))
+
+    def test_patch_aiohttp_unrelated_handler_untouched(self):
+        """A non-matching handler on another route is not rebound."""
+        try:
+            from aiohttp import web
+        except ImportError:
+            self.skipTest("aiohttp not installed")
+
+        async def handler(request):
+            return web.json_response({})
+
+        async def other(request):
+            return web.json_response({})
+
+        app = web.Application()
+        app.router.add_get("/h", handler)
+        app.router.add_get("/o", other)
+
+        wrapper = lambda request: None  # noqa: E731
+        wrapper.__name__ = handler.__name__
+        wrapper.__module__ = handler.__module__
+
+        mod = _make_module(self.module_name, app=app, handler=handler, other=other)
+        FunctionWrapper._patch_aiohttp_routes(mod, handler, wrapper)
+
+        handlers = self._route_handlers(app)
+        self.assertIn(other, handlers)  # untouched
+        self.assertIn(wrapper, handlers)
+
+    def test_patch_aiohttp_no_app_is_noop(self):
+        """A module with no aiohttp Application is a safe no-op."""
+        original = lambda: None  # noqa: E731
+        wrapper = lambda: None  # noqa: E731
+        mod = _make_module(self.module_name, x=1)
+        FunctionWrapper._patch_aiohttp_routes(mod, original, wrapper)  # should not raise
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_function_wrapper_branches.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_function_wrapper_branches.py
@@ -184,7 +184,7 @@ class TestSyncWrapperErrorBranches(_SnapshotEmitterFixture):
         def compute():
             return 7
 
-        func_key = f"{self.module_name}.{FunctionWrapper._get_qualified_name(compute)}"
+        func_key = f"{self.module_name}.{compute.__name__}"
         module = _register_module(self.module_name, compute=compute)
         bp_set = _make_function_bp_set(func_key, self.module_name, "compute")
         manager = _IncrementRaisesManager({func_key: bp_set})
@@ -204,7 +204,7 @@ class TestSyncWrapperErrorBranches(_SnapshotEmitterFixture):
         def boom():
             raise ValueError("user error")
 
-        func_key = f"{self.module_name}.{FunctionWrapper._get_qualified_name(boom)}"
+        func_key = f"{self.module_name}.{boom.__name__}"
         module = _register_module(self.module_name, boom=boom)
         bp_set = _make_function_bp_set(func_key, self.module_name, "boom")
         manager = _FakeIncrementOkManager({func_key: bp_set})
@@ -225,7 +225,7 @@ class TestSyncWrapperErrorBranches(_SnapshotEmitterFixture):
         def compute():
             return 99
 
-        func_key = f"{self.module_name}.{FunctionWrapper._get_qualified_name(compute)}"
+        func_key = f"{self.module_name}.{compute.__name__}"
         module = _register_module(self.module_name, compute=compute)
         bp_set = _make_function_bp_set(func_key, self.module_name, "compute")
         manager = _FakeIncrementOkManager({func_key: bp_set})
@@ -293,7 +293,7 @@ class TestAsyncWrapperErrorBranches(_SnapshotEmitterFixture):
         async def fetch():
             return "ok"
 
-        func_key = f"{self.module_name}.{FunctionWrapper._get_qualified_name(fetch)}"
+        func_key = f"{self.module_name}.{fetch.__name__}"
         module = _register_module(self.module_name, fetch=fetch)
         bp_set = _make_function_bp_set(func_key, self.module_name, "fetch")
         manager = _IncrementRaisesManager({func_key: bp_set})
@@ -311,7 +311,7 @@ class TestAsyncWrapperErrorBranches(_SnapshotEmitterFixture):
         async def fetch(a, b):
             return a + b
 
-        func_key = f"{self.module_name}.{FunctionWrapper._get_qualified_name(fetch)}"
+        func_key = f"{self.module_name}.{fetch.__name__}"
         module = _register_module(self.module_name, fetch=fetch)
         bp_set = _make_function_bp_set(func_key, self.module_name, "fetch")
         manager = _FakeIncrementOkManager({func_key: bp_set})
@@ -331,7 +331,7 @@ class TestAsyncWrapperErrorBranches(_SnapshotEmitterFixture):
         async def boom():
             raise KeyError("async error")
 
-        func_key = f"{self.module_name}.{FunctionWrapper._get_qualified_name(boom)}"
+        func_key = f"{self.module_name}.{boom.__name__}"
         module = _register_module(self.module_name, boom=boom)
         bp_set = _make_function_bp_set(func_key, self.module_name, "boom")
         manager = _FakeIncrementOkManager({func_key: bp_set})
@@ -350,7 +350,7 @@ class TestAsyncWrapperErrorBranches(_SnapshotEmitterFixture):
         async def fetch():
             return 42
 
-        func_key = f"{self.module_name}.{FunctionWrapper._get_qualified_name(fetch)}"
+        func_key = f"{self.module_name}.{fetch.__name__}"
         module = _register_module(self.module_name, fetch=fetch)
         bp_set = _make_function_bp_set(func_key, self.module_name, "fetch")
         manager = _FakeIncrementOkManager({func_key: bp_set})

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_function_wrapper_capture_limits.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_function_wrapper_capture_limits.py
@@ -200,9 +200,10 @@ class TestEndToEndFunctionCaptureRespectsLimits(unittest.TestCase):
     def test_instrumented_function_truncates_return_at_configured_limit(self):
         module = _make_module(self.module_name, echo=_echo)
         wrapper = FunctionWrapper()
-        # The wrapper keys breakpoints by "<module>.<qualified_name>"; use the same key
-        # the wrapper computes so the fake manager's function-level breakpoint is found.
-        func_key = f"{self.module_name}.{FunctionWrapper._get_qualified_name(_echo)}"
+        # The manager registers (and the wrapper now looks up) by the
+        # CONFIGURED key "<module>.<function_name>" — here function_name="echo" (the
+        # module attribute), not the underlying object's __name__ ("_echo").
+        func_key = f"{self.module_name}.echo"
         manager = _FakeManager(func_key)
 
         config = CaptureConfig(capture_arguments=[], capture_return=True, max_string_length=10)

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_function_wrapper_starlette.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_function_wrapper_starlette.py
@@ -189,6 +189,15 @@ class TestStarletteRoutesPatching(unittest.TestCase):
         app = Starlette(routes=[route])
         app_before = route.app
 
+        # Pin that this route IS the matched target (endpoint identity holds), so the test
+        # exercises "matched-but-middleware → safe skip" rather than passing because the
+        # route simply didn't match.
+        self.assertIs(route.endpoint, handler)
+        # And the middleware-wrapped app is genuinely NOT the plain request_response closure
+        # over the endpoint — i.e. the skip is driven by the structural detection, not by a
+        # name check that could drift.
+        self.assertFalse(FunctionWrapper._starlette_app_wraps_endpoint(route.app, handler))
+
         async def wrapper(request):
             return JSONResponse({})
 
@@ -197,8 +206,9 @@ class TestStarletteRoutesPatching(unittest.TestCase):
 
         mod = _make_module(self.module_name, app=app, handler=handler)
         FunctionWrapper._patch_starlette_routes(mod, handler, wrapper)
-        # route.app NOT rebuilt (middleware preserved).
+        # route.app NOT rebuilt (middleware preserved) and endpoint left intact.
         self.assertIs(route.app, app_before)
+        self.assertIs(route.endpoint, handler)
 
     def test_patch_starlette_no_starlette_app_is_noop(self):
         """A module with no Starlette app instance is a safe no-op."""
@@ -207,6 +217,48 @@ class TestStarletteRoutesPatching(unittest.TestCase):
         mod = _make_module(self.module_name, x=1, y="z")
         # Should not raise.
         FunctionWrapper._patch_starlette_routes(mod, original, wrapper)
+
+    def test_starlette_app_wraps_endpoint_detection(self):
+        """The structural plain-app detection recognizes async and sync endpoints, and
+        rejects middleware-wrapped apps — independent of any closure function name."""
+        try:
+            from starlette.middleware import Middleware
+            from starlette.responses import JSONResponse
+            from starlette.routing import Route
+        except ImportError:
+            self.skipTest("Starlette not installed")
+
+        async def async_handler(request):
+            return JSONResponse({})
+
+        def sync_handler(request):
+            return JSONResponse({})
+
+        # Async endpoint: captured directly in the request_response closure -> True.
+        async_route = Route("/a", async_handler)
+        self.assertTrue(FunctionWrapper._starlette_app_wraps_endpoint(async_route.app, async_handler))
+
+        # Sync endpoint: wrapped in functools.partial(run_in_threadpool, endpoint) -> True.
+        sync_route = Route("/s", sync_handler)
+        self.assertTrue(FunctionWrapper._starlette_app_wraps_endpoint(sync_route.app, sync_handler))
+
+        # Wrong endpoint must not match the closure.
+        self.assertFalse(FunctionWrapper._starlette_app_wraps_endpoint(async_route.app, sync_handler))
+
+        # Middleware-wrapped app (no __closure__) -> False.
+        class _NoopMW:
+            def __init__(self, app):
+                self.app = app
+
+            async def __call__(self, scope, receive, send):
+                await self.app(scope, receive, send)
+
+        mw_route = Route("/m", async_handler, middleware=[Middleware(_NoopMW)])
+        self.assertFalse(FunctionWrapper._starlette_app_wraps_endpoint(mw_route.app, async_handler))
+
+        # Non-closure values are safe (return False, never raise).
+        self.assertFalse(FunctionWrapper._starlette_app_wraps_endpoint(None, async_handler))
+        self.assertFalse(FunctionWrapper._starlette_app_wraps_endpoint(object(), async_handler))
 
 
 if __name__ == "__main__":

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_function_wrapper_starlette.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_function_wrapper_starlette.py
@@ -1,0 +1,213 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for Starlette route patching in _function_wrapper.py.
+
+A pure-Starlette app stores ``route.app = request_response(endpoint)`` at import time,
+capturing the original handler in a closure; the per-request path invokes ``route.app``,
+never ``route.endpoint``. So a module-level setattr (or an endpoint-only rebind) never
+reaches the live handler and a function-level breakpoint silently never fires. The fix
+rebuilds ``route.app`` from the wrapper. FastAPI subclasses Starlette and is handled by
+its own patcher, so the Starlette patcher must SKIP FastAPI apps (no double-patch).
+"""
+
+import sys
+import types
+import unittest
+
+from amazon.opentelemetry.distro.debugger._function_wrapper import FunctionWrapper
+
+
+def _make_module(name, **attrs):
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    sys.modules[name] = mod
+    return mod
+
+
+def _remove_module(name):
+    sys.modules.pop(name, None)
+
+
+def _route_for(app, path):
+    for route in app.router.routes:
+        if getattr(route, "path", None) == path:
+            return route
+    raise AssertionError(f"No route found for path {path}")
+
+
+class TestStarletteRoutesPatching(unittest.TestCase):
+    def setUp(self):
+        self.module_name = "_test_starlette_module"
+        _remove_module(self.module_name)
+
+    def tearDown(self):
+        _remove_module(self.module_name)
+
+    def test_patch_starlette_route_rebuilds_app_and_fires(self):
+        """A pure-Starlette route endpoint is rebound: route.app is rebuilt from the wrapper,
+        and invoking the route's ASGI app actually calls the wrapper."""
+        try:
+            from starlette.applications import Starlette
+            from starlette.responses import JSONResponse
+            from starlette.routing import Route
+        except ImportError:
+            self.skipTest("Starlette not installed")
+
+        async def handler(request):
+            return JSONResponse({"v": 1})
+
+        app = Starlette(routes=[Route("/h", handler)])
+        route = _route_for(app, "/h")
+
+        # Precondition: route.app is a request_response closure over the ORIGINAL handler,
+        # and route.endpoint is the original.
+        self.assertIs(route.endpoint, handler)
+        original_app = route.app
+
+        hits = {"n": 0}
+
+        async def wrapper(request):
+            hits["n"] += 1
+            return JSONResponse({"v": "wrapped"})
+
+        wrapper.__name__ = handler.__name__
+        wrapper.__module__ = handler.__module__
+
+        mod = _make_module(self.module_name, app=app, handler=handler)
+        FunctionWrapper._patch_starlette_routes(mod, handler, wrapper)
+
+        # endpoint rebound AND route.app rebuilt (a new closure, not the original).
+        self.assertIs(route.endpoint, wrapper)
+        self.assertIsNot(route.app, original_app)
+
+        # Drive the route's ASGI app end-to-end and confirm the wrapper actually runs.
+        import asyncio
+
+        async def _drive():
+            scope = {"type": "http", "method": "GET", "headers": [], "path": "/h"}
+            sent = []
+
+            async def receive():
+                return {"type": "http.request", "body": b"", "more_body": False}
+
+            async def send(msg):
+                sent.append(msg)
+
+            await route.app(scope, receive, send)
+            return sent
+
+        asyncio.run(_drive())
+        self.assertEqual(hits["n"], 1, "wrapper should have been invoked via route.app")
+
+    def test_patch_starlette_name_module_fallback(self):
+        """When identity doesn't match (e.g. external wrapping) the name+module fallback rebinds."""
+        try:
+            from starlette.applications import Starlette
+            from starlette.responses import JSONResponse
+            from starlette.routing import Route
+        except ImportError:
+            self.skipTest("Starlette not installed")
+
+        async def handler(request):
+            return JSONResponse({})
+
+        app = Starlette(routes=[Route("/h", handler)])
+        route = _route_for(app, "/h")
+
+        # Simulate a different-identity callable that preserves __name__/__module__.
+        async def other_same_name(request):
+            return JSONResponse({})
+
+        other_same_name.__name__ = handler.__name__
+        other_same_name.__module__ = handler.__module__
+        route.endpoint = other_same_name
+
+        async def di_wrapper(request):
+            return JSONResponse({})
+
+        di_wrapper.__name__ = handler.__name__
+        di_wrapper.__module__ = handler.__module__
+
+        mod = _make_module(self.module_name, app=app, handler=handler)
+        FunctionWrapper._patch_starlette_routes(mod, handler, di_wrapper)
+        self.assertIs(route.endpoint, di_wrapper)
+
+    def test_patch_starlette_skips_fastapi_app(self):
+        """FastAPI is a Starlette subclass handled by _patch_fastapi_routes; the Starlette
+        patcher must NOT touch a FastAPI app (no double-patch)."""
+        try:
+            from fastapi import FastAPI
+        except ImportError:
+            self.skipTest("FastAPI not installed")
+
+        app = FastAPI()
+
+        @app.get("/orders")
+        def get_orders():
+            return "orders"
+
+        route = _route_for(app, "/orders")
+        original_endpoint = route.endpoint
+        original_app = route.app
+
+        wrapper = lambda: "wrapper"  # noqa: E731
+        wrapper.__name__ = original_endpoint.__name__
+        wrapper.__module__ = original_endpoint.__module__
+
+        mod = _make_module(self.module_name, app=app, get_orders=original_endpoint)
+        FunctionWrapper._patch_starlette_routes(mod, original_endpoint, wrapper)
+
+        # Untouched by the Starlette patcher (FastAPI's own patcher handles it).
+        self.assertIs(route.endpoint, original_endpoint)
+        self.assertIs(route.app, original_app)
+
+    def test_patch_starlette_route_with_middleware_is_skipped(self):
+        """A route carrying per-route middleware is left untouched (rebuilding route.app
+        would drop the middleware) — a safe no-op rather than a silent middleware loss."""
+        try:
+            from starlette.applications import Starlette
+            from starlette.middleware import Middleware
+            from starlette.responses import JSONResponse
+            from starlette.routing import Route
+        except ImportError:
+            self.skipTest("Starlette not installed")
+
+        class _NoopMW:
+            def __init__(self, app):
+                self.app = app
+
+            async def __call__(self, scope, receive, send):
+                await self.app(scope, receive, send)
+
+        async def handler(request):
+            return JSONResponse({})
+
+        route = Route("/h", handler, middleware=[Middleware(_NoopMW)])
+        app = Starlette(routes=[route])
+        app_before = route.app
+
+        async def wrapper(request):
+            return JSONResponse({})
+
+        wrapper.__name__ = handler.__name__
+        wrapper.__module__ = handler.__module__
+
+        mod = _make_module(self.module_name, app=app, handler=handler)
+        FunctionWrapper._patch_starlette_routes(mod, handler, wrapper)
+        # route.app NOT rebuilt (middleware preserved).
+        self.assertIs(route.app, app_before)
+
+    def test_patch_starlette_no_starlette_app_is_noop(self):
+        """A module with no Starlette app instance is a safe no-op."""
+        original = lambda: None  # noqa: E731
+        wrapper = lambda: None  # noqa: E731
+        mod = _make_module(self.module_name, x=1, y="z")
+        # Should not raise.
+        FunctionWrapper._patch_starlette_routes(mod, original, wrapper)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_instrumentation_manager.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_instrumentation_manager.py
@@ -917,5 +917,90 @@ class TestInheritedMethodEndToEnd(unittest.TestCase):
         self.assertNotIn("handle", Child.__dict__)
 
 
+class TestLineBreakpointNoCodeObjectReportsError(unittest.TestCase):
+    """A line-level breakpoint on a target with no __code__ (e.g. a callable-class
+    instance or a functools.partial) cannot arm the line engine. Instead of skipping
+    silently and leaving the config at READY, the manager must report a non-silent
+    LINE_NOT_EXECUTABLE error for the line-level config(s)."""
+
+    def test_line_bp_on_codeless_target_reports_line_not_executable(self):
+        manager = _make_manager()
+        manager._engine = mock.MagicMock()  # engine present, so the new branch is reachable
+        reporter = mock.MagicMock()
+        manager._status_reporter = reporter
+
+        # A line-level breakpoint config (line > 0) on a real, importable module so the
+        # manager's early module-existence pre-check passes; instrument_function itself is
+        # mocked below to return a codeless target.
+        module_name = "_test_codeless_module"
+        sys.modules[module_name] = types.ModuleType(module_name)
+        self.addCleanup(lambda: sys.modules.pop(module_name, None))
+        config = _make_config(method_name="handler", line_number=14, location_hash="bp-codeless", code_unit=module_name)
+        bp_set = FunctionBreakpointSet(
+            function_key=config.function_key,
+            module=config.module,
+            function_name=config.function_name,
+            breakpoints={config.line_number: config},
+        )
+
+        # instrument_function returns (original, wrapped); make the "original" a callable-class
+        # instance, which has NO __code__ -> bp_set.code_object resolves to None.
+        class _CallableInstance:
+            def __call__(self, *a, **k):
+                return None
+
+        codeless = _CallableInstance()
+        wrapped = lambda *a, **k: None  # noqa: E731
+        manager._wrapper = mock.MagicMock()
+        manager._wrapper.instrument_function.return_value = (codeless, wrapped)
+
+        manager._apply_function(bp_set)
+
+        # code_object could not be resolved...
+        self.assertIsNone(bp_set.code_object)
+        # ...so the line engine was never armed...
+        manager._engine.enable_breakpoints_for_function.assert_not_called()
+        # ...and a non-silent LINE_NOT_EXECUTABLE error was reported (not silent READY).
+        reporter.report_status_immediately.assert_any_call(
+            "bp-codeless", config.instrumentation_type, ConfigurationStatus.ERROR, ErrorCause.LINE_NOT_EXECUTABLE
+        )
+        self.assertEqual(manager._failed_configs.get("bp-codeless"), ErrorCause.LINE_NOT_EXECUTABLE)
+
+    def test_apply_configurations_does_not_overwrite_error_with_ready(self):
+        """End-to-end through apply_configurations: a codeless line-level target must NOT have
+        its ERROR overwritten by the per-config READY report the new-function branch emits."""
+        manager = _make_manager()
+        manager._engine = mock.MagicMock()
+        reporter = mock.MagicMock()
+        manager._status_reporter = reporter
+
+        module_name = "_test_codeless_module_e2e"
+        sys.modules[module_name] = types.ModuleType(module_name)
+        self.addCleanup(lambda: sys.modules.pop(module_name, None))
+
+        # instrument_function yields a codeless target so _apply_function marks it failed.
+        class _CallableInstance:
+            def __call__(self, *a, **k):
+                return None
+
+        manager._wrapper = mock.MagicMock()
+        manager._wrapper.instrument_function.return_value = (_CallableInstance(), lambda *a, **k: None)
+
+        config = _make_config(method_name="handler", line_number=14, location_hash="bp-codeless", code_unit=module_name)
+        manager.apply_configuration([config])
+
+        calls = reporter.report_status_immediately.call_args_list
+        # The error was reported for the codeless config...
+        self.assertTrue(
+            any(c.args[0] == "bp-codeless" and c.args[2] == ConfigurationStatus.ERROR for c in calls),
+            f"expected ERROR for bp-codeless, got {calls}",
+        )
+        # ...and READY was NOT subsequently reported for it (which would mask the error).
+        self.assertFalse(
+            any(c.args[0] == "bp-codeless" and c.args[2] == ConfigurationStatus.READY for c in calls),
+            f"READY must not be reported for a failed config, got {calls}",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_status_reporter_logic.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_status_reporter_logic.py
@@ -192,6 +192,16 @@ class TestPullAndReportStatuses(unittest.TestCase):
             reporter._pull_and_report_statuses(is_initial_report=True)
         mock_send.assert_not_called()
 
+    def test_initial_report_skips_ready_for_failed_config(self):
+        # A config the manager could not bind (in _failed_configs) keeps its ERROR status;
+        # the initial sweep must not promote it to READY.
+        manager = _make_manager({"mod.func": {"k0": _state("hash-failed", hit_count=0)}})
+        manager._failed_configs = {"hash-failed": "LINE_NOT_EXECUTABLE"}
+        reporter = StatusReporter(client=_make_client(), manager=manager)
+        with mock.patch.object(reporter, "_send_report") as mock_send:
+            reporter._pull_and_report_statuses(is_initial_report=True)
+        mock_send.assert_not_called()
+
     def test_periodic_report_emits_active_for_recent_hit(self):
         state = _state("hash-active", hit_count=5, hit_in_last_period=True)
         reporter = self._reporter_with_states({"k0": state})

--- a/contract-tests/images/applications/di-fastapi/di_fastapi_server.py
+++ b/contract-tests/images/applications/di-fastapi/di_fastapi_server.py
@@ -11,6 +11,7 @@ exercises the async instrumentation path with `async def` target functions
 cannot cover.
 """
 
+import functools
 import inspect
 import logging
 import time
@@ -105,8 +106,6 @@ def _partial_base(prefix, value):
 # no __qualname__/__name__, so the wrapper's old runtime-name key was "<module>.<anonymous>"
 # and missed the breakpoint set registered under "<module>.partial_target" -> silently
 # never fired. With the fix the wrapper keys off the configured name, so it fires.
-import functools  # noqa: E402
-
 partial_target = functools.partial(_partial_base, "hello:")
 
 

--- a/contract-tests/images/applications/di-fastapi/di_fastapi_server.py
+++ b/contract-tests/images/applications/di-fastapi/di_fastapi_server.py
@@ -95,6 +95,21 @@ def process_large_collection(large_list):
     return len(large_list)
 
 
+def _partial_base(prefix, value):
+    """Underlying function for the functools.partial target below."""
+    result = prefix + str(value)
+    return result
+
+
+# functools.partial target: a module-level name bound to a functools.partial. A partial has
+# no __qualname__/__name__, so the wrapper's old runtime-name key was "<module>.<anonymous>"
+# and missed the breakpoint set registered under "<module>.partial_target" -> silently
+# never fired. With the fix the wrapper keys off the configured name, so it fires.
+import functools  # noqa: E402
+
+partial_target = functools.partial(_partial_base, "hello:")
+
+
 async def process_data_async(value):
     """Async target for function-level BREAKPOINT instrumentation.
 
@@ -315,6 +330,30 @@ BREAKPOINT_CONFIGS = [
             }
         },
     },
+    # Function-level breakpoint on a functools.partial target. The configured
+    # MethodName "partial_target" must match the manager's registration key; the wrapper
+    # now keys its lookup off that configured name (a partial has no __qualname__/__name__),
+    # so the wrapper fires and a snapshot IS produced.
+    {
+        "InstrumentationType": "BREAKPOINT",
+        "SignalType": "SNAPSHOT",
+        "Location": {
+            "CodeLocation": {
+                "Language": "Python",
+                "CodeUnit": "di_fastapi_server",
+                "MethodName": "partial_target",
+                "FilePath": "di_fastapi_server.py",
+            }
+        },
+        "LocationHash": "aabb00000000000d",
+        "CaptureConfiguration": {
+            "CodeCapture": {
+                "CaptureReturn": True,
+                "CaptureArguments": ["value"],
+                "CaptureLimits": {"MaxStringLength": 255},
+            }
+        },
+    },
 ]
 
 PROBE_CONFIGS = [
@@ -494,6 +533,13 @@ def route_handler_target_sync(multiplier: int = 2):
     produced for this handler.
     """
     result = multiplier * 21
+    return {"status": "ok", "result": result}
+
+
+@app.get("/partial")
+async def partial_endpoint():
+    """Endpoint that triggers the functools.partial BREAKPOINT target."""
+    result = partial_target(9)
     return {"status": "ok", "result": result}
 
 

--- a/contract-tests/images/applications/di-starlette/Dockerfile
+++ b/contract-tests/images/applications/di-starlette/Dockerfile
@@ -1,0 +1,12 @@
+ARG PYTHON_VERSION=3.12
+FROM python:${PYTHON_VERSION}
+WORKDIR /di-starlette
+COPY ./dist/$DISTRO /di-starlette
+COPY ./contract-tests/images/applications/di-starlette /di-starlette
+
+ENV PIP_ROOT_USER_ACTION=ignore
+ARG DISTRO
+RUN pip install --upgrade pip && pip install -r requirements.txt && pip install "${DISTRO}[debugger]" --force-reinstall
+RUN opentelemetry-bootstrap -a install
+
+CMD ["opentelemetry-instrument", "python", "-u", "./di_starlette_server.py"]

--- a/contract-tests/images/applications/di-starlette/di_starlette_server.py
+++ b/contract-tests/images/applications/di-starlette/di_starlette_server.py
@@ -1,0 +1,137 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Pure-Starlette app for DI contract tests.
+
+Starts a mock DI API on port 3030, then runs a pure Starlette app (NOT FastAPI)
+on port 8080. The DI poller fetches breakpoint configs from the mock API.
+
+The key case this app exercises: a function-level breakpoint on a *Starlette route
+handler*. Starlette builds ``route.app = request_response(endpoint)`` at import time,
+capturing the original handler in a closure; the per-request path invokes ``route.app``,
+never ``route.endpoint``. So replacing the module-level name (or rebinding endpoint)
+does not reach the live handler and the breakpoint silently never fires unless DI
+rebuilds ``route.app``. A plain (non-handler) function is also instrumented as a control
+to prove DI is active in this process.
+"""
+
+import logging
+
+import uvicorn
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse, PlainTextResponse
+from starlette.routing import Route
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Target functions
+# ---------------------------------------------------------------------------
+
+
+def process_data(value):
+    """Control target: a plain module-level function (not a route handler).
+
+    Proves DI is active in this Starlette process independently of the route-handler
+    patching path.
+    """
+    result = value * 2
+    return result
+
+
+async def starlette_handler(request):
+    """A Starlette route handler that is ITSELF a DI BREAKPOINT target.
+
+    Body is self-contained so a snapshot attributed to "starlette_handler" unambiguously
+    came from instrumenting the handler (not some inner function).
+    """
+    multiplier = int(request.query_params.get("multiplier", "2"))
+    result = multiplier * 21
+    return JSONResponse({"status": "ok", "result": result})
+
+
+# ---------------------------------------------------------------------------
+# Mock DI API configuration
+# ---------------------------------------------------------------------------
+
+from mock_di_api import set_breakpoint_configs, set_probe_configs, start_mock_api  # noqa: E402
+
+BREAKPOINT_CONFIGS = [
+    # Control: plain module-level function.
+    {
+        "InstrumentationType": "BREAKPOINT",
+        "SignalType": "SNAPSHOT",
+        "Location": {
+            "CodeLocation": {
+                "Language": "Python",
+                "CodeUnit": "di_starlette_server",
+                "MethodName": "process_data",
+                "FilePath": "di_starlette_server.py",
+            }
+        },
+        "LocationHash": "ccdd000000000001",
+        "CaptureConfiguration": {
+            "CodeCapture": {
+                "CaptureReturn": True,
+                "CaptureArguments": ["value"],
+                "CaptureLimits": {"MaxStringLength": 255},
+            }
+        },
+    },
+    # The Starlette route handler itself.
+    {
+        "InstrumentationType": "BREAKPOINT",
+        "SignalType": "SNAPSHOT",
+        "Location": {
+            "CodeLocation": {
+                "Language": "Python",
+                "CodeUnit": "di_starlette_server",
+                "MethodName": "starlette_handler",
+                "FilePath": "di_starlette_server.py",
+            }
+        },
+        "LocationHash": "ccdd000000000002",
+        "CaptureConfiguration": {
+            "CodeCapture": {
+                "CaptureReturn": True,
+                "CaptureArguments": ["request"],
+                "CaptureLimits": {"MaxStringLength": 255},
+            }
+        },
+    },
+]
+
+set_breakpoint_configs(BREAKPOINT_CONFIGS)
+set_probe_configs([])
+start_mock_api(port=3030)
+logger.info("Mock DI API started on port 3030")
+
+
+# ---------------------------------------------------------------------------
+# Starlette application
+# ---------------------------------------------------------------------------
+
+
+async def health(request):
+    return PlainTextResponse("Ready")
+
+
+async def success(request):
+    """Triggers the plain-function control target."""
+    result = process_data(42)
+    return JSONResponse({"status": "ok", "result": result})
+
+
+app = Starlette(
+    routes=[
+        Route("/health", health),
+        Route("/success", success),
+        Route("/handler", starlette_handler),
+    ]
+)
+
+
+if __name__ == "__main__":
+    print("Ready", flush=True)
+    uvicorn.run(app, host="0.0.0.0", port=8080, log_level="info")

--- a/contract-tests/images/applications/di-starlette/mock_di_api.py
+++ b/contract-tests/images/applications/di-starlette/mock_di_api.py
@@ -1,0 +1,85 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Mock DI API server that serves instrumentation configurations.
+
+Runs alongside the Flask app inside the same container, providing
+/list-instrumentation-configurations and /report-instrumentation-configuration-status
+endpoints that the DI poller calls.
+"""
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+PROBE_CONFIGS = []
+BREAKPOINT_CONFIGS = []
+STATUS_REPORTS = []
+
+
+def set_probe_configs(configs):
+    global PROBE_CONFIGS
+    PROBE_CONFIGS = configs
+
+
+def set_breakpoint_configs(configs):
+    global BREAKPOINT_CONFIGS
+    BREAKPOINT_CONFIGS = configs
+
+
+def set_configs(configs):
+    """Legacy: set all configs (treated as breakpoints for backward compatibility)."""
+    set_breakpoint_configs(configs)
+
+
+class MockDIHandler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        content_length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(content_length) if content_length else b""
+
+        if self.path == "/list-instrumentation-configurations":
+            self._handle_list(body)
+        elif self.path == "/report-instrumentation-configuration-status":
+            self._handle_status_report(body)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def _handle_list(self, body):
+        payload = json.loads(body) if body else {}
+        instrumentation_type = payload.get("InstrumentationType", "BREAKPOINT")
+
+        if instrumentation_type == "PROBE":
+            configs = PROBE_CONFIGS
+        else:
+            configs = BREAKPOINT_CONFIGS
+
+        response = {
+            "Changed": True,
+            "Service": payload.get("Service", ""),
+            "Environment": payload.get("Environment", ""),
+            "LatestConfigurations": configs,
+            "NextToken": None,
+            "SyncInterval": 10,
+        }
+        self._send_json(200, response)
+
+    def _handle_status_report(self, body):
+        if body:
+            STATUS_REPORTS.append(json.loads(body))
+        self._send_json(200, {"message": "ok"})
+
+    def _send_json(self, code, data):
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(data).encode())
+
+    def log_message(self, format, *args):
+        pass  # Suppress request logs
+
+
+def start_mock_api(port=3030):
+    server = HTTPServer(("0.0.0.0", port), MockDIHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server

--- a/contract-tests/images/applications/di-starlette/requirements.txt
+++ b/contract-tests/images/applications/di-starlette/requirements.txt
@@ -1,0 +1,2 @@
+starlette
+uvicorn

--- a/contract-tests/tests/test/amazon/di/fastapi_test.py
+++ b/contract-tests/tests/test/amazon/di/fastapi_test.py
@@ -655,3 +655,52 @@ class DIFastAPISyncRouteHandlerTest(DITestInfrastructure):
         self.assert_snapshot_attr(log, "aws.di.instrumentation_level", "method")
         self.assert_snapshot_attr(log, "aws.di.code_unit", _CODE_UNIT)
         self.assert_body_has_entry_or_return(log)
+
+
+# =============================================================================
+# functools.partial target
+# =============================================================================
+class DIFastAPIPartialTargetTest(DITestInfrastructure):
+    """A function-level breakpoint on a functools.partial target must fire.
+
+    A partial has no __qualname__/__name__, so the wrapper's old runtime-name key
+    ("<module>.<anonymous>") missed the breakpoint set the manager registered under
+    the configured key ("<module>.partial_target"), and the partial silently never
+    fired. The fix keys the wrapper's lookup off the configured name, so a snapshot
+    IS produced.
+    """
+
+    __test__ = True
+
+    @override
+    @staticmethod
+    def get_application_image_name() -> str:
+        return _APP_IMAGE
+
+    @override
+    def get_application_wait_pattern(self) -> str:
+        return "Ready"
+
+    def test_partial_target_produces_snapshot(self) -> None:
+        # Control: a plain instrumented function works, proving DI is active here.
+        control = self.send_request("GET", "success")
+        self.assertEqual(200, control.status_code)
+        self.wait_for_snapshots(min_count=1)
+
+        # Hit the functools.partial target.
+        response = self.send_request("GET", "partial")
+        self.assertEqual(200, response.status_code)
+        # The partial still runs normally (DI must never break the application).
+        self.assertEqual(response.json().get("result"), "hello:9")
+
+        partial_logs = self.wait_for_method_snapshots("partial_target", min_count=1)
+        self.assertGreater(
+            len(partial_logs),
+            0,
+            "Expected a snapshot for the functools.partial target 'partial_target'.",
+        )
+
+        log = partial_logs[0]
+        self.assert_snapshot_attr(log, "aws.di.instrumentation_level", "method")
+        self.assert_snapshot_attr(log, "aws.di.code_unit", _CODE_UNIT)
+        self.assert_body_has_entry_or_return(log)

--- a/contract-tests/tests/test/amazon/di/starlette_test.py
+++ b/contract-tests/tests/test/amazon/di/starlette_test.py
@@ -1,0 +1,93 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""DI contract tests for a pure-Starlette application.
+
+Verifies that DI instruments a Starlette route handler. Starlette is NOT FastAPI
+(FastAPI subclasses Starlette and is patched by its own path); a pure-Starlette app
+builds ``route.app = request_response(endpoint)`` at import time, so DI must rebuild
+``route.app`` to instrument the handler. Without the fix the handler breakpoint
+silently never fires.
+
+Follows the same OTLP/mock-collector pattern as flask_test.py / fastapi_test.py.
+"""
+
+from typing_extensions import override
+
+from amazon.di.di_contract_test_base import DITestInfrastructure
+
+_APP_IMAGE = "aws-application-signals-tests-di-starlette-app"
+_CODE_UNIT = "di_starlette_server"
+
+
+class DIStarletteFunctionLevelTest(DITestInfrastructure):
+    """A plain (non-handler) function is instrumented — control proving DI is active."""
+
+    __test__ = True
+
+    @override
+    @staticmethod
+    def get_application_image_name() -> str:
+        return _APP_IMAGE
+
+    @override
+    def get_application_wait_pattern(self) -> str:
+        return "Ready"
+
+    def test_function_level_snapshot_generated(self) -> None:
+        response = self.send_request("GET", "success")
+        self.assertEqual(200, response.status_code)
+
+        logs = self.wait_for_snapshots(min_count=1)
+        method_logs = self.logs_for_method(logs, "process_data")
+        self.assertGreater(len(method_logs), 0, "Expected OTLP snapshot for process_data")
+
+        log = method_logs[0]
+        self.assert_snapshot_attr(log, "aws.di.instrumentation_level", "method")
+        self.assert_snapshot_attr(log, "aws.di.code_unit", _CODE_UNIT)
+        self.assert_body_has_entry_or_return(log)
+
+
+class DIStarletteRouteHandlerTest(DITestInfrastructure):
+    """A Starlette route handler configured as a DI target produces a snapshot.
+
+    Starlette captures the handler in a ``request_response`` closure on ``route.app`` at
+    import time and invokes that per request (never ``route.endpoint``). DI must rebuild
+    ``route.app`` from the wrapper, so the handler fires and a snapshot is produced.
+    """
+
+    __test__ = True
+
+    @override
+    @staticmethod
+    def get_application_image_name() -> str:
+        return _APP_IMAGE
+
+    @override
+    def get_application_wait_pattern(self) -> str:
+        return "Ready"
+
+    def test_route_handler_produces_snapshot(self) -> None:
+        # Control: the plain instrumented function works, proving DI is active in this
+        # Starlette process and the mock collector is receiving snapshots.
+        control = self.send_request("GET", "success")
+        self.assertEqual(200, control.status_code)
+        self.wait_for_snapshots(min_count=1)
+
+        # Hit the Starlette route handler that is itself a DI target.
+        response = self.send_request("GET", "handler", params={"multiplier": 2})
+        self.assertEqual(200, response.status_code)
+        # The handler still runs normally (DI must never break the application).
+        self.assertEqual(response.json().get("result"), 42)
+
+        handler_logs = self.wait_for_method_snapshots("starlette_handler", min_count=1)
+        self.assertGreater(
+            len(handler_logs),
+            0,
+            "Expected a snapshot for the Starlette route handler 'starlette_handler' "
+            "(DI now rebuilds Starlette's route.app).",
+        )
+
+        log = handler_logs[0]
+        self.assert_snapshot_attr(log, "aws.di.instrumentation_level", "method")
+        self.assert_snapshot_attr(log, "aws.di.code_unit", _CODE_UNIT)
+        self.assert_body_has_entry_or_return(log)


### PR DESCRIPTION
## Summary

Four independent Dynamic Instrumentation correctness fixes in the Python distro's debugger. Each closes a **silent failure**: a breakpoint that reported `READY` (or a status that looked healthy) but never actually fired, because the wrapper/patcher never reached the live callable — or, in the last case, a target that can never bind yet never surfaced an error. They are bundled here because they touch the same subsystem (`_function_wrapper.py` dispatch + the manager/status-reporter status path); each is additive and leaves the existing Flask/Django/FastAPI patch paths intact.

## 1. FastAPI `Depends()` sub-dependency handlers silently never fire

A function used as a FastAPI **sub-dependency** (`Depends(get_thing)`) is captured at import time inside the route's pre-built `Dependant` tree (`dependant.dependencies[*].call`). The per-request path invokes those `call` references, not the module-level name, so a function-level breakpoint on a sub-dependency reported `READY` but never fired (line-level worked).

**Fix:** `_rebind_dependant` walks the `Dependant` tree and `_rebind_route` rebinds every matching `call` (and the route's own `endpoint`/`dependant.call`) to the instrumented wrapper. Matching is identity-then-name+module (`_matches`/`_is_identity`), mirroring the existing patchers.

## 2. Route handlers of unsupported frameworks (Starlette, aiohttp) silently never fire

`_patch_framework_references` dispatched to **only** Flask, Django, and FastAPI. A handler on any other framework was never rebound, so a function-level breakpoint on it silently never fired — reproduced on **Starlette** and **aiohttp**.

- **`_patch_starlette_routes`** — a pure-Starlette app builds `route.app = request_response(endpoint)` at import time and the per-request path calls `route.app`; the original handler lives in a closure that `setattr`/endpoint-rebind cannot reach. The patcher rebuilds `route.app` from the wrapper.
  - Detection is **structural** (`_starlette_app_wraps_endpoint` inspects the closure cells for the captured endpoint, handling both the async direct-capture and the sync `functools.partial(run_in_threadpool, endpoint)` forms) rather than matching on an internal function name, so a future Starlette rename won't silently misclassify routes.
  - FastAPI subclasses Starlette and is handled by case #1, so this patcher **explicitly skips FastAPI instances** (no double-patch).
  - Routes with per-route **middleware** are left untouched (rebuilding `route.app` would drop the middleware) — a deliberate, logged safe no-op. `Mount`/sub-routers are descended (`_walk`, depth-capped).
- **`_patch_aiohttp_routes`** — matches on the public `route.handler` and rebinds the backing `_handler` (no public setter), warning if the internal attribute is ever absent.

## 3. `functools.partial` (any callable whose runtime name ≠ configured name) silently never fires

The wrapper computed its `_active_functions` lookup key from the target's runtime `__qualname__`/`__name__`. A `functools.partial` has neither, so the key became `"<module>.<anonymous>"` and missed the set the manager registered under the **configured** key `"<module>.<function_name>"`. The fix threads the configured `function_name` into the wrapper and keys off it (falling back to runtime introspection only when not provided), aligning the wrapper's lookup with the manager's registration key.

## 4. Line breakpoint on a target with no code object reported READY instead of ERROR

A line-level breakpoint whose target resolves to a callable with **no `__code__`** (a callable-class instance, or a `functools.partial`) cannot arm the line engine. Previously this was skipped silently and the config still reported `READY` — indistinguishable from "applied, waiting for traffic", though it could never fire.

**Fix:** the manager now reports a non-silent `LINE_NOT_EXECUTABLE` error for the line-level config(s) and records them as failed. The per-config `READY` report in `apply_configuration` and the periodic status sweep both skip already-failed configs, so the `ERROR` is not overwritten by a later `READY`.

## Testing

- **Unit:** new `test_function_wrapper_starlette.py` and `test_function_wrapper_aiohttp.py` (identity match, name+module fallback, the FastAPI-skip guard, the middleware safe-skip, structural-detection contract); new `functools.partial` test in `test_function_wrapper.py`; FastAPI sub-dependency rebind tests in `test_function_wrapper_fastapi.py`; codeless-line tests in `test_instrumentation_manager.py` (unit, plus an end-to-end `apply_configuration` test asserting `READY` does not overwrite `ERROR`) and `test_status_reporter_logic.py` (periodic sweep suppresses `READY` for a failed config). All are regression guards (verified failing without the fix). Updated pre-existing wrapper tests that keyed breakpoint sets by the runtime `__qualname__` to use the configured key the manager actually registers (`module.function_name`).
- **Contract:** new `di-starlette` app + `starlette_test.py` prove a Starlette route handler fires end-to-end; `di-fastapi` gains a `functools.partial` target + test.
- **Result:** full debugger unit suite **579 passed, 25 skipped, 0 failed**. The framework fixes were additionally verified end-to-end against real Starlette / aiohttp / partial targets. `black`/`isort`/`flake8` clean; `pylint` 10.00/10 on the source.

No change to the existing Flask/Django/FastAPI-route patch paths (their tests are unaffected).

## By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
