### PR TITLE
feat(serviceevents): resolve aws.local.environment for SE/DI in the SDK to align with CloudWatch agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- feat(serviceevents): resolve `aws.local.environment` in the SDK (eks/k8s/ecs/ec2/generic) to align
+  ServiceEvents & Dynamic Instrumentation with the CloudWatch agent, with a custom EC2 ASG detector
+  ([#813](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/813))
 - refactor(serviceevents): make the endpoint span processor framework-agnostic
 - fix(serviceevents): gate incident trace correlation on the SAMPLED flag and harden incident dedup/rate-limiting
 - fix(genai): serialize list-valued message content into typed parts so multimodal/reasoning content is no longer stringified to a Python repr in `gen_ai.input/output.messages` across langchain, llama_index, and crewai

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
@@ -42,6 +42,7 @@ from amazon.opentelemetry.distro.sampler._aws_xray_adaptive_sampling_config impo
 from amazon.opentelemetry.distro.sampler.aws_xray_remote_sampler import AwsXRayRemoteSampler
 from amazon.opentelemetry.distro.scope_based_exporter import ScopeBasedPeriodicExportingMetricReader
 from amazon.opentelemetry.distro.scope_based_filtering_view import ScopeBasedRetainingView
+from amazon.opentelemetry.distro.serviceevents.utils.ec2_asg_detector import Ec2AutoScalingGroupResourceDetector
 from opentelemetry._events import set_event_logger_provider
 from opentelemetry._logs import get_logger_provider, set_logger_provider
 from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
@@ -200,7 +201,14 @@ def _initialize_components():
     auto_resource: Dict[str, any] = {}
     auto_resource = _customize_versions(auto_resource)
 
-    resource_detectors = (
+    # The EC2 ASG detector is intentionally NOT in the global detector list, so
+    # ec2.tag.aws:autoscaling:groupName does NOT ride the global resource (which feeds
+    # Application Signals). The CloudWatch agent reads that exact key off incoming telemetry
+    # (awsapplicationsignals processor) and would resolve the AppSignals EC2 environment from
+    # our SDK-sent value — so keeping it out of the global chain leaves AppSignals' environment
+    # untouched (the SDK's value flows only through ServiceEvents/DI). The ASG is instead
+    # resolved into the dedicated ServiceEvents resource below.
+    base_detectors = (
         [
             AwsEc2ResourceDetector(),
             AwsEksResourceDetector(),
@@ -210,7 +218,22 @@ def _initialize_components():
         else []
     )
 
-    resource = _customize_resource(get_aggregated_resources(resource_detectors).merge(Resource.create(auto_resource)))
+    resource = _customize_resource(get_aggregated_resources(base_detectors).merge(Resource.create(auto_resource)))
+
+    # ServiceEvents gets its OWN resource, built from a full copy of the detector set PLUS the
+    # custom EC2 ASG detector, so aws.local.environment can resolve ec2:<asg> without leaking
+    # the ASG tag onto the global/AppSignals resource.
+    serviceevents_resource = resource
+    if base_detectors:
+        serviceevents_detectors = [
+            AwsEc2ResourceDetector(),
+            Ec2AutoScalingGroupResourceDetector(),
+            AwsEksResourceDetector(),
+            AwsEcsResourceDetector(),
+        ]
+        serviceevents_resource = _customize_resource(
+            get_aggregated_resources(serviceevents_detectors).merge(Resource.create(auto_resource))
+        )
 
     sampler_name = _get_sampler()
     sampler = _custom_import_sampler(sampler_name, resource)
@@ -227,8 +250,9 @@ def _initialize_components():
     if logging_enabled.strip().lower() == "true":
         _init_logging(log_exporters, resource)
 
-    # Initialize ServiceEvents instrumentation
-    _init_serviceevents(resource)
+    # Initialize ServiceEvents instrumentation (uses the ServiceEvents-specific resource,
+    # which includes the EC2 ASG tag; see note above).
+    _init_serviceevents(serviceevents_resource)
 
 
 def _init_serviceevents(resource=None):

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/debugger/_debugger_client.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/debugger/_debugger_client.py
@@ -21,7 +21,10 @@ from amazon.opentelemetry.distro.serviceevents.utils.ec2_asg_detector import (
     EC2_ASG_ATTRIBUTE,
     Ec2AutoScalingGroupResourceDetector,
 )
-from amazon.opentelemetry.distro.serviceevents.utils.environment_resolver import resolve_local_environment
+from amazon.opentelemetry.distro.serviceevents.utils.environment_resolver import (
+    has_platform_context,
+    resolve_local_environment,
+)
 from opentelemetry import trace
 
 try:
@@ -177,12 +180,8 @@ class DebuggerClient:
             # require platform context before caching them — otherwise a still-populating
             # resource would cache the wrong value and never retry. A specific value
             # (eks:/k8s:/ecs:/ec2:<asg>/explicit env) is always safe to cache.
-            has_platform_context = any(
-                global_resource.attributes.get(key)
-                for key in ("cloud.platform", "k8s.cluster.name", "aws.ecs.cluster.arn", "host.id")
-            )
             is_fallback = environment in ("ec2:default", "generic:default")
-            if environment and (not is_fallback or has_platform_context):
+            if environment and (not is_fallback or has_platform_context(global_resource.attributes)):
                 self._cached_environment = environment
                 logger.debug("Deployment environment resolved and cached: %s", environment)
                 return environment

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/debugger/_debugger_client.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/debugger/_debugger_client.py
@@ -17,8 +17,12 @@ from amazon.opentelemetry.distro._aws_resource_attribute_configurator import _OT
 from amazon.opentelemetry.distro._aws_span_processing_util import UNKNOWN_SERVICE
 from amazon.opentelemetry.distro.debugger._data_models import BreakpointConfiguration
 from amazon.opentelemetry.distro.debugger.instrumentation_manager import get_global_manager
+from amazon.opentelemetry.distro.serviceevents.utils.ec2_asg_detector import (
+    EC2_ASG_ATTRIBUTE,
+    Ec2AutoScalingGroupResourceDetector,
+)
+from amazon.opentelemetry.distro.serviceevents.utils.environment_resolver import resolve_local_environment
 from opentelemetry import trace
-from opentelemetry.semconv.resource import ResourceAttributes
 
 try:
     import requests
@@ -37,6 +41,19 @@ DEFAULT_API_URL = "http://localhost:2000"  # Default debugger API URL
 BASE_BACKOFF_INTERVAL = 10  # Base interval for exponential backoff (seconds)
 MAX_BACKOFF_ATTEMPTS = 3  # Maximum number of backoff attempts for initial fetch
 DEGRADED_POLL_INTERVAL = 300  # 5 minutes — used when API endpoint is unreachable
+
+# Process-wide memoized EC2 Auto Scaling group lookup. DI reads the global resource, which
+# omits the ASG tag so it does not ride the AppSignals path; on the EC2 branch the resolver
+# falls back to this lazy IMDS lookup. Sentinel None = not yet attempted.
+_CACHED_ASG: Optional[str] = None
+
+
+def _fetch_ec2_asg() -> str:
+    global _CACHED_ASG  # pylint: disable=global-statement
+    if _CACHED_ASG is None:
+        resource = Ec2AutoScalingGroupResourceDetector().detect()
+        _CACHED_ASG = str(resource.attributes.get(EC2_ASG_ATTRIBUTE, "") or "")
+    return _CACHED_ASG
 
 
 class DebuggerClient:
@@ -125,11 +142,20 @@ class DebuggerClient:
     @property
     def environment(self) -> str:
         """
-        Get environment from OpenTelemetry resource (lazy-loaded, cached after successful resolution).
+        Get aws.local.environment from the OpenTelemetry resource (lazy-loaded, cached).
 
-        Only caches successful environment resolution to handle timing issues with Resource population.
-        If environment is not yet available, returns "UnknownEnvironment" without caching,
-        allowing automatic retry on next call.
+        SDK-only environment resolution: rather than reading only an explicit
+        deployment.environment[.name], compute the full aws.local.environment from the
+        detected resource attributes using the same precedence as the CloudWatch agent
+        (explicit -> eks/k8s:<cluster>/<namespace> -> ecs:<cluster> -> ec2:<asg> ->
+        ec2:default -> generic:default). This makes DI self-sufficient — the value used as
+        the request's Environment lookup key matches Application Signals without relying on
+        the agent proxy to inject it.
+
+        Only caches once the resource carries platform context (for the fallback values
+        ec2:default / generic:default), to handle timing issues with Resource population.
+        Until then returns "UnknownEnvironment" without caching, allowing automatic retry on
+        the next call.
         """
         # Return cached value if we successfully found it before
         if self._cached_environment:
@@ -141,21 +167,30 @@ class DebuggerClient:
             tracer_provider = trace.get_tracer_provider()
             global_resource = tracer_provider.resource
 
-            # Try deployment.environment.name first, then DEPLOYMENT_ENVIRONMENT
-            environment = global_resource.attributes.get(
-                "deployment.environment.name"
-            ) or global_resource.attributes.get(ResourceAttributes.DEPLOYMENT_ENVIRONMENT)
+            # The global resource intentionally omits the EC2 ASG tag (it must not ride the
+            # AppSignals path), so on the EC2 branch the resolver falls back to a lazy IMDS
+            # lookup via the ASG detector. Other branches never invoke the supplier.
+            environment = resolve_local_environment(global_resource.attributes, _fetch_ec2_asg)
 
-            if environment:
-                # SUCCESS! Cache it so we never query again
+            # The resolver's fallback values (ec2:default, generic:default) are what a
+            # half-populated resource momentarily yields before async detectors settle, so
+            # require platform context before caching them — otherwise a still-populating
+            # resource would cache the wrong value and never retry. A specific value
+            # (eks:/k8s:/ecs:/ec2:<asg>/explicit env) is always safe to cache.
+            has_platform_context = any(
+                global_resource.attributes.get(key)
+                for key in ("cloud.platform", "k8s.cluster.name", "aws.ecs.cluster.arn", "host.id")
+            )
+            is_fallback = environment in ("ec2:default", "generic:default")
+            if environment and (not is_fallback or has_platform_context):
                 self._cached_environment = environment
                 logger.debug("Deployment environment resolved and cached: %s", environment)
                 return environment
         except Exception as exception:  # pylint: disable=broad-exception-caught
             logger.debug("Error getting environment from OpenTelemetry resource: %s", exception)
 
-        # Attribute not available yet - don't cache, try again next time
-        logger.debug("deployment.environment.name attribute not yet available, will retry on next call")
+        # Resource not populated yet - don't cache, try again next time
+        logger.debug("environment not yet resolvable from resource, will retry on next call")
         return "UnknownEnvironment"  # Don't cache - Resource might populate later
 
     @staticmethod

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/models/resource_attributes.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/models/resource_attributes.py
@@ -24,6 +24,9 @@ _OTEL_KEY_MAP = {
     "k8s.cluster.name": "k8s_cluster_name",
     "k8s.pod.name": "k8s_pod_name",
     "k8s.namespace.name": "k8s_namespace_name",
+    # Inputs the environment resolver needs to match the CloudWatch agent on ECS/EC2.
+    "aws.ecs.cluster.arn": "aws_ecs_cluster_arn",
+    "ec2.tag.aws:autoscaling:groupName": "ec2_autoscaling_group",
 }
 
 # Reverse mapping: field name -> OTel key
@@ -53,6 +56,8 @@ class ResourceAttributes:
     k8s_cluster_name: Optional[str] = None  # e.g., "my-cluster"
     k8s_pod_name: Optional[str] = None  # e.g., "my-pod-xyz"
     k8s_namespace_name: Optional[str] = None  # e.g., "default"
+    aws_ecs_cluster_arn: Optional[str] = None  # e.g., "arn:aws:ecs:...:cluster/my-cluster"
+    ec2_autoscaling_group: Optional[str] = None  # e.g., "my-asg"
 
     @classmethod
     def from_otel_resource(cls, resource) -> "ResourceAttributes":

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/serviceevents_instrumentation.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/serviceevents_instrumentation.py
@@ -19,6 +19,7 @@ from amazon.opentelemetry.distro.serviceevents.collectors.endpoint_collector imp
 from amazon.opentelemetry.distro.serviceevents.collectors.incident_snapshot_collector import IncidentSnapshotCollector
 from amazon.opentelemetry.distro.serviceevents.config import ServiceEventsConfig
 from amazon.opentelemetry.distro.serviceevents.python_monitor import _ServiceEventsMonitorState
+from amazon.opentelemetry.distro.serviceevents.utils.environment_resolver import stamp_local_environment
 
 logger = logging.getLogger(__name__)
 
@@ -498,7 +499,9 @@ class ServiceEventsInstrumentation:
         git_repo_url = os.getenv("OTEL_AWS_SERVICE_EVENTS_GIT_REPO_URL", "")
         if git_repo_url:
             resource_attrs["vcs.repository.url.full"] = git_repo_url
-        # Add platform attributes from OTel Resource detectors
+        # Add platform attributes from OTel Resource detectors. Includes the k8s/ECS/EC2
+        # inputs the environment resolver needs (cluster, namespace, ECS cluster ARN, ASG)
+        # so it can compute aws.local.environment to match the CloudWatch agent.
         if self.config.resource_attributes:
             ra = self.config.resource_attributes
             for attr_name, attr_key in [
@@ -510,10 +513,21 @@ class ServiceEventsInstrumentation:
                 ("host_id", "host.id"),
                 ("host_type", "host.type"),
                 ("container_id", "container.id"),
+                ("k8s_cluster_name", "k8s.cluster.name"),
+                ("k8s_namespace_name", "k8s.namespace.name"),
+                ("aws_ecs_cluster_arn", "aws.ecs.cluster.arn"),
+                ("ec2_autoscaling_group", "ec2.tag.aws:autoscaling:groupName"),
             ]:
                 val = getattr(ra, attr_name, None)
                 if val:
                     resource_attrs[attr_key] = val
+
+        # SDK-only environment resolution: compute aws.local.environment from the
+        # resource attributes using the same precedence as the CloudWatch agent, so
+        # ServiceEvents correlates with Application Signals. An explicit
+        # deployment.environment[.name] (set above) still wins via the resolver.
+        stamp_local_environment(resource_attrs)
+
         resource = Resource.create(resource_attrs)
 
         # Dedicated LoggerProvider for ServiceEvents OTLP signals.

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/utils/ec2_asg_detector.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/utils/ec2_asg_detector.py
@@ -1,0 +1,63 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Resource detector for the EC2 Auto Scaling group name (from IMDS instance tags).
+
+The stock ``AwsEc2ResourceDetector`` only reads the instance-identity document — it does
+NOT fetch instance tags, so the ASG is absent from the SDK Resource. The CloudWatch agent
+reads the ASG from IMDS instance tags
+(``/latest/meta-data/tags/instance/aws:autoscaling:groupName``) to resolve ``ec2:<asg>``.
+This detector closes that gap so the SDK can compute the same ``aws.local.environment``
+the agent would on EC2, without depending on the agent.
+
+Instance metadata tags must be enabled on the instance
+(``InstanceMetadataTags=enabled``); when they aren't (or IMDS is unreachable / not EC2),
+the detector returns an empty Resource and the resolver falls back to ``ec2:default`` —
+matching the agent.
+"""
+import logging
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+from opentelemetry.sdk.resources import Resource, ResourceDetector
+
+logger = logging.getLogger(__name__)
+
+_AWS_METADATA_HOST = "169.254.169.254"
+_TOKEN_PATH = "/latest/api/token"
+_ASG_TAG_PATH = "/latest/meta-data/tags/instance/aws:autoscaling:groupName"
+_TOKEN_HEADER = "X-aws-ec2-metadata-token"
+_TOKEN_TTL_HEADER = "X-aws-ec2-metadata-token-ttl-seconds"
+_TIMEOUT_SECONDS = 1.0
+
+# Resource attribute key the environment resolver reads — matches the agent's.
+EC2_ASG_ATTRIBUTE = "ec2.tag.aws:autoscaling:groupName"
+
+
+def _http_request(method: str, path: str, headers: dict, host: str) -> str:
+    request = Request("http://" + host + path, headers=headers, method=method)
+    with urlopen(request, timeout=_TIMEOUT_SECONDS) as response:  # nosec B310 - link-local IMDS
+        return response.read().decode("utf-8")
+
+
+class Ec2AutoScalingGroupResourceDetector(ResourceDetector):
+    """Detects the EC2 Auto Scaling group via IMDS instance tags.
+
+    Returns an empty Resource (never raises) when not on EC2, when IMDS is unreachable,
+    or when instance metadata tags are not enabled.
+    """
+
+    def __init__(self, host: str = _AWS_METADATA_HOST):
+        # host is overridable for tests; defaults to the EC2 link-local address.
+        self._host = host
+
+    def detect(self) -> Resource:
+        try:
+            token = _http_request("PUT", _TOKEN_PATH, {_TOKEN_TTL_HEADER: "60"}, self._host)
+            asg = _http_request("GET", _ASG_TAG_PATH, {_TOKEN_HEADER: token}, self._host).strip()
+            if asg:
+                return Resource({EC2_ASG_ATTRIBUTE: asg})
+        except (URLError, OSError, ValueError) as exception:
+            # Not on EC2, IMDS unreachable, or instance tags not enabled — all expected,
+            # non-fatal. The resolver falls back to ec2:default, matching the agent.
+            logger.debug("Ec2AutoScalingGroupResourceDetector: ASG not available via IMDS: %s", exception)
+        return Resource.get_empty()

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/utils/environment_resolver.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/utils/environment_resolver.py
@@ -1,0 +1,94 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Resolve ``aws.local.environment`` from OTel Resource attributes.
+
+Mirrors the CloudWatch agent's awsapplicationsignals resolver precedence so the SDK can compute
+the same environment value the agent would, with no dependency on the agent process:
+
+    1. Explicit deployment.environment[.name] -> use as-is
+    2. EKS / K8s -> "eks:<cluster>/<namespace>" or "k8s:<cluster>/<namespace>"
+    3. ECS -> "ecs:<cluster>" (cluster name from aws.ecs.cluster.arn)
+    4. EC2 (cloud.platform == aws_ec2) -> "ec2:<asg>" when an ASG is known, else "ec2:default"
+    5. Otherwise (non-AWS / undetected host) -> "generic:default"
+
+The EC2 branch is gated on the platform actually being EC2, mirroring the CloudWatch agent,
+whose environment branches only run for EC2 (Platform == ModeEC2) or Kubernetes. On a
+non-AWS / non-K8s host the CloudWatch agent runs its "generic" resolver (Mode == onPremise)
+and emits "generic:default" -- it never leaves Environment empty -- so the SDK matches by
+returning "generic:default" rather than empty. (Verified live: blocking IMDS makes the agent
+fall to the generic resolver / "generic:default".)
+
+Scope is the LOCAL environment only (aws.local.environment); remote-environment
+correlation is out of scope (it depends on the agent's cluster-wide pod watcher).
+"""
+from typing import Callable, Dict, Mapping, Optional
+
+AWS_LOCAL_ENVIRONMENT_KEY = "aws.local.environment"
+
+
+def resolve_local_environment(
+    attributes: Mapping[str, object], asg_supplier: Optional[Callable[[], str]] = None
+) -> str:
+    """Resolve aws.local.environment from the given resource attributes.
+
+    asg_supplier, when provided, supplies the EC2 Auto Scaling group name and is invoked
+    ONLY if the resolver reaches the EC2 branch (so EKS/ECS/explicit-env never trigger an
+    IMDS lookup). It is the fallback for callers whose resource does not already carry
+    ``ec2.tag.aws:autoscaling:groupName`` (e.g. Dynamic Instrumentation reading the global
+    resource, which intentionally omits the ASG tag).
+    """
+
+    def _str(key: str) -> str:
+        value = attributes.get(key)
+        if value is None:
+            return ""
+        text = str(value).strip()
+        return text
+
+    # 1. Explicit deployment.environment[.name] wins outright.
+    explicit_env = _str("deployment.environment.name") or _str("deployment.environment")
+    if explicit_env:
+        return explicit_env
+
+    # 2. Kubernetes (EKS / K8s): "<prefix>:<cluster>/<namespace>".
+    k8s_cluster = _str("k8s.cluster.name")
+    namespace = _str("k8s.namespace.name")
+    cloud_platform = _str("cloud.platform")
+    if k8s_cluster:
+        ns = namespace or "UnknownNamespace"
+        prefix = "eks" if cloud_platform == "aws_eks" else "k8s"
+        return f"{prefix}:{k8s_cluster}/{ns}"
+
+    # 3. ECS: "ecs:<cluster>" — cluster name is the last segment of the ECS cluster ARN.
+    ecs_cluster_arn = _str("aws.ecs.cluster.arn")
+    if ecs_cluster_arn:
+        ecs_cluster = ecs_cluster_arn.rsplit("/", maxsplit=1)[-1]
+        if ecs_cluster:
+            return f"ecs:{ecs_cluster}"
+
+    # 4. EC2: only when the host is actually EC2 (matches the agent's Platform == ModeEC2
+    #    gate). Signals that the host is EC2: cloud.platform=aws_ec2, host.id (EC2 instance
+    #    id from the OTel EC2 detector), or the ASG tag (an IMDS-only EC2 signal). Accept any
+    #    so we still resolve ec2:* when cloud.platform wasn't populated.
+    asg = _str("ec2.tag.aws:autoscaling:groupName")
+    if not asg and asg_supplier is not None:
+        asg = (asg_supplier() or "").strip()
+    is_ec2 = cloud_platform == "aws_ec2" or bool(_str("host.id")) or bool(asg)
+    if is_ec2:
+        return f"ec2:{asg}" if asg else "ec2:default"
+
+    # 5. Non-AWS / undetected host: the CloudWatch agent runs its "generic" resolver here and
+    #    emits "generic:default" (never empty), so mirror that instead of omitting the key.
+    return "generic:default"
+
+
+def stamp_local_environment(attrs: Dict[str, str]) -> None:
+    """Stamp aws.local.environment onto a mutable attribute dict (idempotent).
+
+    The resolver always yields a non-empty value (a platform scope, an explicit env, or the
+    "generic:default" fallback), matching the CloudWatch agent, which always sets Environment."""
+    if attrs.get(AWS_LOCAL_ENVIRONMENT_KEY):
+        return
+    resolved = resolve_local_environment(attrs)
+    if resolved:
+        attrs[AWS_LOCAL_ENVIRONMENT_KEY] = resolved

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/utils/environment_resolver.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/utils/environment_resolver.py
@@ -25,6 +25,10 @@ from typing import Callable, Dict, Mapping, Optional
 
 AWS_LOCAL_ENVIRONMENT_KEY = "aws.local.environment"
 
+# Attributes that indicate the resource has real platform context (i.e. detection has populated),
+# used to distinguish a genuine fallback from a still-populating resource.
+_PLATFORM_CONTEXT_KEYS = ("cloud.platform", "k8s.cluster.name", "aws.ecs.cluster.arn", "host.id")
+
 
 def resolve_local_environment(
     attributes: Mapping[str, object], asg_supplier: Optional[Callable[[], str]] = None
@@ -80,6 +84,17 @@ def resolve_local_environment(
     # 5. Non-AWS / undetected host: the CloudWatch agent runs its "generic" resolver here and
     #    emits "generic:default" (never empty), so mirror that instead of omitting the key.
     return "generic:default"
+
+
+def has_platform_context(attributes: Mapping[str, object]) -> bool:
+    """Return True if the attributes carry enough platform context for a fallback value to be real.
+
+    ``ec2:default`` and ``generic:default`` are also what a half-populated resource momentarily
+    yields before detectors settle, so callers that cache the resolved value use this to avoid
+    caching a fallback prematurely. A specific value (eks:/k8s:/ecs:/ec2:<asg>/explicit env) is
+    always safe to cache.
+    """
+    return any(attributes.get(key) for key in _PLATFORM_CONTEXT_KEYS)
 
 
 def stamp_local_environment(attrs: Dict[str, str]) -> None:

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_debugger_client.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/debugger/test_debugger_client.py
@@ -227,6 +227,69 @@ class TestFetchConfigurationByType(unittest.TestCase):
         self.assertEqual(result["LatestConfigurations"], [])
 
 
+class TestEnvironmentResolution(unittest.TestCase):
+    """The DI client's `environment` property computes the full aws.local.environment
+    from the OTel Resource using the same precedence as the CloudWatch agent, so the DI
+    request's Environment lookup key matches Application Signals (SDK-only resolution).
+    """
+
+    def _client_with_attributes(self, attributes):
+        client = DebuggerClient(
+            probe_poll_interval=60,
+            breakpoint_poll_interval=30,
+            service_name="my-service",
+            api_url="http://localhost:2000",
+        )
+        provider = mock.MagicMock()
+        provider.resource.attributes = attributes
+        return client, provider
+
+    def _resolve(self, attributes):
+        client, provider = self._client_with_attributes(attributes)
+        with mock.patch.object(dc_module.trace, "get_tracer_provider", return_value=provider):
+            return client.environment
+
+    def test_explicit_environment(self):
+        self.assertEqual("prod", self._resolve({"deployment.environment.name": "prod"}))
+
+    def test_eks_cluster_namespace(self):
+        env = self._resolve(
+            {
+                "cloud.platform": "aws_eks",
+                "k8s.cluster.name": "my-cluster",
+                "k8s.namespace.name": "default",
+            }
+        )
+        self.assertEqual("eks:my-cluster/default", env)
+
+    def test_ecs_cluster(self):
+        env = self._resolve(
+            {
+                "cloud.platform": "aws_ecs",
+                "aws.ecs.cluster.arn": "arn:aws:ecs:us-west-2:123456789012:cluster/my-ecs",
+            }
+        )
+        self.assertEqual("ecs:my-ecs", env)
+
+    def test_ec2_with_asg(self):
+        env = self._resolve({"cloud.platform": "aws_ec2", "ec2.tag.aws:autoscaling:groupName": "my-asg"})
+        self.assertEqual("ec2:my-asg", env)
+
+    def test_ec2_default_is_cached_with_platform_context(self):
+        client, provider = self._client_with_attributes({"cloud.platform": "aws_ec2"})
+        with mock.patch.object(dc_module.trace, "get_tracer_provider", return_value=provider):
+            self.assertEqual("ec2:default", client.environment)
+            # Platform context present -> ec2:default is a real answer and is cached.
+            self.assertEqual("ec2:default", client._cached_environment)
+
+    def test_empty_resource_returns_unknown_and_does_not_cache(self):
+        client, provider = self._client_with_attributes({})
+        with mock.patch.object(dc_module.trace, "get_tracer_provider", return_value=provider):
+            self.assertEqual("UnknownEnvironment", client.environment)
+            # No platform context yet -> don't cache, allow retry once the Resource fills in.
+            self.assertIsNone(client._cached_environment)
+
+
 class TestConfigurationPollerLogic(unittest.TestCase):
     def setUp(self):
         self.client = _make_client()

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/utils/test_ec2_asg_detector.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/utils/test_ec2_asg_detector.py
@@ -1,0 +1,89 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the EC2 Auto Scaling group resource detector.
+
+The custom detector fetches aws:autoscaling:groupName from IMDS instance tags (the
+stock AwsEc2ResourceDetector does not), so the SDK resource carries the same ASG the
+CloudWatch agent uses to resolve ec2:<asg>. A local HTTP server stands in for IMDS.
+"""
+
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from unittest import TestCase
+
+from amazon.opentelemetry.distro.serviceevents.utils.ec2_asg_detector import (
+    EC2_ASG_ATTRIBUTE,
+    Ec2AutoScalingGroupResourceDetector,
+)
+
+_TOKEN = "fake-token"
+_ASG_PATH = "/latest/meta-data/tags/instance/aws:autoscaling:groupName"
+_TOKEN_PATH = "/latest/api/token"
+
+
+def _make_handler(asg_status: int, asg_body: str, captured: dict):
+    class _Handler(BaseHTTPRequestHandler):
+        def log_message(self, *args):  # silence test server logging
+            pass
+
+        def do_PUT(self):  # noqa: N802 - http.server API
+            if self.path == _TOKEN_PATH:
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(_TOKEN.encode("utf-8"))
+            else:
+                self.send_response(404)
+                self.end_headers()
+
+        def do_GET(self):  # noqa: N802 - http.server API
+            if self.path == _ASG_PATH:
+                captured["token"] = self.headers.get("X-aws-ec2-metadata-token")
+                self.send_response(asg_status)
+                self.end_headers()
+                if asg_status == 200:
+                    self.wfile.write(asg_body.encode("utf-8"))
+            else:
+                self.send_response(404)
+                self.end_headers()
+
+    return _Handler
+
+
+class TestEc2AutoScalingGroupResourceDetector(TestCase):
+    def _detect_with_server(self, asg_status: int, asg_body: str):
+        captured = {}
+        server = HTTPServer(("127.0.0.1", 0), _make_handler(asg_status, asg_body, captured))
+        thread = threading.Thread(target=server.serve_forever)
+        thread.daemon = True
+        thread.start()
+        try:
+            host = f"127.0.0.1:{server.server_address[1]}"
+            resource = Ec2AutoScalingGroupResourceDetector(host=host).detect()
+            return resource, captured
+        finally:
+            server.shutdown()
+            thread.join()
+
+    def test_fetches_asg_from_imds_tags(self):
+        resource, captured = self._detect_with_server(200, "my-asg")
+        self.assertEqual(resource.attributes.get(EC2_ASG_ATTRIBUTE), "my-asg")
+        # The token from the PUT must be forwarded on the tag GET.
+        self.assertEqual(captured.get("token"), _TOKEN)
+
+    def test_trims_whitespace_from_asg_value(self):
+        resource, _ = self._detect_with_server(200, "  my-asg\n")
+        self.assertEqual(resource.attributes.get(EC2_ASG_ATTRIBUTE), "my-asg")
+
+    def test_empty_resource_when_tags_disabled(self):
+        # 404 on the tag path mimics instance metadata tags not being enabled.
+        resource, _ = self._detect_with_server(404, "")
+        self.assertNotIn(EC2_ASG_ATTRIBUTE, resource.attributes)
+
+    def test_empty_resource_when_asg_value_blank(self):
+        resource, _ = self._detect_with_server(200, "   ")
+        self.assertNotIn(EC2_ASG_ATTRIBUTE, resource.attributes)
+
+    def test_empty_resource_when_not_on_ec2(self):
+        # Point at a closed port — connection refused, mimicking "not on EC2".
+        resource = Ec2AutoScalingGroupResourceDetector(host="127.0.0.1:1").detect()
+        self.assertNotIn(EC2_ASG_ATTRIBUTE, resource.attributes)

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/utils/test_environment_resolver.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/utils/test_environment_resolver.py
@@ -1,0 +1,176 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest import TestCase
+
+from amazon.opentelemetry.distro.serviceevents.utils.environment_resolver import (
+    AWS_LOCAL_ENVIRONMENT_KEY,
+    resolve_local_environment,
+    stamp_local_environment,
+)
+
+
+class TestResolveLocalEnvironment(TestCase):
+    """The SDK-side resolver must produce the SAME aws.local.environment the CloudWatch
+    agent's awsapplicationsignals resolver produces, from the same OTel resource attributes.
+    Precedence: explicit deployment.environment[.name] -> eks/k8s cluster/namespace ->
+    ecs:<cluster> -> ec2:<asg> -> ec2:default.
+    """
+
+    def test_explicit_environment_name_wins(self):
+        self.assertEqual(
+            resolve_local_environment(
+                {
+                    "deployment.environment.name": "my-env",
+                    "k8s.cluster.name": "c",
+                    "k8s.namespace.name": "ns",
+                    "cloud.platform": "aws_eks",
+                    "ec2.tag.aws:autoscaling:groupName": "asg",
+                }
+            ),
+            "my-env",
+        )
+
+    def test_legacy_deployment_environment_honored(self):
+        self.assertEqual(
+            resolve_local_environment({"deployment.environment": "legacy-env"}),
+            "legacy-env",
+        )
+
+    def test_environment_name_preferred_over_legacy(self):
+        self.assertEqual(
+            resolve_local_environment({"deployment.environment.name": "new", "deployment.environment": "legacy"}),
+            "new",
+        )
+
+    def test_eks_cluster_namespace(self):
+        self.assertEqual(
+            resolve_local_environment(
+                {
+                    "cloud.platform": "aws_eks",
+                    "k8s.cluster.name": "my-cluster",
+                    "k8s.namespace.name": "default",
+                }
+            ),
+            "eks:my-cluster/default",
+        )
+
+    def test_eks_missing_namespace_falls_back_to_unknown(self):
+        self.assertEqual(
+            resolve_local_environment({"cloud.platform": "aws_eks", "k8s.cluster.name": "my-cluster"}),
+            "eks:my-cluster/UnknownNamespace",
+        )
+
+    def test_non_eks_kubernetes_uses_k8s_prefix(self):
+        self.assertEqual(
+            resolve_local_environment({"k8s.cluster.name": "c", "k8s.namespace.name": "team-a"}),
+            "k8s:c/team-a",
+        )
+
+    def test_ecs_cluster_from_arn(self):
+        self.assertEqual(
+            resolve_local_environment(
+                {
+                    "cloud.platform": "aws_ecs",
+                    "aws.ecs.cluster.arn": "arn:aws:ecs:us-west-2:123456789012:cluster/my-ecs-cluster",
+                }
+            ),
+            "ecs:my-ecs-cluster",
+        )
+
+    def test_explicit_environment_wins_over_ecs(self):
+        self.assertEqual(
+            resolve_local_environment(
+                {
+                    "deployment.environment.name": "prod",
+                    "cloud.platform": "aws_ecs",
+                    "aws.ecs.cluster.arn": "arn:aws:ecs:us-west-2:123456789012:cluster/my-ecs-cluster",
+                }
+            ),
+            "prod",
+        )
+
+    def test_ec2_with_asg(self):
+        self.assertEqual(
+            resolve_local_environment({"ec2.tag.aws:autoscaling:groupName": "my-asg"}),
+            "ec2:my-asg",
+        )
+
+    def test_ec2_without_asg_defaults(self):
+        self.assertEqual(resolve_local_environment({"cloud.platform": "aws_ec2"}), "ec2:default")
+
+    def test_empty_attributes_non_aws_returns_generic_default(self):
+        # No platform signal (non-AWS / undetected host): the agent runs its "generic" resolver
+        # and emits "generic:default", so the SDK matches that rather than claiming ec2:default.
+        self.assertEqual(resolve_local_environment({}), "generic:default")
+
+    def test_non_aws_host_with_only_service_name_returns_generic_default(self):
+        self.assertEqual(resolve_local_environment({"service.name": "svc", "host.name": "my-vm"}), "generic:default")
+
+    def test_ec2_default_when_host_id_present(self):
+        # host.id (EC2 instance id from the OTel EC2 detector) marks the host as EC2.
+        self.assertEqual(resolve_local_environment({"cloud.platform": "aws_ec2", "host.id": "i-0abc"}), "ec2:default")
+
+    def test_kubernetes_precedes_ecs_and_ec2(self):
+        # When both k8s and ec2 ASG are present (unusual), Kubernetes wins, matching the agent.
+        self.assertEqual(
+            resolve_local_environment(
+                {
+                    "k8s.cluster.name": "c",
+                    "k8s.namespace.name": "ns",
+                    "ec2.tag.aws:autoscaling:groupName": "asg",
+                }
+            ),
+            "k8s:c/ns",
+        )
+
+    def test_whitespace_only_values_ignored(self):
+        # Blank/whitespace explicit env must not win; falls through to platform scope.
+        self.assertEqual(
+            resolve_local_environment(
+                {
+                    "deployment.environment.name": "   ",
+                    "cloud.platform": "aws_eks",
+                    "k8s.cluster.name": "my-cluster",
+                    "k8s.namespace.name": "default",
+                }
+            ),
+            "eks:my-cluster/default",
+        )
+
+    def test_ecs_arn_without_slash_uses_whole_value(self):
+        # No slash -> the whole value is the last segment; still non-empty, so "ecs:<value>".
+        self.assertEqual(
+            resolve_local_environment({"cloud.platform": "aws_ecs", "aws.ecs.cluster.arn": "bogus"}),
+            "ecs:bogus",
+        )
+
+    def test_ecs_empty_arn_falls_through_to_generic_default(self):
+        # A trailing-slash ARN yields an empty cluster name; with cloud.platform=aws_ecs (not
+        # aws_ec2) and no EC2 signal, the resolver falls through to "generic:default" (not
+        # ec2:default), matching the agent's generic resolver.
+        self.assertEqual(
+            resolve_local_environment({"cloud.platform": "aws_ecs", "aws.ecs.cluster.arn": "arn:.../cluster/"}),
+            "generic:default",
+        )
+
+
+class TestStampLocalEnvironment(TestCase):
+    def test_stamps_resolved_value(self):
+        attrs = {
+            "cloud.platform": "aws_eks",
+            "k8s.cluster.name": "my-cluster",
+            "k8s.namespace.name": "default",
+        }
+        stamp_local_environment(attrs)
+        self.assertEqual(attrs[AWS_LOCAL_ENVIRONMENT_KEY], "eks:my-cluster/default")
+
+    def test_does_not_overwrite_existing(self):
+        attrs = {
+            AWS_LOCAL_ENVIRONMENT_KEY: "already-set",
+            "cloud.platform": "aws_eks",
+            "k8s.cluster.name": "c",
+            "k8s.namespace.name": "ns",
+        }
+        stamp_local_environment(attrs)
+        self.assertEqual(attrs[AWS_LOCAL_ENVIRONMENT_KEY], "already-set")


### PR DESCRIPTION
ServiceEvents and Dynamic Instrumentation need aws.local.environment, which today only the CloudWatch agent sets. This adds an SDK-side resolver that computes the same value the agent's awsapplicationsignals resolver would, from the OTel Resource, with no dependency on the agent process:

- environment_resolver: mirror the agent's precedence — explicit deployment.environment[.name] -> eks/k8s:<cluster>/<namespace> -> ecs:<cluster> -> ec2:<asg>/ec2:default -> generic:default (never empty, matching the agent's generic resolver off-platform).
- Ec2AutoScalingGroupResourceDetector: read the ASG name from IMDS instance tags (the stock OTel EC2 detector omits it). Scoped to a dedicated ServiceEvents/DI resource so the ASG tag stays OFF the global/AppSignals resource — the SDK's value flows only through ServiceEvents/DI, leaving AppSignals' environment untouched.
- DI (_debugger_client): resolve aws.local.environment from the ServiceEvents resource for the instrumentation-config lookup key, with a lazy memoized IMDS ASG fallback.

Unit tests included for the resolver, detector, and DI client.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

