### PR TITLE
ci: refactor build/test actions & parallelize main-build unit tests

### DIFF
--- a/.github/actions/artifacts_build/action.yml
+++ b/.github/actions/artifacts_build/action.yml
@@ -33,10 +33,6 @@ inputs:
   os:
     required: true
     description: "The os"
-  run_unit_tests:
-    required: false
-    default: 'true'
-    description: "Whether to run unit tests during setup. Set to false when unit tests run in a separate job."
   build_image:
     required: false
     default: 'true'
@@ -67,7 +63,6 @@ runs:
         python_version: ${{ inputs.python_version }}
         package_name: ${{ inputs.package_name }}
         os: ${{ inputs.os }}
-        run_unit_tests: ${{ inputs.run_unit_tests }}
 
     - name: Configure AWS Credentials
       if: ${{ inputs.push_image == true || inputs.push_image == 'true' }}
@@ -76,14 +71,8 @@ runs:
         role-to-assume: ${{ inputs.snapshot-ecr-role }}
         aws-region: ${{ inputs.aws-region }}
 
-    - name: Install Dependencies and Build Wheel
-      id: staging_wheel_build
-      shell: bash
-      run: |
-        pip install --upgrade pip setuptools wheel packaging build
-        rm -rf ./dist/*
-        cd ./aws-opentelemetry-distro
-        python -m build --outdir ../dist
+    - name: Build distro wheel
+      uses: ./.github/actions/artifacts_build/build_wheel
 
     - name: Set up QEMU
       if: ${{ inputs.build_image == true || inputs.build_image == 'true' }}

--- a/.github/actions/artifacts_build/build_wheel/action.yml
+++ b/.github/actions/artifacts_build/build_wheel/action.yml
@@ -1,0 +1,14 @@
+name: Build aws-opentelemetry-distro wheel
+description: |
+  This action assumes that the repo was checked out and Python is set up. Builds the aws-opentelemetry-distro wheel into ./dist.
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Dependencies and Build Wheel
+      shell: bash
+      run: |
+        pip install --upgrade pip setuptools wheel packaging build
+        rm -rf ./dist/*
+        cd ./aws-opentelemetry-distro
+        python -m build --outdir ../dist

--- a/.github/actions/set_up/action.yml
+++ b/.github/actions/set_up/action.yml
@@ -1,6 +1,6 @@
 name: Set up
 description: |
-  This action assumes that the repo was checked out. Installs python and tox, then runs tox to trigger unit tests.
+  This action assumes that the repo was checked out. Installs python and tox and restores the tox cache.
 
 inputs:
   python_version:
@@ -12,9 +12,6 @@ inputs:
   os:
     required: true
     description: "The os"
-  run_unit_tests:
-    required: true
-    description: "true/false flag indicating if we should run unit tests/benchmarks with tox"
   wheel_path:
     required: false
     default: ''
@@ -47,27 +44,3 @@ runs:
           .tox
           ~/.cache/pip
         key: v7-build-tox-cache-${{ inputs.python_version }}-${{ inputs.package_name }}-${{ inputs.os }}-${{ hashFiles('tox.ini', 'dev-requirements.txt') }}
-
-    - name: Run unit tests/benchmarks with tox
-      if: ${{ inputs.run_unit_tests == 'true' }}
-      shell: bash
-      run: |
-        PY_VERSION="${{ inputs.python_version }}"
-        # we intend for new or unrecognized Python versions to fail if a new Python version is added to the test 
-        # to ensure they are not silently skipped from testing
-        ENVS=$(tox list -q | grep "^${PY_VERSION}-test-" | sed 's/ .*//' | tr '\n' ',' | sed 's/,$//' || true)
-        echo "Running tox envs: $ENVS"
-        tox --parallel auto --parallel-live -e "$ENVS" -- -v
-
-    - name: Combine and check coverage
-      if: ${{ inputs.run_unit_tests == 'true' }}
-      shell: bash
-      run: |
-        pip install coverage
-        if [ "${{ inputs.python_version }}" = "3.14" ]; then
-          RCFILE=.coveragerc-py314
-        else
-          RCFILE=.coveragerc
-        fi
-        coverage combine --rcfile=$RCFILE
-        coverage report --rcfile=$RCFILE

