### PR TITLE
ci: wire Service Events EC2 test into main-build

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -265,6 +265,14 @@ jobs:
       caller-workflow-name: 'main-build'
       staging-wheel-name: ${{ inputs.staging-wheel-name }}
 
+  service-events-ec2:
+    needs: [ upload-main-build ]
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-ec2-service-events-test.yml@main
+    secrets: inherit
+    with:
+      caller-workflow-name: 'main-build'
+      staging-wheel-name: ${{ inputs.staging-wheel-name }}
+
   # This validation is to ensure that all test workflows relevant to this repo are actually
   # being used in this repo, which is referring to all the other jobs in this file.
   #


### PR DESCRIPTION
## Summary
- Adds `service-events-ec2` job to the E2E test workflow, calling `python-ec2-service-events-test.yml@main` from the test-framework repo.
- Runs after `upload-main-build` to validate Service Events telemetry (DeploymentEvent, IncidentSnapshot, FunctionCall) on every main-build.

## Dependencies
- Requires [aws-application-signals-test-framework PR #651](https://github.com/aws-observability/aws-application-signals-test-framework/pull/651) to merge first (the SE workflow must exist on `main`).

## Test plan
- [ ] Merge test-framework PR #651
- [ ] Trigger main-build workflow and verify `service-events-ec2` job passes