### PR TITLE
fix(crewai): use native per-call token usage when crewai provides it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- fix(crewai): use native per-call token usage when crewai provides it
+  ([#822](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/822))
 - fix(crewai): normalize tool description across crewai versions
   ([#821](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/821))
 - fix(crewai): report per-call LLM token usage instead of cumulative total

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/crewai/_event_handler.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/crewai/_event_handler.py
@@ -397,7 +397,17 @@ class OpenTelemetryEventHandler:
         if model_name:
             attrs[GEN_AI_RESPONSE_MODEL] = model_name
 
-        input_tokens, output_tokens = self._resolve_per_call_tokens(source, event)
+        # crewai >=1.13.0 reports per-call usage on the completed event; older versions only expose a
+        # cumulative summary, so diff it against the snapshot taken when the call started.
+        prev_prompt_tokens, prev_completion_tokens = self._event_id_to_token_usage.pop(event.started_event_id) or (0, 0)
+        event_usage = getattr(event, "usage", None)
+        if isinstance(event_usage, dict):
+            input_tokens = event_usage.get("prompt_tokens") or 0
+            output_tokens = event_usage.get("completion_tokens") or 0
+        else:
+            usage: "UsageMetrics" = source.get_token_usage_summary()
+            input_tokens = usage.prompt_tokens - prev_prompt_tokens
+            output_tokens = usage.completion_tokens - prev_completion_tokens
         if input_tokens > 0:
             attrs[GEN_AI_USAGE_INPUT_TOKENS] = input_tokens
         if output_tokens > 0:
@@ -408,16 +418,6 @@ class OpenTelemetryEventHandler:
     def _on_llm_failed(self, source: Any, event: "LLMCallFailedEvent") -> None:  # pylint: disable=unused-argument
         self._event_id_to_token_usage.pop(event.started_event_id)
         self._end_span(event.started_event_id, error=getattr(event, "error", None))
-
-    def _resolve_per_call_tokens(self, source: "LLM", event: "LLMCallCompletedEvent") -> Tuple[int, int]:
-        # crewai >=1.13.0 reports per-call usage on the completed event; older versions only expose a
-        # cumulative summary, so diff it against the snapshot taken when the call started.
-        prev_prompt_tokens, prev_completion_tokens = self._event_id_to_token_usage.pop(event.started_event_id) or (0, 0)
-        usage = getattr(event, "usage", None)
-        if isinstance(usage, dict):
-            return usage.get("prompt_tokens") or 0, usage.get("completion_tokens") or 0
-        summary: "UsageMetrics" = source.get_token_usage_summary()
-        return summary.prompt_tokens - prev_prompt_tokens, summary.completion_tokens - prev_completion_tokens
 
     def _start_span(
         self,

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/crewai/_event_handler.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/crewai/_event_handler.py
@@ -397,10 +397,7 @@ class OpenTelemetryEventHandler:
         if model_name:
             attrs[GEN_AI_RESPONSE_MODEL] = model_name
 
-        usage: "UsageMetrics" = source.get_token_usage_summary()
-        prev_prompt_tokens, prev_completion_tokens = self._event_id_to_token_usage.pop(event.started_event_id) or (0, 0)
-        input_tokens = usage.prompt_tokens - prev_prompt_tokens
-        output_tokens = usage.completion_tokens - prev_completion_tokens
+        input_tokens, output_tokens = self._resolve_per_call_tokens(source, event)
         if input_tokens > 0:
             attrs[GEN_AI_USAGE_INPUT_TOKENS] = input_tokens
         if output_tokens > 0:
@@ -411,6 +408,16 @@ class OpenTelemetryEventHandler:
     def _on_llm_failed(self, source: Any, event: "LLMCallFailedEvent") -> None:  # pylint: disable=unused-argument
         self._event_id_to_token_usage.pop(event.started_event_id)
         self._end_span(event.started_event_id, error=getattr(event, "error", None))
+
+    def _resolve_per_call_tokens(self, source: "LLM", event: "LLMCallCompletedEvent") -> Tuple[int, int]:
+        # crewai >=1.13.0 reports per-call usage on the completed event; older versions only expose a
+        # cumulative summary, so diff it against the snapshot taken when the call started.
+        prev_prompt_tokens, prev_completion_tokens = self._event_id_to_token_usage.pop(event.started_event_id) or (0, 0)
+        usage = getattr(event, "usage", None)
+        if isinstance(usage, dict):
+            return usage.get("prompt_tokens") or 0, usage.get("completion_tokens") or 0
+        summary: "UsageMetrics" = source.get_token_usage_summary()
+        return summary.prompt_tokens - prev_prompt_tokens, summary.completion_tokens - prev_completion_tokens
 
     def _start_span(
         self,

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/crewai/test_crewai_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/crewai/test_crewai_instrumentor.py
@@ -198,6 +198,32 @@ class TestCrewAIInstrumentor(TestCase):
                         if isinstance(value, str):
                             self.assertFalse(value.lstrip().startswith("[{") and "'type'" in value)
 
+    def test_per_call_token_usage_prefers_event_usage(self):
+        if "usage" not in LLMCallCompletedEvent.model_fields:
+            self.skipTest("crewai <1.13.0 does not report per-call usage on LLMCallCompletedEvent")
+
+        llm = LLM(model="openai/gpt-4", is_litellm=True)
+        # get_token_usage_summary would report a cumulative total; the event usage must win.
+        llm.get_token_usage_summary = lambda: MagicMock(prompt_tokens=9999, completion_tokens=8888)
+
+        start_event = LLMCallStartedEvent(call_id="c1", messages=[{"role": "user", "content": "hi"}])
+        crewai_event_bus.emit(llm, start_event)
+        crewai_event_bus.emit(
+            llm,
+            LLMCallCompletedEvent(
+                call_id="c1",
+                response="Hello",
+                call_type=LLMCallType.LLM_CALL,
+                started_event_id=start_event.event_id,
+                usage={"prompt_tokens": 123, "completion_tokens": 45},
+            ),
+        )
+
+        chat_span = self._find_span("chat")
+        self.assertIsNotNone(chat_span)
+        self.assertEqual(chat_span.attributes[GEN_AI_USAGE_INPUT_TOKENS], 123)
+        self.assertEqual(chat_span.attributes[GEN_AI_USAGE_OUTPUT_TOKENS], 45)
+
     def test_crew_kickoff_error_handling(self):
         mock_llm = MagicMock(spec=LLM)
         mock_llm.provider = "openai"


### PR DESCRIPTION
## Description

crewai 1.13.0+ reports real per-call token usage directly on `LLMCallCompletedEvent.usage`. Prefer that when present, and fall back to the existing cumulative-summary snapshot/subtract (added in #806) only on older crewai versions that lack the field. On current crewai the workaround path no longer runs, while correctness is preserved across the supported range (`>=1.10.0,<2`).

## Testing

Added a test asserting the event `usage` dict wins over the cumulative `get_token_usage_summary()`; it skips on crewai <1.13.0 which lacks the field. Ran the crewai instrumentor suite: 1.15.2 → 24 passed; 1.10.0 → 23 passed, 1 skipped; new test passes on 1.15.3/1.15.2. Lint clean (black, isort, flake8, pylint 10/10).