### PR TITLE
feat(genai): extract gen_ai.tool.call.arguments/result as LLO content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- feat(genai): extract gen_ai.tool.call.arguments/result as LLO content
+  ([#816](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/816))
 - feat(genai): capture user input and agent output on invoke_agent spans
   ([#815](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/815))
 - refactor(serviceevents): make the endpoint span processor framework-agnostic

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/llo_handler.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/llo_handler.py
@@ -180,6 +180,18 @@ LLO_PATTERNS: Dict[str, PatternConfig] = {
         "role": ROLE_SYSTEM,
         "source": "prompt",
     },
+    # OTel GenAI tool call content (execute_tool spans)
+    # Reference: https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/
+    "gen_ai.tool.call.arguments": {
+        "type": PatternType.DIRECT,
+        "role": ROLE_TOOL,
+        "source": "input",
+    },
+    "gen_ai.tool.call.result": {
+        "type": PatternType.DIRECT,
+        "role": ROLE_TOOL,
+        "source": "output",
+    },
 }
 
 

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/llo_handler/test_llo_handler_collection.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/llo_handler/test_llo_handler_collection.py
@@ -46,6 +46,32 @@ class TestLLOHandlerCollection(LLOHandlerTestBase):
         self.assertEqual(message["role"], "user")
         self.assertEqual(message["source"], "prompt")
 
+    def test_collect_gen_ai_tool_call_content(self):
+        """
+        Verify gen_ai.tool.call.arguments/result are collected with role=tool and routed by source
+        (arguments -> input, result -> output).
+        """
+        attributes = {
+            "gen_ai.tool.call.arguments": '{"city": "Paris"}',
+            "gen_ai.tool.call.result": "72F and sunny",
+        }
+
+        span = self._create_mock_span(attributes)
+
+        messages = self.llo_handler._collect_all_llo_messages(span, attributes)
+
+        by_content = {msg["content"]: msg for msg in messages}
+        self.assertIn('{"city": "Paris"}', by_content)
+        self.assertIn("72F and sunny", by_content)
+
+        arguments_message = by_content['{"city": "Paris"}']
+        self.assertEqual(arguments_message["role"], "tool")
+        self.assertEqual(arguments_message["source"], "input")
+
+        result_message = by_content["72F and sunny"]
+        self.assertEqual(result_message["role"], "tool")
+        self.assertEqual(result_message["source"], "output")
+
     def test_collect_gen_ai_prompt_messages_assistant_role(self):
         """
         Verify indexed prompt messages with assistant role are collected with correct content, role, and source.

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/llo_handler/test_llo_handler_patterns.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/llo_handler/test_llo_handler_patterns.py
@@ -124,6 +124,8 @@ class TestLLOHandlerPatterns(LLOHandlerTestBase):
         self.assertTrue(self.llo_handler._is_llo_attribute("gen_ai.input.messages"))
         self.assertTrue(self.llo_handler._is_llo_attribute("gen_ai.output.messages"))
         self.assertTrue(self.llo_handler._is_llo_attribute("gen_ai.system_instructions"))
+        self.assertTrue(self.llo_handler._is_llo_attribute("gen_ai.tool.call.arguments"))
+        self.assertTrue(self.llo_handler._is_llo_attribute("gen_ai.tool.call.result"))
 
     def test_is_llo_attribute_otel_genai_patterns_no_match(self):
         """


### PR DESCRIPTION
Adds the OTel GenAI tool-call content attributes (`gen_ai.tool.call.arguments`, `gen_ai.tool.call.result`) to the LLO pattern registry so the handler extracts them into Gen AI events (role=tool, arguments→input / result→output) and strips them off execute_tool spans. Tool metadata (name/type/description/call.id) stays on the span.