### PR TITLE
test(crewai): fix instrumentor tests for crewAI 1.15.0

### DIFF
--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/crewai/test_crewai_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/crewai/test_crewai_instrumentor.py
@@ -130,6 +130,7 @@ class TestCrewAIInstrumentor(TestCase):
         mock_llm.model = "gpt-4"
         mock_llm.temperature = 0.7
         mock_llm.max_tokens = 1024
+        mock_llm.stop = []
         mock_llm.call.side_effect = RuntimeError("LLM call failed")
 
         with patch.object(LLM, "__new__", return_value=mock_llm):
@@ -148,6 +149,7 @@ class TestCrewAIInstrumentor(TestCase):
         mock_llm.model = "gpt-4"
         mock_llm.temperature = 0.7
         mock_llm.max_tokens = 1024
+        mock_llm.stop = []
         mock_llm.supports_function_calling.return_value = False
         mock_llm.supports_stop_words.return_value = True
         mock_llm.call.side_effect = [
@@ -424,8 +426,15 @@ class TestCrewAIInstrumentor(TestCase):
         async def mock_acompletion(*args, **kwargs):
             return next(responses)
 
+        def mock_completion(*args, **kwargs):
+            return next(responses)
+
         async def run():
-            with patch("litellm.acompletion", side_effect=mock_acompletion):
+            # crewai routes akickoff through either litellm.acompletion or sync
+            # litellm.completion depending on the executor, so patch both.
+            with patch("litellm.acompletion", side_effect=mock_acompletion), patch(
+                "litellm.completion", side_effect=mock_completion
+            ):
                 return await crew.akickoff()
 
         asyncio.run(run())
@@ -461,8 +470,15 @@ class TestCrewAIInstrumentor(TestCase):
         async def mock_acompletion(*args, **kwargs):
             return next(responses)
 
+        def mock_completion(*args, **kwargs):
+            return next(responses)
+
         async def run():
-            with patch("litellm.acompletion", side_effect=mock_acompletion):
+            # crewai routes akickoff through either litellm.acompletion or sync
+            # litellm.completion depending on the executor, so patch both.
+            with patch("litellm.acompletion", side_effect=mock_acompletion), patch(
+                "litellm.completion", side_effect=mock_completion
+            ):
                 return await crew.akickoff()
 
         asyncio.run(run())


### PR DESCRIPTION
The crewai `-latest` unit-test env started failing once [crewAI 1.15.0](https://github.com/crewAIInc/crewAI/releases/tag/1.15.0) was released. Per that release, agents inside a Crew now use the experimental `AgentExecutor` by default, which (a) applies LLM stop words per call by reading `llm.stop`, and (b) dispatches the async kickoff path through the sync `litellm.completion` entrypoint.

This updates the crewai instrumentor tests to match:
- Give the `MagicMock(spec=LLM)` mocks an explicit `stop = []` (the new executor reads `llm.stop`, which a spec mock does not expose).
- Patch sync `litellm.completion` in the async tests in addition to `litellm.acompletion`, so the mocked response is used instead of a real network call.

No production code changes.