### PR TITLE
add skeleton for aws-opentelemetry-extensions package

### DIFF
--- a/aws-opentelemetry-extensions/.coveragerc
+++ b/aws-opentelemetry-extensions/.coveragerc
@@ -1,0 +1,22 @@
+[run]
+parallel = true
+
+[paths]
+source =
+    aws-opentelemetry-components/src/amazon
+    .tox/3.*/lib/python*/site-packages/amazon
+    */site-packages/amazon
+
+[report]
+include_namespace_packages = true
+fail_under = 70.00
+precision = 2
+omit =
+    */tests/*
+    */pip-build-env-*/*
+exclude_lines =
+    pragma: no cover
+    @unittest.skip
+    @unittest.skipIf
+    @pytest.mark.skip
+    @pytest.mark.skipif

--- a/aws-opentelemetry-extensions/README.rst
+++ b/aws-opentelemetry-extensions/README.rst
@@ -1,0 +1,24 @@
+AWS OpenTelemetry Components
+============================
+
+Installation
+------------
+
+::
+
+    pip install aws-opentelemetry-components
+
+
+Shared components for the AWS Distro for OpenTelemetry Python, packaged as an
+independent distribution. Consumed by ``aws-opentelemetry-distro``.
+
+ServiceEvents
+    Deep observability instrumentation including function-level invocation metrics,
+    HTTP endpoint performance tracking, and automated error investigation on failures
+    (``amazon.opentelemetry.serviceevents``).
+
+References
+----------
+
+* `OpenTelemetry Project <https://opentelemetry.io/>`_
+* `AWS Distro for OpenTelemetry <https://aws-otel.github.io/>`_

--- a/aws-opentelemetry-extensions/pyproject.toml
+++ b/aws-opentelemetry-extensions/pyproject.toml
@@ -1,0 +1,47 @@
+[build-system]
+requires = ["hatchling==1.25.0"]
+build-backend = "hatchling.build"
+
+[project]
+name = "aws-opentelemetry-components"
+dynamic = ["version"]
+description = "AWS OpenTelemetry Components (ServiceEvents)"
+readme = "README.rst"
+license = {text = "Apache-2.0"}
+requires-python = ">=3.10"
+authors = [
+  { name = "Amazon Web Services" },
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+]
+
+dependencies = [
+  "opentelemetry-api >= 1.39, < 2.0",
+  "opentelemetry-sdk >= 1.39, < 2.0",
+  "opentelemetry-exporter-otlp-proto-http >= 1.39, < 2.0",
+  "opentelemetry-semantic-conventions >= 0.60b0",
+]
+
+[project.urls]
+Homepage = "https://github.com/aws-observability/aws-otel-python-instrumentation/tree/main/aws-opentelemetry-components"
+
+[tool.hatch.version]
+path = "src/amazon/opentelemetry/serviceevents/version.py"
+
+[tool.hatch.build.targets.sdist]
+include = [
+  "/src",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/amazon"]

--- a/aws-opentelemetry-extensions/src/amazon/opentelemetry/serviceevents/__init__.py
+++ b/aws-opentelemetry-extensions/src/amazon/opentelemetry/serviceevents/__init__.py
@@ -1,0 +1,2 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/aws-opentelemetry-extensions/src/amazon/opentelemetry/serviceevents/version.py
+++ b/aws-opentelemetry-extensions/src/amazon/opentelemetry/serviceevents/version.py
@@ -1,0 +1,4 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+__version__ = "0.18.0.dev0"


### PR DESCRIPTION
**PACKAGE NAME IS SUBJECT TO CHANGE**

Adds the skeleton for a new standalone `aws-opentelemetry-extensions` package as the first step toward migrating ServiceEvents out of `aws-opentelemetry-distro` into its own package.

This PR is scaffolding only — `pyproject.toml`, `README.rst`, `.coveragerc`, `version.py`, and the `amazon.opentelemetry.serviceevents` namespace. No ServiceEvents code is moved yet, and nothing outside the new folder changes. Follow-up PRs will move the code over.