### PR TITLE
refactor(serviceevents): remove direct-to-CloudWatch SigV4 OTLP log export path

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/serviceevents_instrumentation.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/serviceevents_instrumentation.py
@@ -27,70 +27,18 @@ _serviceevents_instance: Optional["ServiceEventsInstrumentation"] = None
 
 
 def _build_log_otlp_exporter(logs_endpoint: str, headers: dict, compression):
-    """Build an OTLP log exporter for the configured logs endpoint.
+    """Build a plain OTLP log exporter for the configured logs endpoint.
 
-    When the endpoint matches the CloudWatch Logs OTLP pattern
-    (``https://logs.{region}.amazonaws.com/v1/logs``), wrap the upstream
-    ``OTLPLogExporter`` with ADOT's ``OTLPAwsLogRecordExporter`` so
-    requests are SigV4-signed. The ``x-aws-log-group`` / ``x-aws-log-stream``
-    headers travel with every batch (already populated in ``headers``).
-    Otherwise return a plain upstream ``OTLPLogExporter`` pointing at the
-    collector-proxied endpoint.
-
-    Mirrors the Java SDK's behavior in ``ServiceEventsInstrumentation.java:557``.
-    Imports are deferred so this module stays importable without OTel SDK
-    and botocore at import time.
-
-    The SigV4 path requires ``botocore`` (an optional distro dependency). When
-    it is unavailable we fall back to a plain, unsigned ``OTLPLogExporter``
-    against the same endpoint rather than raising — telemetry must never crash
-    the host app, and a usable exporter keeps ``initialize()`` from tripping its
-    broad-except and silently disabling all of ServiceEvents.
+    ServiceEvents exports through the collector-proxied OTLP endpoint (e.g.
+    ``http://localhost:4316/v1/logs``); the ``x-aws-log-group`` / ``x-aws-log-stream``
+    headers travel with every batch (already populated in ``headers``). The import is
+    deferred so this module stays importable without the OTel SDK at import time.
     """
-    # Module-local imports to preserve the file's lazy-import posture (defer OTel SDK / botocore).
+    # Module-local import to preserve the file's lazy-import posture (defer OTel SDK).
     # pylint: disable=import-outside-toplevel
-    import re
-
-    from amazon.opentelemetry.distro.aws_opentelemetry_configurator import AWS_LOGS_OTLP_ENDPOINT_PATTERN
     from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
 
-    is_cw_endpoint = bool(re.match(AWS_LOGS_OTLP_ENDPOINT_PATTERN, (logs_endpoint or "").lower()))
-    if not is_cw_endpoint:
-        return OTLPLogExporter(endpoint=logs_endpoint, headers=headers, compression=compression)
-
-    # Direct-to-CloudWatch (SigV4) path. Use the shared botocore-session helper
-    # the rest of the distro relies on (see aws_opentelemetry_configurator
-    # ._create_aws_otlp_exporter). It returns a ``botocore.session.Session`` —
-    # the type OTLPAwsLogRecordExporter is annotated for — or ``None`` when
-    # botocore is not installed.
-    # pylint: disable=import-outside-toplevel
-    from amazon.opentelemetry.distro._utils import get_aws_session
-
-    session = get_aws_session()
-    if not session:
-        # botocore unavailable: cannot SigV4-sign. Degrade to a plain OTLP
-        # exporter against the same endpoint instead of returning None (the
-        # caller does not handle None) or raising into the host app.
-        logger.warning(
-            "ServiceEvents direct-to-CloudWatch SigV4 export requires botocore, which is not installed; "
-            "falling back to an unsigned OTLP log exporter for %s",
-            logs_endpoint,
-        )
-        return OTLPLogExporter(endpoint=logs_endpoint, headers=headers, compression=compression)
-
-    from amazon.opentelemetry.distro.exporter.otlp.aws.logs.otlp_aws_log_record_exporter import OTLPAwsLogRecordExporter
-
-    region = (logs_endpoint or "").lower().split(".")[1]
-    # OTLPAwsLogRecordExporter hardcodes compression=Gzip (matches ADOT design —
-    # CloudWatch OTLP ingestion assumes gzip for LLO batching). The `compression`
-    # argument is honored only on the collector-proxied branch above.
-    _ = compression  # suppress unused-kwarg lint on this branch
-    return OTLPAwsLogRecordExporter(
-        aws_region=region,
-        session=session,
-        endpoint=logs_endpoint,
-        headers=headers,
-    )
+    return OTLPLogExporter(endpoint=logs_endpoint, headers=headers, compression=compression)
 
 
 def get_serviceevents_instrumentation(

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/test_direct_cw_otlp.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/test_direct_cw_otlp.py
@@ -6,14 +6,16 @@ Kept in a separate file to avoid interactions with the stateful
 ServiceEventsInstrumentation lifecycle tests (which initialize real collectors).
 """
 
-import sys
-import types
 from unittest import TestCase
-from unittest.mock import MagicMock, patch
 
 
 class TestBuildLogOtlpExporter(TestCase):
-    """Verify _build_log_otlp_exporter routes correctly based on endpoint shape."""
+    """Verify _build_log_otlp_exporter builds a plain OTLPLogExporter for every endpoint.
+
+    ServiceEvents exports through the collector-proxied OTLP endpoint; the direct-to-CloudWatch
+    SigV4 path (``OTLPAwsLogRecordExporter``) was removed, so every endpoint yields the plain
+    upstream exporter.
+    """
 
     def test_collector_proxied_endpoint_returns_plain_exporter(self):
         from amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation import _build_log_otlp_exporter
@@ -25,8 +27,6 @@ class TestBuildLogOtlpExporter(TestCase):
             {"x-aws-log-group": "g", "x-aws-log-stream": "s"},
             Compression.NoCompression,
         )
-        # OTLPAwsLogRecordExporter subclasses OTLPLogExporter, so use `type is`
-        # rather than `isinstance` to distinguish the plain upstream class.
         self.assertIs(type(exp), OTLPLogExporter)
 
     def test_arbitrary_https_endpoint_returns_plain_exporter(self):
@@ -41,91 +41,15 @@ class TestBuildLogOtlpExporter(TestCase):
         )
         self.assertIs(type(exp), OTLPLogExporter)
 
