### PR TITLE
test: serialize service-events-eks after eks-py314 (NodePort clash follow-up to #808)

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -290,6 +290,11 @@ jobs:
 
   service-events-eks:
     if: ${{ always() }}
+    # Chain onto the tail of the eks-py* jobs: they all target e2e-python-adot-test and the
+    # sample-app Service binds cluster-wide NodePort 30100, which this SE test also uses. Running
+    # in parallel would collide on that port ("provided port is already allocated"), so serialize
+    # after the last eks-py* job, matching how eks-py311..314 chain via needs.
+    needs: eks-py314-amd64
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-service-events-test.yml@main
     secrets: inherit
     with:


### PR DESCRIPTION
## Summary

Follow-up to #808. The `service-events-eks` job added there targets the shared `e2e-python-adot-test` cluster but had no `needs:` on the `eks-py*` chain, so on a real `main-build` it runs in parallel with `eks-py310..314`.

The sample-app Kubernetes Service binds cluster-wide **NodePort 30100**, which the regular `python-eks-test` also binds. Two Services cannot claim the same NodePort, so parallel runs collide — whichever `terraform apply` runs second fails with *"provided port is already allocated"*. The `eks-py*` jobs already serialize via `needs:` for exactly this reason.

## Change

Add `needs: eks-py314-amd64` to `service-events-eks` so it runs after the last `eks-py*` job on that cluster, matching the existing chain.

## Why it wasn't caught earlier

The reusable workflow was validated 5/5 by dispatching it in isolation (only the SE job ran, so it had the cluster to itself). The contention only arises once the job is wired alongside the `eks-py*` chain in `application-signals-e2e-test.yml`, which is the context this fixes.
