### PR TITLE
Guard OTel logger usage in Lambda sample app with try/except

### DIFF
--- a/lambda-layer/sample-apps/function/lambda_function.py
+++ b/lambda-layer/sample-apps/function/lambda_function.py
@@ -5,11 +5,16 @@ import os
 import boto3
 import requests
 
-from opentelemetry._logs import LogRecord, SeverityNumber, get_logger
+try:
+    from opentelemetry._logs import LogRecord, SeverityNumber, get_logger
+except Exception:  # pylint: disable=broad-except
+    LogRecord = None
+    SeverityNumber = None
+    get_logger = None
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
-otel_logger = get_logger(__name__)
+otel_logger = get_logger(__name__) if get_logger else None
 
 client = boto3.client("s3")
 
@@ -22,18 +27,22 @@ def lambda_handler(event, context):
     logger.error("error-level-test-message")
 
     # Test all attribute data types via OTel Logs API directly
-    otel_logger.emit(
-        LogRecord(
-            body="type-test-message",
-            severity_number=SeverityNumber.INFO,
-            attributes={
-                "bool_attr": True,
-                "float_attr": 3.14,
-                "int_attr": 42,
-                "string_attr": "hello",
-            },
-        )
-    )
+    try:
+        if otel_logger is not None:
+            otel_logger.emit(
+                LogRecord(
+                    body="type-test-message",
+                    severity_number=SeverityNumber.INFO,
+                    attributes={
+                        "bool_attr": True,
+                        "float_attr": 3.14,
+                        "int_attr": 42,
+                        "string_attr": "hello",
+                    },
+                )
+            )
+    except Exception:  # pylint: disable=broad-except
+        logger.exception("Failed to emit OTel log record")
 
     requests.get("https://aws.amazon.com/")
 


### PR DESCRIPTION
Wraps the OTel logger import and `otel_logger.emit()` call in the Lambda sample app with try/except so an OTel logs API failure can't break the handler.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.