-    def test_cloudwatch_endpoint_routes_to_sigv4_exporter(self):
-        """The CloudWatch endpoint builds the SigV4 exporter via a botocore session.
-
-        Regression guard for the boto3-vs-botocore finding: the SigV4 path must
-        obtain its session from ``get_aws_session()`` (which returns a
-        ``botocore.session.Session``) and must NOT ``import boto3``. ``boto3`` is
-        not a declared distro dependency, so we assert it stays absent from
-        ``sys.modules`` throughout — if the production code reintroduced
-        ``import boto3`` this would fail in a botocore-only environment.
-
-        The AWS log-record exporter module is stubbed via ``sys.modules`` rather
-        than ``mock.patch("dotted.path")``. That matters because ``mock.patch``
-        resolves its target by dotted-name lookup, which walks
-        ``sys.meta_path`` finders. Other tests in this suite
-        (``TestServiceEventsModes``) install the ServiceEvents AST import hook
-        and never uninstall it, so accumulated finders turn that lookup into
-        pathological recursion. Pre-populating ``sys.modules`` sidesteps
-        meta_path entirely — the lazy ``import`` inside the function under test
-        resolves directly from the cache. ``get_aws_session`` is patched at its
-        source module so the function picks up the stub on its lazy import.
-        """
-        from amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation import _build_log_otlp_exporter
-        from opentelemetry.exporter.otlp.proto.http import Compression
-
-        stub_session = MagicMock(name="stub-botocore-session")
-
-        exporter_module_path = "amazon.opentelemetry.distro.exporter.otlp.aws.logs.otlp_aws_log_record_exporter"
-        stub_exporter_module = types.ModuleType(exporter_module_path)
-        mock_ctor = MagicMock(name="OTLPAwsLogRecordExporter")
-        stub_exporter_module.OTLPAwsLogRecordExporter = mock_ctor
-
-        # Guard: boto3 must never be imported by the SigV4 path.
-        had_boto3 = "boto3" in sys.modules
-        if had_boto3:
-            self.addCleanup(lambda saved=sys.modules["boto3"]: sys.modules.__setitem__("boto3", saved))
-            del sys.modules["boto3"]
-
-        with patch.dict(sys.modules, {exporter_module_path: stub_exporter_module}), patch(
-            "amazon.opentelemetry.distro._utils.get_aws_session", return_value=stub_session
-        ):
-            _build_log_otlp_exporter(
-                "https://logs.us-east-2.amazonaws.com/v1/logs",
-                {"x-aws-log-group": "/my/group", "x-aws-log-stream": "my-stream"},
-                Compression.Gzip,
-            )
-
-        # boto3 must not have been imported as a side effect of the SigV4 build.
-        self.assertNotIn("boto3", sys.modules)
-
-        mock_ctor.assert_called_once()
-        kwargs = mock_ctor.call_args.kwargs
-        # The exporter receives the botocore session from get_aws_session(),
-        # not a boto3.Session().
-        self.assertIs(kwargs["session"], stub_session)
-        # Region was extracted from the endpoint hostname.
-        self.assertEqual(kwargs["aws_region"], "us-east-2")
-        self.assertEqual(kwargs["endpoint"], "https://logs.us-east-2.amazonaws.com/v1/logs")
-        self.assertEqual(
-            kwargs["headers"],
-            {"x-aws-log-group": "/my/group", "x-aws-log-stream": "my-stream"},
-        )
-
-    def test_cloudwatch_endpoint_without_botocore_falls_back_to_plain_exporter(self):
-        """When botocore is unavailable the CloudWatch path must degrade gracefully.
-
-        ``get_aws_session()`` returns ``None`` when botocore is not installed.
-        The SigV4 path must then fall back to a plain (unsigned) ``OTLPLogExporter``
-        against the same endpoint — never return ``None`` (the caller does not
-        handle it) and never raise into the host app. This is the core
-        regression: previously the path did ``import boto3`` and an
-        ``ImportError`` was swallowed by ``initialize()``'s broad-except,
-        silently disabling all ServiceEvents telemetry.
-        """
+    def test_cloudwatch_shaped_endpoint_returns_plain_exporter(self):
+        """A ``logs.{region}.amazonaws.com`` endpoint no longer routes to a SigV4 exporter."""
         from amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation import _build_log_otlp_exporter
         from opentelemetry.exporter.otlp.proto.http import Compression
         from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
 