--- a/.github/actions/set_up/action.yml
+++ b/.github/actions/set_up/action.yml
@@ -12,10 +12,6 @@ inputs:
   os:
     required: true
     description: "The os"
-  wheel_path:
-    required: false
-    default: ''
-    description: "Optional path to a prebuilt aws-opentelemetry-distro wheel. When set, tox installs the distro from this wheel (via ADOT_WHEEL) instead of building from source."
 
 
 runs:
@@ -25,11 +21,6 @@ runs:
       uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c #v6.0.0
       with:
         python-version: ${{ inputs.python_version }}
-
-    - name: Use prebuilt distro wheel
-      if: ${{ inputs.wheel_path != '' }}
-      shell: bash
-      run: echo "ADOT_WHEEL=$(realpath '${{ inputs.wheel_path }}')" >> "$GITHUB_ENV"
 
     - name: Install tox
       shell: bash

--- a/.github/actions/unit_tests/action.yml
+++ b/.github/actions/unit_tests/action.yml
@@ -1,0 +1,53 @@
+name: Run unit tests
+description: |
+  This action assumes that the repo was checked out. Sets up the Python/tox environment
+  (via the set_up action) and runs the unit tests/benchmarks with tox, then checks coverage.
+
+inputs:
+  python_version:
+    required: true
+    description: "The python version used in actions"
+  package_name:
+    required: true
+    description: "The package name"
+  os:
+    required: true
+    description: "The os"
+  wheel_path:
+    required: false
+    default: ''
+    description: "Optional path to a prebuilt aws-opentelemetry-distro wheel. When set, tox installs the distro from this wheel (via ADOT_WHEEL) instead of building from source."
+
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Python and tox
+      uses: ./.github/actions/set_up
+      with:
+        python_version: ${{ inputs.python_version }}
+        package_name: ${{ inputs.package_name }}
+        os: ${{ inputs.os }}
+        wheel_path: ${{ inputs.wheel_path }}
+
+    - name: Run unit tests/benchmarks with tox
+      shell: bash
+      run: |
+        PY_VERSION="${{ inputs.python_version }}"
+        # we intend for new or unrecognized Python versions to fail if a new Python version is added to the test
+        # to ensure they are not silently skipped from testing
+        ENVS=$(tox list -q | grep "^${PY_VERSION}-test-" | sed 's/ .*//' | tr '\n' ',' | sed 's/,$//' || true)
+        echo "Running tox envs: $ENVS"
+        tox --parallel auto --parallel-live -e "$ENVS" -- -v
+
+    - name: Combine and check coverage
+      shell: bash
+      run: |
+        pip install coverage
+        if [ "${{ inputs.python_version }}" = "3.14" ]; then
+          RCFILE=.coveragerc-py314
+        else
+          RCFILE=.coveragerc
+        fi
+        coverage combine --rcfile=$RCFILE
+        coverage report --rcfile=$RCFILE

--- a/.github/actions/unit_tests/action.yml
+++ b/.github/actions/unit_tests/action.yml
@@ -28,7 +28,11 @@ runs:
         python_version: ${{ inputs.python_version }}
         package_name: ${{ inputs.package_name }}
         os: ${{ inputs.os }}
-        wheel_path: ${{ inputs.wheel_path }}
+
+    - name: Use prebuilt distro wheel
+      if: ${{ inputs.wheel_path != '' }}
+      shell: bash
+      run: echo "ADOT_WHEEL=$(realpath '${{ inputs.wheel_path }}')" >> "$GITHUB_ENV"
 
     - name: Run unit tests/benchmarks with tox
       shell: bash

--- a/.github/workflows/di-contract-tests.yml
+++ b/.github/workflows/di-contract-tests.yml
@@ -31,7 +31,6 @@ jobs:
         uses: ./.github/actions/artifacts_build
         with:
           build_image: false
-          run_unit_tests: false
           python_version: ${{ matrix.python-version }}
           package_name: aws-opentelemetry-distro
           os: ubuntu-latest

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -116,11 +116,49 @@ jobs:
             dist/aws_opentelemetry_distro-${{ steps.python_output.outputs.ADOT_PYTHON_VERSION }}-py3-none-any.whl
             dist/aws_opentelemetry_distro-${{ steps.python_output.outputs.ADOT_PYTHON_VERSION }}.tar.gz
 
