### PR TITLE
fix(genai): match OTel util-genai tool value and bytes serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- fix(genai): serialize tool call arguments/results and blob bytes to match OTel util-genai (primitives kept native, bytes base64-encoded)
+  ([#817](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/817))
 - feat(genai): capture user input and agent output on invoke_agent spans
   ([#815](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/815))
 - refactor(serviceevents): make the endpoint span processor framework-agnostic

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/common/instrumentation_utils.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/common/instrumentation_utils.py
@@ -4,9 +4,10 @@
 import json
 import logging
 import threading
+from base64 import b64encode
 from contextvars import Token
 from functools import wraps
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional, Union
 
 from wrapt import wrap_function_wrapper
 
@@ -80,8 +81,17 @@ class DictWithLock:
             return len(self._data)
 
 
+class _GenAIJSONEncoder(json.JSONEncoder):
+    # Mirrors the OTel util-genai encoder: bytes are emitted as base64 text rather than dropped.
+    # https://github.com/open-telemetry/opentelemetry-python-genai/blob/main/util/opentelemetry-util-genai/src/opentelemetry/util/genai/utils.py
+    def default(self, o: Any) -> Any:
+        if isinstance(o, bytes):
+            return b64encode(o).decode()
+        return super().default(o)
+
+
 def serialize_to_json_string(value: Any, max_depth: int = 10) -> str:
-    json_safe_types = (str, int, float, bool, dict, list, tuple, type(None))
+    json_safe_types = (str, int, float, bool, bytes, dict, list, tuple, type(None))
 
     def _sanitize(obj: Any, depth: int) -> Any:
         if depth <= 0:
@@ -93,9 +103,23 @@ def serialize_to_json_string(value: Any, max_depth: int = 10) -> str:
         return obj
 
     try:
-        return json.dumps(_sanitize(value, max_depth))
+        return json.dumps(_sanitize(value, max_depth), cls=_GenAIJSONEncoder)
     except (TypeError, ValueError):
         return str(value)
+
+
+def to_tool_attribute_value(value: Any) -> Union[str, int, float, bool, bytes, None]:
+    """Serialize a tool call argument/result for a span attribute the way OTel util-genai does.
+
+    Primitives (bool/str/bytes/int/float) are kept native; everything else is JSON-serialized,
+    falling back to str() when it is not JSON-serializable. Mirrors _any_value_to_attribute_value:
+    https://github.com/open-telemetry/opentelemetry-python-genai/blob/main/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_tool_invocation.py
+    """
+    if value is None:
+        return None
+    if isinstance(value, (bool, str, bytes, int, float)):
+        return value
+    return serialize_to_json_string(value)
 
 
 def content_to_parts(content: Any) -> list:  # pylint: disable=too-many-branches

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/common/instrumentation_utils.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/common/instrumentation_utils.py
@@ -81,15 +81,6 @@ class DictWithLock:
             return len(self._data)
 
 
-class _GenAIJSONEncoder(json.JSONEncoder):
-    # Mirrors the OTel util-genai encoder: bytes are emitted as base64 text rather than dropped.
-    # https://github.com/open-telemetry/opentelemetry-python-genai/blob/main/util/opentelemetry-util-genai/src/opentelemetry/util/genai/utils.py
-    def default(self, o: Any) -> Any:
-        if isinstance(o, bytes):
-            return b64encode(o).decode()
-        return super().default(o)
-
-
 def serialize_to_json_string(value: Any, max_depth: int = 10) -> str:
     json_safe_types = (str, int, float, bool, bytes, dict, list, tuple, type(None))
 
@@ -103,18 +94,12 @@ def serialize_to_json_string(value: Any, max_depth: int = 10) -> str:
         return obj
 
     try:
-        return json.dumps(_sanitize(value, max_depth), cls=_GenAIJSONEncoder)
+        return json.dumps(_sanitize(value, max_depth), default=lambda o: b64encode(o).decode())
     except (TypeError, ValueError):
         return str(value)
 
 
 def to_tool_attribute_value(value: Any) -> Union[str, int, float, bool, bytes, None]:
-    """Serialize a tool call argument/result for a span attribute the way OTel util-genai does.
-
-    Primitives (bool/str/bytes/int/float) are kept native; everything else is JSON-serialized,
-    falling back to str() when it is not JSON-serializable. Mirrors _any_value_to_attribute_value:
-    https://github.com/open-telemetry/opentelemetry-python-genai/blob/main/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_tool_invocation.py
-    """
     if value is None:
         return None
     if isinstance(value, (bool, str, bytes, int, float)):

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/crewai/_event_handler.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/crewai/_event_handler.py
@@ -13,6 +13,7 @@ from amazon.opentelemetry.distro.instrumentation.common.instrumentation_utils im
     content_to_parts,
     serialize_to_json_string,
     skip_instrumentation_if_suppressed,
+    to_tool_attribute_value,
 )
 from opentelemetry import context, trace
 from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
@@ -312,7 +313,7 @@ class OpenTelemetryEventHandler:
                 attributes[GEN_AI_REQUEST_MODEL] = model
 
         if event.tool_args:
-            attributes[GEN_AI_TOOL_CALL_ARGUMENTS] = serialize_to_json_string(event.tool_args)
+            attributes[GEN_AI_TOOL_CALL_ARGUMENTS] = to_tool_attribute_value(event.tool_args)
 
         self._start_span(span_name, event.event_id, attributes, event.parent_event_id)
 
@@ -322,7 +323,7 @@ class OpenTelemetryEventHandler:
         attrs: Dict[str, Any] = {}
         output = getattr(event, "output", None)
         if output is not None:
-            attrs[GEN_AI_TOOL_CALL_RESULT] = serialize_to_json_string(output)
+            attrs[GEN_AI_TOOL_CALL_RESULT] = to_tool_attribute_value(output)
         self._end_span(event.started_event_id, attrs)
 
     def _on_llm_start(self, source: "LLM", event: "LLMCallStartedEvent") -> None:

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/langchain/callback_handler.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/langchain/callback_handler.py
@@ -17,6 +17,7 @@ from amazon.opentelemetry.distro.instrumentation.common.instrumentation_utils im
     content_to_parts,
     serialize_to_json_string,
     skip_instrumentation_if_suppressed,
+    to_tool_attribute_value,
     try_detach,
 )
 from opentelemetry import context
@@ -300,7 +301,7 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
         self._set_span_attribute(span, GEN_AI_TOOL_DESCRIPTION, description)
         self._set_span_attribute(span, GEN_AI_TOOL_CALL_ID, tool_call_id)
         self._set_span_attribute(
-            span, GEN_AI_TOOL_CALL_ARGUMENTS, serialize_to_json_string(inputs if inputs is not None else input_str)
+            span, GEN_AI_TOOL_CALL_ARGUMENTS, to_tool_attribute_value(inputs if inputs is not None else input_str)
         )
 
     @skip_instrumentation_if_suppressed
@@ -310,7 +311,7 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
         if not entry:
             return
         span, _ = entry
-        self._set_span_attribute(span, GEN_AI_TOOL_CALL_RESULT, serialize_to_json_string(output))
+        self._set_span_attribute(span, GEN_AI_TOOL_CALL_RESULT, to_tool_attribute_value(output))
         self._end_span(run_id)
 
     def on_tool_error(self, error: BaseException, *, run_id: UUID, **kwargs: Any) -> None:

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/llama_index/_handler.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/llama_index/_handler.py
@@ -20,7 +20,10 @@ from llama_index.core.tools import BaseTool
 from llama_index.core.tools.types import ToolOutput
 from pydantic import PrivateAttr
 
-from amazon.opentelemetry.distro.instrumentation.common.instrumentation_utils import skip_instrumentation_if_suppressed
+from amazon.opentelemetry.distro.instrumentation.common.instrumentation_utils import (
+    skip_instrumentation_if_suppressed,
+    to_tool_attribute_value,
+)
 from opentelemetry import context as context_api
 from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
     GEN_AI_AGENT_NAME,
@@ -209,7 +212,7 @@ class _SpanHandler(BaseSpanHandler[_Span], extra="allow"):
             return None
 
         if isinstance(result, ToolOutput):
-            span._attributes[GEN_AI_TOOL_CALL_RESULT] = result.content
+            span._attributes[GEN_AI_TOOL_CALL_RESULT] = to_tool_attribute_value(result.content)
         span.end()
         return span
 

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/llama_index/_span.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/llama_index/_span.py
@@ -54,6 +54,7 @@ from amazon.opentelemetry.distro.instrumentation.common.instrumentation_utils im
     OPERATION_INVOKE_WORKFLOW,
     content_to_parts,
     serialize_to_json_string,
+    to_tool_attribute_value,
     try_detach,
 )
 from opentelemetry import context as context_api
@@ -346,7 +347,7 @@ class _Span(BaseSpan):
         if isinstance(instance, (BaseTool, FunctionTool)):
             kwargs = bound_args.kwargs
             if kwargs:
-                self[GEN_AI_TOOL_CALL_ARGUMENTS] = serialize_to_json_string(kwargs)
+                self[GEN_AI_TOOL_CALL_ARGUMENTS] = to_tool_attribute_value(kwargs)
 
     @singledispatchmethod
     def process_instance(self, instance: Any) -> None: ...  # noqa: E704  # pylint: disable=no-self-use

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/mcp/_wrappers.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/mcp/_wrappers.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Coroutine, Dict, Optional, Tuple
 from urllib.parse import urlparse
 
 from amazon.opentelemetry.distro._utils import is_agent_observability_enabled
-from amazon.opentelemetry.distro.instrumentation.common.instrumentation_utils import serialize_to_json_string
+from amazon.opentelemetry.distro.instrumentation.common.instrumentation_utils import to_tool_attribute_value
 from opentelemetry import context, trace
 from opentelemetry.instrumentation.utils import suppress_http_instrumentation
 from opentelemetry.propagate import get_global_textmap
@@ -118,7 +118,7 @@ class McpWrapper:
             if message.params.arguments:
                 span.set_attribute(
                     GEN_AI_TOOL_CALL_ARGUMENTS,
-                    serialize_to_json_string(message.params.arguments),
+                    to_tool_attribute_value(message.params.arguments),
                 )
 
         elif isinstance(message, types.GetPromptRequest):
@@ -156,7 +156,7 @@ class McpWrapper:
 
         if isinstance(message, types.CallToolRequest) and result is not None:
             try:
-                span.set_attribute(GEN_AI_TOOL_CALL_RESULT, serialize_to_json_string(result))
+                span.set_attribute(GEN_AI_TOOL_CALL_RESULT, to_tool_attribute_value(result))
                 if hasattr(result, "isError") and result.isError:
                     span.set_attribute(ERROR_TYPE, "tool_error")
                     span.set_status(Status(StatusCode.ERROR))

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/common/test_instrumentation_utils.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/common/test_instrumentation_utils.py
@@ -1,9 +1,11 @@
 import json
+from base64 import b64encode
 from unittest import TestCase
 
 from amazon.opentelemetry.distro.instrumentation.common.instrumentation_utils import (
     serialize_to_json_string,
     skip_instrumentation_if_suppressed,
+    to_tool_attribute_value,
     try_detach,
     try_unwrap,
     try_wrap,
@@ -51,6 +53,36 @@ class TestInstrumentationUtils(TestCase):
         obj = object()
         result = serialize_to_json_string(obj)
         self.assertEqual(result, str(obj))
+
+    def test_serialize_bytes_base64_encoded(self):
+        # bytes are base64-encoded rather than dropped (matches OTel util-genai encoder).
+        raw = b"\x89PNG\r\n"
+        expected = b64encode(raw).decode()
+        self.assertEqual(serialize_to_json_string(raw), json.dumps(expected))
+
+    def test_serialize_bytes_nested_in_structure(self):
+        raw = b"\x89PNG"
+        result = serialize_to_json_string({"parts": [{"type": "blob", "content": raw}]})
+        self.assertIn(b64encode(raw).decode(), result)
+        self.assertIn('"content"', result)
+
+    def test_to_tool_attribute_value_primitives_kept_native(self):
+        self.assertEqual(to_tool_attribute_value("Hello, World!"), "Hello, World!")
+        self.assertEqual(to_tool_attribute_value(42), 42)
+        self.assertEqual(to_tool_attribute_value(3.14), 3.14)
+        self.assertEqual(to_tool_attribute_value(True), True)
+        self.assertEqual(to_tool_attribute_value(b"raw"), b"raw")
+
+    def test_to_tool_attribute_value_none(self):
+        self.assertIsNone(to_tool_attribute_value(None))
+
+    def test_to_tool_attribute_value_dict_and_list_json_encoded(self):
+        self.assertEqual(to_tool_attribute_value({"city": "Paris"}), '{"city": "Paris"}')
+        self.assertEqual(to_tool_attribute_value([1, 2, 3]), "[1, 2, 3]")
+
+    def test_to_tool_attribute_value_unserializable_falls_back_to_str(self):
+        obj = object()
+        self.assertEqual(to_tool_attribute_value(obj), str(obj))
 
     def test_try_unwrap_not_wrapped(self):
         try_unwrap(json, "dumps")

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/common/test_instrumentation_utils.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/common/test_instrumentation_utils.py
@@ -55,7 +55,6 @@ class TestInstrumentationUtils(TestCase):
         self.assertEqual(result, str(obj))
 
     def test_serialize_bytes_base64_encoded(self):
-        # bytes are base64-encoded rather than dropped (matches OTel util-genai encoder).
         raw = b"\x89PNG\r\n"
         expected = b64encode(raw).decode()
         self.assertEqual(serialize_to_json_string(raw), json.dumps(expected))
@@ -65,6 +64,11 @@ class TestInstrumentationUtils(TestCase):
         result = serialize_to_json_string({"parts": [{"type": "blob", "content": raw}]})
         self.assertIn(b64encode(raw).decode(), result)
         self.assertIn('"content"', result)
+
+    def test_to_tool_attribute_value_dict_with_bytes_base64_encoded(self):
+        raw = b"\x89PNG\r\n"
+        result = to_tool_attribute_value({"parts": [{"type": "blob", "content": raw}]})
+        self.assertEqual(json.loads(result), {"parts": [{"type": "blob", "content": b64encode(raw).decode()}]})
 
     def test_to_tool_attribute_value_primitives_kept_native(self):
         self.assertEqual(to_tool_attribute_value("Hello, World!"), "Hello, World!")

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/crewai/test_crewai_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/crewai/test_crewai_instrumentor.py
@@ -657,7 +657,7 @@ class TestCrewAIInstrumentor(TestCase):
         self.assertIsNotNone(tool_span.attributes)
         self.assertIn("get_greeting", tool_span.attributes[GEN_AI_TOOL_DESCRIPTION])
         self.assertIn(GEN_AI_TOOL_CALL_ARGUMENTS, tool_span.attributes)
-        self.assertEqual('"Hello, World!"', tool_span.attributes[GEN_AI_TOOL_CALL_RESULT])
+        self.assertEqual("Hello, World!", tool_span.attributes[GEN_AI_TOOL_CALL_RESULT])
 
         self._assert_span_parent(agent_span, crew_span)
         self._assert_span_parent(tool_span, agent_span)

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/langchain/test_langchain_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/langchain/test_langchain_instrumentor.py
@@ -258,7 +258,7 @@ class TestLangChainInstrumentor(TestCase):
         self.assertEqual(span.attributes[GEN_AI_TOOL_DESCRIPTION], "Add two numbers")
         self.assertEqual(span.attributes[GEN_AI_TOOL_TYPE], "function")
         self.assertIsNotNone(span.attributes.get(GEN_AI_TOOL_CALL_ARGUMENTS))
-        self.assertEqual(span.attributes[GEN_AI_TOOL_CALL_RESULT], str(result))
+        self.assertEqual(span.attributes[GEN_AI_TOOL_CALL_RESULT], result)
 
     def test_internal_chains_suppressed(self):
         chain_factories = [


### PR DESCRIPTION
Aligns tool call argument/result serialization with OTel util-genai's `_any_value_to_attribute_value`: primitives (bool/str/bytes/int/float) are kept as native span attribute values instead of being JSON-quoted, while dicts/lists are JSON-serialized. Also fixes `serialize_to_json_string` to base64-encode bytes (matching util-genai's JSON encoder) instead of silently dropping them, so multimodal blob content survives. Applied via a shared `to_tool_attribute_value` helper across crewai, langchain, llama_index, and mcp.