### PR TITLE
fix(genai): serialize list-valued message content into typed parts so multimodal/reasoning content is no longer stringified to a Python repr in `gen_ai.input/output.messages` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- fix(genai): serialize list-valued message content into typed parts so multimodal/reasoning content is no longer stringified to a Python repr in `gen_ai.input/output.messages` across langchain, llama_index, and crewai
+  ([#805](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/805))
 - feat: add OTel lite SDK for Lambda cold start optimization
   ([#789](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/789))
 

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/common/instrumentation_utils.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/common/instrumentation_utils.py
@@ -135,8 +135,9 @@ def content_to_parts(content: Any) -> list:  # pylint: disable=too-many-branches
             if not url:
                 continue
             if url.startswith("data:"):
-                mime = url[len("data:") :].split(",", 1)[0].split(";", 1)[0] or "image/*"
-                parts.append({"type": "blob", "modality": "image", "mime_type": mime, "content": url})
+                header, _, data = url[len("data:") :].partition(",")
+                mime = header.split(";", 1)[0] or "image/*"
+                parts.append({"type": "blob", "modality": "image", "mime_type": mime, "content": data})
             else:
                 parts.append({"type": "uri", "modality": "image", "uri": url})
         elif block_type == "image":

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/common/instrumentation_utils.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/common/instrumentation_utils.py
@@ -98,6 +98,63 @@ def serialize_to_json_string(value: Any, max_depth: int = 10) -> str:
         return str(value)
 
 
+def content_to_parts(content: Any) -> list:
+    """Convert a GenAI message's content into GenAI message parts, mapping each block to
+    its typed part per the input and output message schemas:
+    https://github.com/open-telemetry/semantic-conventions-genai/blob/main/model/gen-ai/gen-ai-input-messages.json
+    https://github.com/open-telemetry/semantic-conventions-genai/blob/main/model/gen-ai/gen-ai-output-messages.json
+    """
+    if isinstance(content, str):
+        return [{"type": "text", "content": content}] if content else []
+    if isinstance(content, dict):
+        content = [content]
+    elif not isinstance(content, list):
+        return [{"type": "text", "content": str(content)}] if content else []
+
+    parts: list = []
+    for block in content:
+        if isinstance(block, str):
+            if block:
+                parts.append({"type": "text", "content": block})
+            continue
+        if not isinstance(block, dict):
+            parts.append({"type": "text", "content": str(block)})
+            continue
+
+        block_type = block.get("type", "")
+        if block_type == "text":
+            text = block.get("text", "")
+            if text:
+                parts.append({"type": "text", "content": str(text)})
+        elif block_type in ("thinking", "reasoning"):
+            reasoning = block.get("thinking") or block.get("reasoning") or block.get("content") or ""
+            if reasoning:
+                parts.append({"type": "reasoning", "content": str(reasoning)})
+        elif block_type == "image_url":
+            url = (block.get("image_url") or {}).get("url", "")
+            if not url:
+                continue
+            if url.startswith("data:"):
+                mime = url[len("data:") :].split(",", 1)[0].split(";", 1)[0] or "image/*"
+                parts.append({"type": "blob", "modality": "image", "mime_type": mime, "content": url})
+            else:
+                parts.append({"type": "uri", "modality": "image", "uri": url})
+        elif block_type == "image":
+            parts.append(
+                {
+                    "type": "blob",
+                    "modality": "image",
+                    "mime_type": block.get("media_type") or block.get("mime_type") or "image/*",
+                    "content": block.get("data", ""),
+                }
+            )
+        else:
+            part = dict(block)
+            part["type"] = block_type or "text"
+            parts.append(part)
+    return parts
+
+
 def try_wrap(
     module: str, name: str, wrapper: Callable[..., Any], should_wrap: Optional[Callable[..., bool]] = None
 ) -> None:

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/common/instrumentation_utils.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/common/instrumentation_utils.py
@@ -98,7 +98,7 @@ def serialize_to_json_string(value: Any, max_depth: int = 10) -> str:
         return str(value)
 
 
-def content_to_parts(content: Any) -> list:
+def content_to_parts(content: Any) -> list:  # pylint: disable=too-many-branches
     """Convert a GenAI message's content into GenAI message parts, mapping each block to
     its typed part per the input and output message schemas:
     https://github.com/open-telemetry/semantic-conventions-genai/blob/main/model/gen-ai/gen-ai-input-messages.json

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/crewai/_event_handler.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/crewai/_event_handler.py
@@ -10,6 +10,7 @@ from amazon.opentelemetry.distro.instrumentation.common.instrumentation_utils im
     OPERATION_INVOKE_WORKFLOW,
     PROVIDER_MAP,
     DictWithLock,
+    content_to_parts,
     serialize_to_json_string,
     skip_instrumentation_if_suppressed,
 )
@@ -337,7 +338,7 @@ class OpenTelemetryEventHandler:
             system_instructions = [m for m in messages if m.get("role") == "system"]
             non_system_messages = [m for m in messages if m.get("role") != "system"]
             if system_instructions:
-                parts = [{"type": "text", "content": m.get("content", "")} for m in system_instructions]
+                parts = [p for m in system_instructions for p in content_to_parts(m.get("content", ""))]
                 attributes[GEN_AI_SYSTEM_INSTRUCTIONS] = serialize_to_json_string(parts)
             if non_system_messages:
                 attributes[GEN_AI_INPUT_MESSAGES] = serialize_to_json_string(
@@ -455,7 +456,7 @@ class OpenTelemetryEventHandler:
         parts = []
         content = msg.get("content")
         if content:
-            parts.append({"type": "text", "content": content})
+            parts.extend(content_to_parts(content))
         tool_calls = msg.get("tool_calls")
         if tool_calls:
             parts.extend(OpenTelemetryEventHandler._to_tool_call_parts(tool_calls))
@@ -468,7 +469,7 @@ class OpenTelemetryEventHandler:
         parts = []
         content = msg.get("content")
         if content:
-            parts.append({"type": "text", "content": content})
+            parts.extend(content_to_parts(content))
         tool_calls = msg.get("tool_calls")
         if tool_calls:
             parts.extend(OpenTelemetryEventHandler._to_tool_call_parts(tool_calls))

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/langchain/callback_handler.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/langchain/callback_handler.py
@@ -13,6 +13,7 @@ from langchain_core.callbacks import BaseCallbackHandler
 from amazon.opentelemetry.distro.instrumentation.common.instrumentation_utils import (
     PROVIDER_MAP,
     DictWithLock,
+    content_to_parts,
     serialize_to_json_string,
     skip_instrumentation_if_suppressed,
     try_detach,
@@ -350,11 +351,11 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
                         {
                             "type": "tool_call_response",
                             "id": tool_call_id,
-                            "response": str(content) if content else "",
+                            "response": content if content else "",
                         }
                     )
                 elif content:
-                    parts.append({"type": "text", "content": str(content)})
+                    parts.extend(content_to_parts(content))
                 tool_calls: list[dict] = getattr(msg, "tool_calls", None) or []
                 for tc in tool_calls:
                     parts.append(

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/llama_index/_span.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/llama_index/_span.py
@@ -154,7 +154,7 @@ def _safe_get(obj: Any, key: str) -> Any:
     return obj.get(key) if isinstance(obj, Mapping) else getattr(obj, key, None)
 
 
-def _message_to_parts(msg: ChatMessage) -> list:
+def _message_to_parts(msg: ChatMessage) -> list:  # pylint: disable=too-many-branches
     """Convert a ChatMessage's blocks to OTel parts format."""
     blocks = getattr(msg, "blocks", None)
     if blocks:

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/llama_index/_span.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/llama_index/_span.py
@@ -19,6 +19,11 @@ try:
     from llama_index.core.base.llms.types import ToolCallBlock
 except ImportError:
     ToolCallBlock = None
+
+try:
+    from llama_index.core.base.llms.types import ImageBlock
+except ImportError:
+    ImageBlock = None
 from llama_index.core.instrumentation.events import BaseEvent
 from llama_index.core.instrumentation.events.chat_engine import (
     StreamChatDeltaReceivedEvent,
@@ -47,6 +52,7 @@ from pydantic import PrivateAttr
 from amazon.opentelemetry.distro.instrumentation.common.instrumentation_utils import (
     GEN_AI_WORKFLOW_NAME,
     OPERATION_INVOKE_WORKFLOW,
+    content_to_parts,
     serialize_to_json_string,
     try_detach,
 )
@@ -167,10 +173,24 @@ def _message_to_parts(msg: ChatMessage) -> list:
                 parts.append(part)
             elif ThinkingBlock is not None and isinstance(block, ThinkingBlock):
                 parts.append({"type": "reasoning", "content": str(block.content)})
+            elif ImageBlock is not None and isinstance(block, ImageBlock):
+                if getattr(block, "url", None):
+                    parts.append({"type": "uri", "modality": "image", "uri": str(block.url)})
+                elif getattr(block, "image", None) is not None:
+                    image = block.image
+                    parts.append(
+                        {
+                            "type": "blob",
+                            "modality": "image",
+                            "mime_type": getattr(block, "image_mimetype", None) or "image/*",
+                            "content": image.decode() if isinstance(image, (bytes, bytearray)) else str(image),
+                        }
+                    )
+                elif getattr(block, "path", None):
+                    parts.append({"type": "uri", "modality": "image", "uri": str(block.path)})
         if parts:
             return parts
-    content = str(getattr(msg, "content", ""))
-    return [{"type": "text", "content": content}]
+    return content_to_parts(getattr(msg, "content", ""))
 
 
 def _format_messages(messages: Iterable[ChatMessage]) -> tuple:

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/crewai/test_crewai_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/crewai/test_crewai_instrumentor.py
@@ -18,6 +18,8 @@ if sys.version_info < (3, 10) or sys.version_info >= (3, 14):
     raise unittest.SkipTest("crewai requires >=3.10, <3.14")
 
 from crewai import LLM, Agent, Crew, Task
+from crewai.events import crewai_event_bus
+from crewai.events.types.llm_events import LLMCallCompletedEvent, LLMCallStartedEvent, LLMCallType
 from crewai.tools import tool
 
 from amazon.opentelemetry.distro.instrumentation.common.instrumentation_utils import (
@@ -123,6 +125,76 @@ class TestCrewAIInstrumentor(TestCase):
 
     def test_perplexity_crew_kickoff(self):
         self._run_crew_kickoff_test("perplexity/sonar-medium", GenAiProviderNameValues.PERPLEXITY.value, "sonar-medium")
+
+    def test_multimodal_input_and_output_messages(self):
+        models = [
+            "bedrock/anthropic.claude-3-haiku-20240307-v1:0",
+            "openai/gpt-4",
+            "anthropic/claude-3-sonnet-20240229",
+            "google/gemini-pro",
+            "groq/llama-3",
+            "cohere/command-r",
+            "mistral/mistral-large",
+            "deepseek/deepseek-chat",
+            "perplexity/sonar-medium",
+        ]
+
+        input_content = [
+            {"type": "text", "text": "describe"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+        ]
+        expected_input_parts = [
+            {"type": "text", "content": "describe"},
+            {"type": "uri", "modality": "image", "uri": "https://example.com/cat.png"},
+            {"type": "blob", "modality": "image", "mime_type": "image/png", "content": "data:image/png;base64,AAAA"},
+        ]
+
+        output_content = [
+            {"type": "text", "text": "The answer is blue."},
+            {"type": "thinking", "thinking": "Let me reason about this."},
+            {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+        ]
+        expected_output_parts = [
+            {"type": "text", "content": "The answer is blue."},
+            {"type": "reasoning", "content": "Let me reason about this."},
+            {"type": "uri", "modality": "image", "uri": "https://example.com/cat.png"},
+            {"type": "blob", "modality": "image", "mime_type": "image/png", "content": "data:image/png;base64,AAAA"},
+        ]
+
+        for model in models:
+            with self.subTest(model=model):
+                self.span_exporter.clear()
+                llm = LLM(model=model, is_litellm=True)
+                start_event = LLMCallStartedEvent(call_id="c1", messages=[{"role": "user", "content": input_content}])
+                crewai_event_bus.emit(llm, start_event)
+                crewai_event_bus.emit(
+                    llm,
+                    LLMCallCompletedEvent(
+                        call_id="c1",
+                        response=[{"role": "assistant", "content": output_content}],
+                        call_type=LLMCallType.LLM_CALL,
+                        started_event_id=start_event.event_id,
+                    ),
+                )
+
+                chat_span = self._find_span("chat")
+                self.assertIsNotNone(chat_span)
+
+                input_messages = json.loads(chat_span.attributes[GEN_AI_INPUT_MESSAGES])
+                validate_otel_genai_schema(input_messages, "gen-ai-input-messages")
+                self.assertEqual(input_messages[0]["parts"], expected_input_parts)
+
+                output_messages = json.loads(chat_span.attributes[GEN_AI_OUTPUT_MESSAGES])
+                validate_otel_genai_schema(output_messages, "gen-ai-output-messages")
+                self.assertEqual(output_messages[0]["parts"], expected_output_parts)
+
+                for parts in (input_messages[0]["parts"], output_messages[0]["parts"]):
+                    for part in parts:
+                        value = part.get("content", "")
+                        if isinstance(value, str):
+                            self.assertFalse(value.lstrip().startswith("[{") and "'type'" in value)
 
     def test_crew_kickoff_error_handling(self):
         mock_llm = MagicMock(spec=LLM)

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/crewai/test_crewai_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/crewai/test_crewai_instrumentor.py
@@ -147,7 +147,7 @@ class TestCrewAIInstrumentor(TestCase):
         expected_input_parts = [
             {"type": "text", "content": "describe"},
             {"type": "uri", "modality": "image", "uri": "https://example.com/cat.png"},
-            {"type": "blob", "modality": "image", "mime_type": "image/png", "content": "data:image/png;base64,AAAA"},
+            {"type": "blob", "modality": "image", "mime_type": "image/png", "content": "AAAA"},
         ]
 
         output_content = [
@@ -160,7 +160,7 @@ class TestCrewAIInstrumentor(TestCase):
             {"type": "text", "content": "The answer is blue."},
             {"type": "reasoning", "content": "Let me reason about this."},
             {"type": "uri", "modality": "image", "uri": "https://example.com/cat.png"},
-            {"type": "blob", "modality": "image", "mime_type": "image/png", "content": "data:image/png;base64,AAAA"},
+            {"type": "blob", "modality": "image", "mime_type": "image/png", "content": "AAAA"},
         ]
 
         for model in models:

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/langchain/test_langchain_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/langchain/test_langchain_instrumentor.py
@@ -655,6 +655,94 @@ class TestLangChainInstrumentor(TestCase):
         self.assertEqual(output[0]["parts"][0]["type"], "text")
         self.assertIn("Final Answer: Done.", output[0]["parts"][0]["content"])
 
+    def test_multimodal_input_and_output_messages(self):
+        from langchain_anthropic import ChatAnthropic
+        from langchain_aws import ChatBedrock, ChatBedrockConverse
+        from langchain_cohere import ChatCohere
+        from langchain_deepseek import ChatDeepSeek
+        from langchain_google_genai import ChatGoogleGenerativeAI
+        from langchain_groq import ChatGroq
+        from langchain_mistralai import ChatMistralAI
+        from langchain_openai import AzureChatOpenAI, ChatOpenAI
+        from langchain_xai import ChatXAI
+
+        models = [
+            (ChatBedrock, {"model_id": "test", "region_name": "us-east-1"}),
+            (ChatBedrockConverse, {"model": "test", "region_name": "us-east-1"}),
+            (ChatOpenAI, {"api_key": "fake"}),
+            (
+                AzureChatOpenAI,
+                {"api_key": "fake", "azure_endpoint": "https://fake.openai.azure.com", "api_version": "2024-01-01"},
+            ),
+            (ChatAnthropic, {"anthropic_api_key": "fake", "model_name": "claude-3"}),
+            (ChatGoogleGenerativeAI, {"google_api_key": "fake", "model": "gemini-pro"}),
+            (ChatMistralAI, {"api_key": "fake", "model": "test"}),
+            (ChatGroq, {"api_key": "fake", "model": "test"}),
+            (ChatCohere, {"cohere_api_key": "fake", "model": "test"}),
+            (ChatDeepSeek, {"api_key": "fake", "model": "test"}),
+            (ChatXAI, {"api_key": "fake", "model": "test"}),
+        ]
+
+        input_content = [
+            {"type": "text", "text": "describe"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+        ]
+        expected_input_parts = [
+            {"type": "text", "content": "describe"},
+            {"type": "uri", "modality": "image", "uri": "https://example.com/cat.png"},
+            {"type": "blob", "modality": "image", "mime_type": "image/png", "content": "data:image/png;base64,AAAA"},
+        ]
+
+        output_content = [
+            {"type": "text", "text": "The answer is blue."},
+            {"type": "thinking", "thinking": "Let me reason about this."},
+            {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+        ]
+        expected_output_parts = [
+            {"type": "text", "content": "The answer is blue."},
+            {"type": "reasoning", "content": "Let me reason about this."},
+            {"type": "uri", "modality": "image", "uri": "https://example.com/cat.png"},
+            {"type": "blob", "modality": "image", "mime_type": "image/png", "content": "data:image/png;base64,AAAA"},
+        ]
+
+        fake_result = ChatResult(
+            generations=[
+                ChatGeneration(message=AIMessage(content=output_content), generation_info={"finish_reason": "stop"})
+            ],
+            llm_output={"model_name": "test", "token_usage": {"prompt_tokens": 1, "completion_tokens": 1}},
+        )
+
+        for model_cls, init_kwargs in models:
+            with self.subTest(model=model_cls.__name__):
+                self.span_exporter.clear()
+                llm = model_cls(**init_kwargs)
+                with patch.object(type(llm), "_generate", return_value=fake_result):
+                    llm.invoke([HumanMessage(content=input_content)])
+
+                chat_spans = [
+                    s
+                    for s in self.span_exporter.get_finished_spans()
+                    if "chat" in s.name or "text_completion" in s.name
+                ]
+                self.assertGreaterEqual(len(chat_spans), 1, f"No chat span for {model_cls.__name__}")
+                attrs = chat_spans[0].attributes
+
+                input_messages = json.loads(attrs[GEN_AI_INPUT_MESSAGES])
+                validate_otel_genai_schema(input_messages, "gen-ai-input-messages")
+                self.assertEqual(input_messages[0]["parts"], expected_input_parts)
+
+                output_messages = json.loads(attrs[GEN_AI_OUTPUT_MESSAGES])
+                validate_otel_genai_schema(output_messages, "gen-ai-output-messages")
+                self.assertEqual(output_messages[0]["parts"], expected_output_parts)
+
+                for parts in (input_messages[0]["parts"], output_messages[0]["parts"]):
+                    for part in parts:
+                        value = part.get("content", "")
+                        if isinstance(value, str):
+                            self.assertFalse(value.lstrip().startswith("[{") and "'type'" in value)
+
     def test_system_instructions_schema_validation(self):
         llm = self.FakeChatModel(messages=iter([AIMessage(content="Hi!")]))
         llm.invoke([SystemMessage(content="You are a helpful assistant."), HumanMessage(content="Hello")])

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/langchain/test_langchain_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/langchain/test_langchain_instrumentor.py
@@ -691,7 +691,7 @@ class TestLangChainInstrumentor(TestCase):
         expected_input_parts = [
             {"type": "text", "content": "describe"},
             {"type": "uri", "modality": "image", "uri": "https://example.com/cat.png"},
-            {"type": "blob", "modality": "image", "mime_type": "image/png", "content": "data:image/png;base64,AAAA"},
+            {"type": "blob", "modality": "image", "mime_type": "image/png", "content": "AAAA"},
         ]
 
         output_content = [
@@ -704,7 +704,7 @@ class TestLangChainInstrumentor(TestCase):
             {"type": "text", "content": "The answer is blue."},
             {"type": "reasoning", "content": "Let me reason about this."},
             {"type": "uri", "modality": "image", "uri": "https://example.com/cat.png"},
-            {"type": "blob", "modality": "image", "mime_type": "image/png", "content": "data:image/png;base64,AAAA"},
+            {"type": "blob", "modality": "image", "mime_type": "image/png", "content": "AAAA"},
         ]
 
         fake_result = ChatResult(

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/llama_index/test_llama_index_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/llama_index/test_llama_index_instrumentor.py
@@ -1348,8 +1348,12 @@ class TestLlamaIndexInstrumentor(unittest.TestCase):
         span.end()
 
     def test_multimodal_input_and_output_messages(self):
-        from llama_index.core.base.llms.types import ThinkingBlock
         from llama_index.core.instrumentation.events.llm import LLMChatEndEvent
+
+        try:
+            from llama_index.core.base.llms.types import ThinkingBlock
+        except ImportError:
+            ThinkingBlock = None
 
         input_message = ChatMessage(
             role="user",
@@ -1365,21 +1369,20 @@ class TestLlamaIndexInstrumentor(unittest.TestCase):
             {"type": "blob", "modality": "image", "mime_type": "image/png", "content": "QQ=="},
         ]
 
-        output_message = ChatMessage(
-            role="assistant",
-            blocks=[
-                TextBlock(text="The answer is blue."),
-                ThinkingBlock(content="Let me reason about this."),
-                ImageBlock(url="https://example.com/cat.png"),
-                ImageBlock(image=b"QQ==", image_mimetype="image/png"),
-            ],
-        )
-        expected_output_parts = [
-            {"type": "text", "content": "The answer is blue."},
-            {"type": "reasoning", "content": "Let me reason about this."},
+        output_blocks = [TextBlock(text="The answer is blue.")]
+        expected_output_parts = [{"type": "text", "content": "The answer is blue."}]
+        if ThinkingBlock is not None:
+            output_blocks.append(ThinkingBlock(content="Let me reason about this."))
+            expected_output_parts.append({"type": "reasoning", "content": "Let me reason about this."})
+        output_blocks += [
+            ImageBlock(url="https://example.com/cat.png"),
+            ImageBlock(image=b"QQ==", image_mimetype="image/png"),
+        ]
+        expected_output_parts += [
             {"type": "uri", "modality": "image", "uri": "https://example.com/cat.png"},
             {"type": "blob", "modality": "image", "mime_type": "image/png", "content": "QQ=="},
         ]
+        output_message = ChatMessage(role="assistant", blocks=output_blocks)
 
         otel_span = self.tracer.start_span("test")
         span = self._Span(otel_span=otel_span)

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/llama_index/test_llama_index_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/llama_index/test_llama_index_instrumentor.py
@@ -18,7 +18,16 @@ if sys.version_info < (3, 10):
     raise unittest.SkipTest("llama-index requires Python >= 3.10")
 
 from llama_index.core.agent.workflow import AgentWorkflow, FunctionAgent
-from llama_index.core.base.llms.types import ChatMessage, ChatResponse, CompletionResponse, LLMMetadata, MessageRole
+from llama_index.core.base.llms.types import (
+    ChatMessage,
+    ChatResponse,
+    CompletionResponse,
+    ImageBlock,
+    LLMMetadata,
+    MessageRole,
+    TextBlock,
+)
+from llama_index.core.instrumentation.events.llm import LLMChatStartEvent
 from llama_index.core.llms.function_calling import FunctionCallingLLM
 from llama_index.core.llms.llm import ToolSelection
 from llama_index.core.tools import FunctionTool
@@ -1337,6 +1346,60 @@ class TestLlamaIndexInstrumentor(unittest.TestCase):
         self.assertIn("sunny", output[0]["parts"][0]["content"])
         self.assertNotIn(GEN_AI_RESPONSE_FINISH_REASONS, span._attributes)
         span.end()
+
+    def test_multimodal_input_and_output_messages(self):
+        from llama_index.core.base.llms.types import ThinkingBlock
+        from llama_index.core.instrumentation.events.llm import LLMChatEndEvent
+
+        input_message = ChatMessage(
+            role="user",
+            blocks=[
+                TextBlock(text="describe"),
+                ImageBlock(url="https://example.com/cat.png"),
+                ImageBlock(image=b"QQ==", image_mimetype="image/png"),
+            ],
+        )
+        expected_input_parts = [
+            {"type": "text", "content": "describe"},
+            {"type": "uri", "modality": "image", "uri": "https://example.com/cat.png"},
+            {"type": "blob", "modality": "image", "mime_type": "image/png", "content": "QQ=="},
+        ]
+
+        output_message = ChatMessage(
+            role="assistant",
+            blocks=[
+                TextBlock(text="The answer is blue."),
+                ThinkingBlock(content="Let me reason about this."),
+                ImageBlock(url="https://example.com/cat.png"),
+                ImageBlock(image=b"QQ==", image_mimetype="image/png"),
+            ],
+        )
+        expected_output_parts = [
+            {"type": "text", "content": "The answer is blue."},
+            {"type": "reasoning", "content": "Let me reason about this."},
+            {"type": "uri", "modality": "image", "uri": "https://example.com/cat.png"},
+            {"type": "blob", "modality": "image", "mime_type": "image/png", "content": "QQ=="},
+        ]
+
+        otel_span = self.tracer.start_span("test")
+        span = self._Span(otel_span=otel_span)
+        span._process_event(LLMChatStartEvent(messages=[input_message], additional_kwargs={}, model_dict={}))
+        span._process_event(LLMChatEndEvent(messages=[], response=ChatResponse(message=output_message)))
+        otel_span.end()
+
+        input_messages = json.loads(span._attributes[GEN_AI_INPUT_MESSAGES])
+        validate_otel_genai_schema(input_messages, "gen-ai-input-messages")
+        self.assertEqual(input_messages[0]["parts"], expected_input_parts)
+
+        output_messages = json.loads(span._attributes[GEN_AI_OUTPUT_MESSAGES])
+        validate_otel_genai_schema(output_messages, "gen-ai-output-messages")
+        self.assertEqual(output_messages[0]["parts"], expected_output_parts)
+
+        for parts in (input_messages[0]["parts"], output_messages[0]["parts"]):
+            for part in parts:
+                value = part.get("content", "")
+                if isinstance(value, str):
+                    self.assertFalse(value.lstrip().startswith("[{") and "'type'" in value)
 
     def test_chat_response_by_provider(self):
         from llama_index.core.base.llms.types import TextBlock


### PR DESCRIPTION
Fixes a bug where list-valued message content was stringified to a Python repr, corrupting `gen_ai.input/output.messages` for multimodal/reasoning content across langchain, llama_index, and crewai.

Adds a shared `content_to_parts` helper that maps each block to its typed part, used by all three instrumentations.