-        with patch("amazon.opentelemetry.distro._utils.get_aws_session", return_value=None):
-            exp = _build_log_otlp_exporter(
-                "https://logs.us-east-2.amazonaws.com/v1/logs",
-                {"x-aws-log-group": "/my/group", "x-aws-log-stream": "my-stream"},
-                Compression.Gzip,
-            )
-
-        # Falls back to the plain upstream exporter (not the SigV4 subclass),
-        # and crucially is not None.
-        self.assertIsNotNone(exp)
+        exp = _build_log_otlp_exporter(
+            "https://logs.us-east-2.amazonaws.com/v1/logs",
+            {"x-aws-log-group": "/my/group", "x-aws-log-stream": "my-stream"},
+            Compression.Gzip,
+        )
         self.assertIs(type(exp), OTLPLogExporter)

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/test_serviceevents_instrumentation.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/test_serviceevents_instrumentation.py
@@ -3,9 +3,7 @@
 
 import logging
 import os
-import sys
 import tempfile
-import types
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
@@ -774,44 +772,6 @@ class TestServiceEventsShutdownEdgeCases(TestCase):
 
         # Should not raise.
         inst.shutdown()
-
-
-class TestBuildLogOtlpExporterSigV4(TestCase):
-    """Cover the CloudWatch SigV4 branch of _build_log_otlp_exporter.
-
-    Kept in this file (in addition to test_direct_cw_otlp.py) so the module's
-    isolated coverage reaches the SigV4 path. boto3 and the AWS exporter module
-    are stubbed via sys.modules so the lazy imports resolve from cache, avoiding
-    AWS credential resolution and meta_path finder recursion.
-    """
-
-    def test_cloudwatch_endpoint_routes_to_sigv4_exporter(self):
-        """A CloudWatch logs endpoint is wrapped with the SigV4 AWS exporter."""
-        from amazon.opentelemetry.distro.serviceevents.serviceevents_instrumentation import _build_log_otlp_exporter
-        from opentelemetry.exporter.otlp.proto.http import Compression
-
-        stub_boto3 = types.ModuleType("boto3")
-        stub_boto3.Session = MagicMock(return_value=MagicMock(name="stub-boto3-session"))
-
-        exporter_module_path = "amazon.opentelemetry.distro.exporter.otlp.aws.logs.otlp_aws_log_record_exporter"
-        stub_exporter_module = types.ModuleType(exporter_module_path)
-        mock_ctor = MagicMock(name="OTLPAwsLogRecordExporter")
-        stub_exporter_module.OTLPAwsLogRecordExporter = mock_ctor
-
-        with patch.dict(
-            sys.modules,
-            {"boto3": stub_boto3, exporter_module_path: stub_exporter_module},
-        ):
-            _build_log_otlp_exporter(
-                "https://logs.us-east-2.amazonaws.com/v1/logs",
-                {"x-aws-log-group": "/my/group", "x-aws-log-stream": "my-stream"},
-                Compression.Gzip,
-            )
-
-        mock_ctor.assert_called_once()
-        kwargs = mock_ctor.call_args.kwargs
-        self.assertEqual(kwargs["aws_region"], "us-east-2")
-        self.assertEqual(kwargs["endpoint"], "https://logs.us-east-2.amazonaws.com/v1/logs")
 
 
 class TestEndpointMeasurementMode(TestCase):


### PR DESCRIPTION
Removes the direct-to-CloudWatch SigV4 OTLP log export path from ServiceEvents. This path was originally added for testing and is no longer needed — ServiceEvents exports through the collector-proxied OTLP endpoint.