### PR TITLE
Update lambda compatible runtimes to include Python 3.14

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -314,7 +314,7 @@ jobs:
             aws lambda publish-layer-version \
               --layer-name ${{ env.LAYER_NAME }} \
               --content S3Bucket=${{ env.BUCKET_NAME }},S3Key=${{ env.LAYER_ARTIFACT_NAME }} \
-              --compatible-runtimes python3.10 python3.11 python3.12 python3.13 \
+              --compatible-runtimes python3.10 python3.11 python3.12 python3.13 python3.14  \
               --compatible-architectures "arm64" "x86_64" \
               --license-info "Apache-2.0" \
               --description "AWS Distro of OpenTelemetry Lambda Layer for Python Runtime" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- add official Python 3.14 support:([]())
 - Nightly dependency update: OpenTelemetry 1.42.1/0.63b1
   ([#762](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/762))
 - feat(agent-observability): add `AWS_AGENTIC_INSTRUMENTATION` (`auto`/`enabled`/`disabled`, case-insensitive) as an escape hatch over auto-detection when `AGENT_OBSERVABILITY_ENABLED=true`; the switch only governs AWS native instrumentors and never disables third-party ones

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
-- add official Python 3.14 support:([]())
 - Nightly dependency update: OpenTelemetry 1.42.1/0.63b1
   ([#762](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/762))
 - feat(agent-observability): add `AWS_AGENTIC_INSTRUMENTATION` (`auto`/`enabled`/`disabled`, case-insensitive) as an escape hatch over auto-detection when `AGENT_OBSERVABILITY_ENABLED=true`; the switch only governs AWS native instrumentors and never disables third-party ones


### PR DESCRIPTION
## Background
Python 3.14 is now available as a Lambda runtime, and our instrumentation layer should declare compatibility with it so customers can use the ADOT Python layer on python3.14 Lambda functions.

## Summary
Updated the release build workflow `release-build.yml` to add Python 3.14 to the list of compatible runtimes for the AWS Lambda layer.

## Changes
Updated the compatible runtimes list to include python3.14

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

