### PR TITLE
fix(crewai): normalize tool description across crewai versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- fix(crewai): normalize tool description across crewai versions
+  ([#821](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/821))
 - fix(crewai): report per-call LLM token usage instead of cumulative total
   ([#806](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/806))
 - fix(genai): serialize tool call arguments/results and blob bytes to match OTel util-genai (primitives kept native, bytes base64-encoded)

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/crewai/_event_handler.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/crewai/_event_handler.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
 
@@ -538,7 +539,7 @@ class OpenTelemetryEventHandler:
         if tool_class:
             desc = getattr(tool_class, "description", None)
             if desc:
-                return desc
+                return OpenTelemetryEventHandler._normalize_tool_description(desc)
         for tools_holder in [source, getattr(source, "agent", None), getattr(event, "agent", None)]:
             tools = getattr(tools_holder, "tools", None) if tools_holder else None
             if not tools:
@@ -547,7 +548,7 @@ class OpenTelemetryEventHandler:
                 if getattr(tool, "name", None) == tool_name:
                     desc = getattr(tool, "description", None)
                     if desc:
-                        return desc
+                        return OpenTelemetryEventHandler._normalize_tool_description(desc)
         return None
 
     @staticmethod
@@ -557,7 +558,7 @@ class OpenTelemetryEventHandler:
             tool_def: Dict[str, Any] = {"type": "function"}
             if name := getattr(tool, "name", None):
                 tool_def["name"] = name
-            if desc := getattr(tool, "description", None):
+            if desc := OpenTelemetryEventHandler._normalize_tool_description(getattr(tool, "description", None)):
                 tool_def["description"] = desc
             args_schema = getattr(tool, "args_schema", None)
             if args_schema is not None:
@@ -567,3 +568,12 @@ class OpenTelemetryEventHandler:
                     pass
             defs.append(tool_def)
         return defs
+
+    @staticmethod
+    def _normalize_tool_description(desc: Optional[str]) -> Optional[str]:
+        # crewai <1.15.3 stored the LLM prompt composite in description; strip it to the authored text.
+        # See crewai 1.15.3 changelog: https://github.com/crewAIInc/crewAI/releases/tag/1.15.3
+        if not desc:
+            return desc
+        match = re.match(r"^Tool Name:.*\nTool Arguments:.*\nTool Description:\s*", desc, re.DOTALL)
+        return desc[match.end() :] if match else desc

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/crewai/test_crewai_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/crewai/test_crewai_instrumentor.py
@@ -661,7 +661,10 @@ class TestCrewAIInstrumentor(TestCase):
         )
         self.assertIsNotNone(tool_span)
         self.assertIsNotNone(tool_span.attributes)
-        self.assertIn("get_greeting", tool_span.attributes[GEN_AI_TOOL_DESCRIPTION])
+        self.assertEqual(
+            "Get a greeting message for the given name.",
+            tool_span.attributes[GEN_AI_TOOL_DESCRIPTION],
+        )
         self.assertIn(GEN_AI_TOOL_CALL_ARGUMENTS, tool_span.attributes)
         self.assertEqual("Hello, World!", tool_span.attributes[GEN_AI_TOOL_CALL_RESULT])
 


### PR DESCRIPTION
## Description

crewai 1.15.3 (PR crewAIInc/crewAI#6508) stopped rewriting `BaseTool.description` into the LLM-facing composite (`Tool Name: ...\nTool Arguments: {...}\nTool Description: <authored>`) and now preserves the authored description, exposing the composite separately via `formatted_description`. The instrumentor copied whichever form crewai stored, so `gen_ai.tool.description` changed shape across versions — and on <1.15.3 it carried the tool name and full args schema already emitted in `gen_ai.tool.name` / `gen_ai.tool.definitions`.

Normalize in the instrumentor to always emit the authored description, stripping the composite prefix with the same anchored-marker shape crewai uses internally (`strip_composite_description_prefix`, added in 1.15.3 and unavailable in the older versions we still support). This also unblocks the scheduled `crewai-latest` instrumentation tests, which will pick up 1.15.3 on the next run.

## Testing

Ran the crewai instrumentor suite against both crewai 1.15.3 and 1.15.2: 23 passed each. Lint clean (black, isort, flake8, pylint 10/10).