### PR TITLE
test: wire EKS Service Events e2e into application-signals-e2e-test

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -288,6 +288,17 @@ jobs:
       caller-workflow-name: 'main-build'
       staging-wheel-name: ${{ inputs.staging-wheel-name }}
 
+  service-events-eks:
+    if: ${{ always() }}
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-service-events-test.yml@main
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      test-cluster-name: 'e2e-python-adot-test'
+      adot-image-name: ${{ inputs.adot-image-name }}
+      caller-workflow-name: 'main-build'
+      python-version: '3.10'
+
   # This validation is to ensure that all test workflows relevant to this repo are actually
   # being used in this repo, which is referring to all the other jobs in this file.
   #


### PR DESCRIPTION
## Summary

Wires the EKS Service Events E2E test into `application-signals-e2e-test.yml` by adding a `service-events-eks` job that calls the reusable `python-eks-service-events-test.yml` workflow from `aws-application-signals-test-framework` (added in [test-framework PR #658](https://github.com/aws-observability/aws-application-signals-test-framework/pull/658), now merged).

Mirrors the existing `service-events-ec2` job and the `eks-*` jobs already in this file: image-based via `adot-image-name` (passed through; when empty, the cluster operator's default SE-capable ADOT image is validated), `caller-workflow-name: 'main-build'`, cluster `e2e-python-adot-test`.

## Why this is needed

Beyond adding EKS SE coverage, this is required to keep the `validate-e2e-tests-are-accounted-for` check green. That check enumerates every `python-*-test.yml` on the test-framework `main` branch and fails if any is not referenced here. Now that `python-eks-service-events-test.yml` exists on test-framework `main`, this reference is mandatory.

## Validation

The reusable workflow was validated end-to-end 5/5 (all 5 Service Events signals) against `e2e-python-adot-test` in us-east-1 prior to test-framework PR #658 merging. See that PR for the run evidence.