+      - name: Upload distro wheel
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
+        with:
+          name: distro-wheel
+          path: dist/aws_opentelemetry_distro-${{ steps.python_output.outputs.ADOT_PYTHON_VERSION }}-py3-none-any.whl
+          retention-days: 1
+
       - name: Set up and run contract tests with pytest
         run: |
           bash scripts/set-up-contract-tests.sh
           pip install pytest
           pytest contract-tests/tests
+
+  unit-tests:
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      fail-fast: false # ensures the entire test matrix is run, even if one permutation fails
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - name: Checkout Repo @ SHA - ${{ github.sha }}
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #5.0.0
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Download distro wheel
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
+        with:
+          name: distro-wheel
+          path: dist
+
+      - name: Resolve wheel path
+        id: wheel
+        run: echo "path=$(ls dist/aws_opentelemetry_distro-*-py3-none-any.whl)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up and run unit tests
+        uses: ./.github/actions/unit_tests
+        with:
+          python_version: ${{ matrix.python-version }}
+          package_name: aws-opentelemetry-distro
+          os: ubuntu-latest
+          wheel_path: ${{ steps.wheel.outputs.path }}
 
   application-signals-e2e-test:
     name: "Application Signals E2E Test"
@@ -146,7 +184,7 @@ jobs:
 
   publish-main-build-status:
     name: "Publish Main Build Status"
-    needs: [ build, application-signals-e2e-test ]
+    needs: [ build, unit-tests, application-signals-e2e-test ]
     runs-on: ubuntu-latest
     if: always() && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/v'))
     steps:
@@ -158,7 +196,7 @@ jobs:
 
       - name: Publish main build status
         run: |
-          value="${{ needs.build.result == 'success' && needs.application-signals-e2e-test.result == 'success' && '0.0' || '1.0'}}"
+          value="${{ needs.build.result == 'success' && needs.unit-tests.result == 'success' && needs.application-signals-e2e-test.result == 'success' && '0.0' || '1.0'}}"
           aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
             --metric-name Failure \
             --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=main_build \

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -131,11 +131,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Build distro wheel
-        run: |
-          pip install --upgrade pip setuptools wheel packaging build
-          rm -rf ./dist/*
-          cd ./aws-opentelemetry-distro
-          python -m build --outdir ../dist
+        uses: ./.github/actions/artifacts_build/build_wheel
       - name: Upload distro wheel
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         with:
@@ -185,7 +181,6 @@ jobs:
           python_version: ${{ matrix.python-version }}
           package_name: aws-opentelemetry-distro
           os: ubuntu-latest
-          run_unit_tests: false
           trivyignore-file: .github/trivy/pr-build.trivyignore.yaml
           platforms: linux/amd64
 
@@ -211,12 +206,11 @@ jobs:
         run: echo "path=$(ls dist/aws_opentelemetry_distro-*-py3-none-any.whl)" >> "$GITHUB_OUTPUT"
 
       - name: Set up and run unit tests
-        uses: ./.github/actions/set_up
+        uses: ./.github/actions/unit_tests
         with:
           python_version: ${{ matrix.python-version }}
           package_name: aws-opentelemetry-distro
           os: ubuntu-latest
-          run_unit_tests: true
           wheel_path: ${{ steps.wheel.outputs.path }}
 
   contract-tests:
@@ -249,7 +243,6 @@ jobs:
           python_version: 3.11
           package_name: aws-opentelemetry-distro
           os: ubuntu-latest
-          run_unit_tests: false
 
       - name: Run ${{ matrix.tox-environment }} with tox
         run: tox -e ${{ matrix.tox-environment }}

--- a/.github/workflows/serviceevents-contract-tests.yml
+++ b/.github/workflows/serviceevents-contract-tests.yml
@@ -27,7 +27,6 @@ jobs:
         uses: ./.github/actions/artifacts_build
         with:
           build_image: false
-          run_unit_tests: false
           python_version: "3.10"
           package_name: aws-opentelemetry-distro
           os: ubuntu-latest


### PR DESCRIPTION
Refactors the CI composite actions (shared `build_wheel`, dedicated `unit_tests`, `set_up` reduced to env-only, `run_unit_tests` flag dropped) and parallelizes main-build unit tests into a matrix job (3.10–3.14) that reuses the wheel built by `build`. Contract tests stay serial here (parallelized in the follow-up).