### PR TITLE
feat(genai): capture user input and agent output on invoke_agent spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- feat(genai): capture user input and agent output on invoke_agent spans
+  ([#815](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/815))
 - refactor(serviceevents): make the endpoint span processor framework-agnostic
 - fix(serviceevents): gate incident trace correlation on the SAMPLED flag and harden incident dedup/rate-limiting
 - fix(genai): serialize list-valued message content into typed parts so multimodal/reasoning content is no longer stringified to a Python repr in `gen_ai.input/output.messages` across langchain, llama_index, and crewai

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/crewai/_event_handler.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/crewai/_event_handler.py
@@ -260,12 +260,24 @@ class OpenTelemetryEventHandler:
                 if getattr(llm, "stop", None):
                     attributes[GEN_AI_REQUEST_STOP_SEQUENCES] = llm.stop
 
+        task_prompt = getattr(event, "task_prompt", None)
+        if task_prompt:
+            attributes[GEN_AI_INPUT_MESSAGES] = serialize_to_json_string(
+                [{"role": "user", "parts": content_to_parts(task_prompt)}]
+            )
+
         self._start_span(span_name, event.event_id, attributes, event.parent_event_id)
 
     def _on_agent_completed(
         self, source: "BaseAgent", event: "AgentExecutionCompletedEvent"  # pylint: disable=unused-argument
     ) -> None:
-        self._end_span(event.started_event_id)
+        attrs: Dict[str, Any] = {}
+        output = getattr(event, "output", None)
+        if output:
+            attrs[GEN_AI_OUTPUT_MESSAGES] = serialize_to_json_string(
+                [{"role": "assistant", "parts": content_to_parts(output), "finish_reason": "stop"}]
+            )
+        self._end_span(event.started_event_id, attrs)
 
     def _on_agent_failed(
         self, source: "BaseAgent", event: "AgentExecutionErrorEvent"

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/langchain/callback_handler.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/langchain/callback_handler.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Optional
 from uuid import UUID
 
 from langchain_core.callbacks import BaseCallbackHandler
+from langchain_core.messages import convert_to_messages
 
 from amazon.opentelemetry.distro.instrumentation.common.instrumentation_utils import (
     PROVIDER_MAP,
@@ -184,8 +185,12 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
         if response.generations:
             output_messages = self._format_lc_llm_output(response.generations)
             self._set_span_attribute(span, GEN_AI_OUTPUT_MESSAGES, serialize_to_json_string(output_messages))
-            finish_reasons = self._extract_finish_reasons(response.generations)
-            if finish_reasons is not None:
+            finish_reasons = [
+                self._extract_finish_reason(getattr(gen, "message", None), getattr(gen, "generation_info", None))
+                for batch in response.generations
+                for gen in batch
+            ]
+            if finish_reasons:
                 self._set_span_attribute(span, GEN_AI_RESPONSE_FINISH_REASONS, finish_reasons)
 
         self._set_span_attribute(span, GEN_AI_RESPONSE_MODEL, model)
@@ -199,7 +204,7 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
         self._handle_error(error, run_id, **kwargs)
 
     @skip_instrumentation_if_suppressed
-    def on_chain_start(
+    def on_chain_start(  # pylint: disable=too-many-locals
         self,
         serialized: dict[str, Any],
         inputs: dict[str, Any],
@@ -236,10 +241,28 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
         self._set_span_attribute(span, GEN_AI_PROVIDER_NAME, provider)
         if is_agent_chain:
             self._set_span_attribute(span, GEN_AI_OPERATION_NAME, GenAiOperationNameValues.INVOKE_AGENT.value)
+            payload = inputs.get("messages") or inputs.get("input") if isinstance(inputs, dict) else None
+            if payload:
+                _, conversation = self._format_lc_messages(
+                    [convert_to_messages([payload] if isinstance(payload, str) else payload)]
+                )
+                if conversation:
+                    self._set_span_attribute(span, GEN_AI_INPUT_MESSAGES, serialize_to_json_string(conversation))
         self._set_span_attribute(span, GEN_AI_AGENT_NAME, agent_name)
 
     @skip_instrumentation_if_suppressed
     def on_chain_end(self, outputs: dict[str, Any], *, run_id: UUID, **kwargs: Any) -> None:
+        entry = self._safe_get_span(run_id)
+        if entry:
+            span, _ = entry
+            payload = outputs.get("messages") or outputs.get("output") if isinstance(outputs, dict) else None
+            if payload and GenAiOperationNameValues.INVOKE_AGENT.value in getattr(span, "name", ""):
+                messages = convert_to_messages([payload] if isinstance(payload, str) else payload)
+                _, conversation = self._format_lc_messages([messages])
+                if conversation:
+                    finish_reason = self._extract_finish_reason(messages[-1]) if messages else "stop"
+                    message = {**conversation[-1], "role": "assistant", "finish_reason": finish_reason}
+                    self._set_span_attribute(span, GEN_AI_OUTPUT_MESSAGES, serialize_to_json_string([message]))
         self._end_span(run_id)
 
     def on_chain_error(self, error: BaseException, *, run_id: UUID, **kwargs: Any) -> None:
@@ -391,14 +414,6 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
         #       {"type": "text", "content": "The weather is sunny."},
         #       {"type": "tool_call", "id": "call_abc", "name": "get_weather", "arguments": {...}},
         #   ], "finish_reason": "stop"}]
-        finish_reason_map: dict[str, str] = {
-            "stop": "stop",
-            "end_turn": "stop",
-            "tool_use": "tool_call",
-            "max_tokens": "length",
-            "length": "length",
-            "content_filter": "content_filter",
-        }
         formatted: list[dict] = []
         for batch in generations:
             for gen in batch:
@@ -407,10 +422,9 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
                     _, msgs = OpenTelemetryCallbackHandler._format_lc_messages([[msg]])
                     # https://github.com/langchain-ai/langchain/blob/7a4cc3ec321c4ded3681b57456df365936139333/libs/core/langchain_core/outputs/chat_generation.py#L28
                     # https://github.com/langchain-ai/langchain/blob/7a4cc3ec321c4ded3681b57456df365936139333/libs/core/langchain_core/messages/ai.py#L195
-                    raw_reason: str | None = (getattr(gen, "generation_info", None) or {}).get("finish_reason") or (
-                        getattr(msg, "response_metadata", None) or {}
-                    ).get("stop_reason")
-                    finish_reason: str = finish_reason_map.get(raw_reason, raw_reason) if raw_reason else "stop"
+                    finish_reason: str = OpenTelemetryCallbackHandler._extract_finish_reason(
+                        msg, getattr(gen, "generation_info", None)
+                    )
                     for msg_dict in msgs:
                         msg_dict["finish_reason"] = finish_reason
                     formatted.extend(msgs)
@@ -551,16 +565,21 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
         return kwargs.get("name")
 
     @staticmethod
-    def _extract_finish_reasons(generations: list) -> list[str] | None:
-        reasons: list[str] = []
-        for batch in generations:
-            for gen in batch:
-                raw = (getattr(gen, "generation_info", None) or {}).get("finish_reason")
-                if not raw and (msg := getattr(gen, "message", None)):
-                    raw = (getattr(msg, "response_metadata", None) or {}).get("stop_reason")
-                if raw:
-                    reasons.append(raw)
-        return reasons or None
+    def _extract_finish_reason(message: Any, generation_info: Optional[dict] = None) -> str:
+        finish_reason_map: dict[str, str] = {
+            "stop": "stop",
+            "end_turn": "stop",
+            "tool_use": "tool_call",
+            "tool_calls": "tool_call",
+            "max_tokens": "length",
+            "length": "length",
+            "content_filter": "content_filter",
+        }
+        metadata: dict = getattr(message, "response_metadata", None) or {}
+        raw: str | None = (
+            (generation_info or {}).get("finish_reason") or metadata.get("finish_reason") or metadata.get("stop_reason")
+        )
+        return finish_reason_map.get(raw, raw) if raw else "stop"
 
     @staticmethod
     def _extract_llm_model_id(kwargs: dict, serialized: Optional[dict] = None) -> Optional[str]:

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/crewai/test_crewai_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/crewai/test_crewai_instrumentor.py
@@ -630,6 +630,20 @@ class TestCrewAIInstrumentor(TestCase):
             },
         )
 
+        agent_input_messages = json.loads(agent_span.attributes[GEN_AI_INPUT_MESSAGES])
+        validate_otel_genai_schema(agent_input_messages, "gen-ai-input-messages")
+        self.assertTrue(
+            any(
+                part.get("type") == "text" and "Greet the user warmly." in part.get("content", "")
+                for message in agent_input_messages
+                if message.get("role") == "user"
+                for part in message.get("parts", [])
+            )
+        )
+        agent_output_messages = json.loads(agent_span.attributes[GEN_AI_OUTPUT_MESSAGES])
+        validate_otel_genai_schema(agent_output_messages, "gen-ai-output-messages")
+        self.assertTrue(any(message.get("role") == "assistant" for message in agent_output_messages))
+
         self._assert_span_attributes(
             spans,
             "execute_tool get_greeting",

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/langchain/test_langchain_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/langchain/test_langchain_instrumentor.py
@@ -227,6 +227,20 @@ class TestLangChainInstrumentor(TestCase):
         agent_span = agent_spans[0]
         self.assertEqual(agent_span.attributes[GEN_AI_OPERATION_NAME], GenAiOperationNameValues.INVOKE_AGENT.value)
 
+        input_messages = json.loads(agent_span.attributes[GEN_AI_INPUT_MESSAGES])
+        validate_otel_genai_schema(input_messages, "gen-ai-input-messages")
+        self.assertTrue(
+            any(
+                part.get("type") == "text" and "What's the weather in Paris?" in part.get("content", "")
+                for message in input_messages
+                if message.get("role") == "user"
+                for part in message.get("parts", [])
+            )
+        )
+        output_messages = json.loads(agent_span.attributes[GEN_AI_OUTPUT_MESSAGES])
+        validate_otel_genai_schema(output_messages, "gen-ai-output-messages")
+        self.assertTrue(any(message.get("role") == "assistant" for message in output_messages))
+
     def test_tool_span_has_all_attributes(self):
         def add_numbers(a: int, b: int) -> int:
             return a + b

--- a/contract-tests/tests/test/amazon/gen_ai/gen_ai_test_base.py
+++ b/contract-tests/tests/test/amazon/gen_ai/gen_ai_test_base.py
@@ -28,6 +28,8 @@ from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (  # 
     GenAiOperationNameValues,
 )
 
+AGENT_FINAL_OUTPUT = "Hello, World!"
+
 
 class GenAITestBase(ContractTestBase):
 
@@ -71,6 +73,18 @@ class GenAITestBase(ContractTestBase):
             self.assertIn(GEN_AI_AGENT_NAME, attrs)
             self.assertIn(GEN_AI_PROVIDER_NAME, attrs)
             self.assertIn(GEN_AI_REQUEST_MODEL, attrs)
+
+            self.assertIn(GEN_AI_INPUT_MESSAGES, attrs)
+            self.assertIn(GEN_AI_OUTPUT_MESSAGES, attrs)
+            input_messages = json.loads(attrs[GEN_AI_INPUT_MESSAGES].string_value)
+            output_messages = json.loads(attrs[GEN_AI_OUTPUT_MESSAGES].string_value)
+
+            user_inputs = self._text_parts(input_messages, "user")
+            self.assertTrue(user_inputs, "Expected the first user input on the invoke_agent span")
+
+            agent_outputs = self._text_parts(output_messages, "assistant")
+            self.assertTrue(agent_outputs, "Expected the final agent output on the invoke_agent span")
+            self.assertEqual(agent_outputs[-1], AGENT_FINAL_OUTPUT)
 
     def _assert_execute_tool_spans(self, execute_tool_spans: list, expected_count: int = 1):
         self.assertGreaterEqual(len(execute_tool_spans), expected_count)

--- a/contract-tests/tests/test/amazon/gen_ai/openai_agents/openai_agents_test.py
+++ b/contract-tests/tests/test/amazon/gen_ai/openai_agents/openai_agents_test.py
@@ -1,18 +1,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-import json
-
 from typing_extensions import override
 
-from amazon.gen_ai.gen_ai_test_base import (
-    GEN_AI_INPUT_MESSAGES,
-    GEN_AI_OUTPUT_MESSAGES,
-    GEN_AI_REQUEST_TEMPERATURE,
-    GenAITestBase,
-)
-
-_EXPECTED_USER_INPUTS = {"Greet the world", "Format: Hello World"}
-_EXPECTED_FINAL_OUTPUT = "Hello, World!"
+from amazon.gen_ai.gen_ai_test_base import GEN_AI_REQUEST_TEMPERATURE, GenAITestBase
 
 
 class OpenAIAgentsTest(GenAITestBase):
@@ -28,22 +18,6 @@ class OpenAIAgentsTest(GenAITestBase):
         self.do_test_requests(
             "openai_agents/multiagent", "GET", 200, 0, 0, expected_agent_count=2, expected_tool_count=2
         )
-
-    @override
-    def _assert_invoke_agent_spans(self, invoke_agent_spans: list, expected_count: int = 1):
-        super()._assert_invoke_agent_spans(invoke_agent_spans, expected_count)
-        for span in invoke_agent_spans:
-            attrs = self._get_attributes_dict(span.attributes)
-            input_messages = json.loads(attrs[GEN_AI_INPUT_MESSAGES].string_value)
-            output_messages = json.loads(attrs[GEN_AI_OUTPUT_MESSAGES].string_value)
-
-            user_inputs = self._text_parts(input_messages, "user")
-            self.assertTrue(user_inputs)
-            self.assertIn(user_inputs[0], _EXPECTED_USER_INPUTS)
-
-            agent_outputs = self._text_parts(output_messages, "assistant")
-            self.assertTrue(agent_outputs)
-            self.assertEqual(agent_outputs[-1], _EXPECTED_FINAL_OUTPUT)
 
     @override
     def _assert_chat_spans(self, chat_spans: list, expected_count: int = 1):


### PR DESCRIPTION
Adds `gen_ai.input.messages` / `gen_ai.output.messages` to invoke_agent spans for the CrewAI and LangChain instrumentors so agent spans carry the user input and final agent output. Extends the gen AI contract tests to assert this content across crewai, langchain, and openai_agents.