### PR TITLE
feat(genai): capture user input and agent output on llama_index invoke_agent spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- feat(genai): capture user input and agent output on llama_index invoke_agent spans
+  ([#824](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/824))
 - fix(crewai): use native per-call token usage when crewai provides it
   ([#822](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/822))
 - fix(crewai): normalize tool description across crewai versions

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/llama_index/_handler.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/llama_index/_handler.py
@@ -25,11 +25,7 @@ from amazon.opentelemetry.distro.instrumentation.common.instrumentation_utils im
     to_tool_attribute_value,
 )
 from opentelemetry import context as context_api
-from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
-    GEN_AI_AGENT_NAME,
-    GEN_AI_OPERATION_NAME,
-    GenAiOperationNameValues,
-)
+from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import GEN_AI_AGENT_NAME
 from opentelemetry.trace import SpanKind, Tracer, set_span_in_context
 
 from ._span import (  # noqa: F401  # pylint: disable=unused-import
@@ -179,7 +175,6 @@ class _SpanHandler(BaseSpanHandler[_Span], extra="allow"):
 
         agent_setup = self._get_agent_setup(bound_args)
         if agent_setup is not None:
-            span[GEN_AI_OPERATION_NAME] = GenAiOperationNameValues.INVOKE_AGENT.value
             agent_name = getattr(agent_setup, "current_agent_name", None)
             if agent_name:
                 span[GEN_AI_AGENT_NAME] = agent_name
@@ -212,8 +207,8 @@ class _SpanHandler(BaseSpanHandler[_Span], extra="allow"):
             return None
 
         if isinstance(result, ToolOutput):
-            span._attributes[GEN_AI_TOOL_CALL_RESULT] = to_tool_attribute_value(result.content)
-        elif span._attributes.get(GEN_AI_OPERATION_NAME) == GenAiOperationNameValues.INVOKE_AGENT.value:
+            span[GEN_AI_TOOL_CALL_RESULT] = to_tool_attribute_value(result.content)
+        else:
             span.process_agent_output(result)
         span.end()
         return span

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/llama_index/_handler.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/llama_index/_handler.py
@@ -25,7 +25,11 @@ from amazon.opentelemetry.distro.instrumentation.common.instrumentation_utils im
     to_tool_attribute_value,
 )
 from opentelemetry import context as context_api
-from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import GEN_AI_AGENT_NAME
+from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
+    GEN_AI_AGENT_NAME,
+    GEN_AI_OPERATION_NAME,
+    GenAiOperationNameValues,
+)
 from opentelemetry.trace import SpanKind, Tracer, set_span_in_context
 
 from ._span import (  # noqa: F401  # pylint: disable=unused-import
@@ -175,6 +179,7 @@ class _SpanHandler(BaseSpanHandler[_Span], extra="allow"):
 
         agent_setup = self._get_agent_setup(bound_args)
         if agent_setup is not None:
+            span[GEN_AI_OPERATION_NAME] = GenAiOperationNameValues.INVOKE_AGENT.value
             agent_name = getattr(agent_setup, "current_agent_name", None)
             if agent_name:
                 span[GEN_AI_AGENT_NAME] = agent_name
@@ -207,8 +212,8 @@ class _SpanHandler(BaseSpanHandler[_Span], extra="allow"):
             return None
 
         if isinstance(result, ToolOutput):
-            span[GEN_AI_TOOL_CALL_RESULT] = to_tool_attribute_value(result.content)
-        else:
+            span._attributes[GEN_AI_TOOL_CALL_RESULT] = to_tool_attribute_value(result.content)
+        elif span._attributes.get(GEN_AI_OPERATION_NAME) == GenAiOperationNameValues.INVOKE_AGENT.value:
             span.process_agent_output(result)
         span.end()
         return span

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/llama_index/_handler.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/llama_index/_handler.py
@@ -184,6 +184,7 @@ class _SpanHandler(BaseSpanHandler[_Span], extra="allow"):
             if agent_name:
                 span[GEN_AI_AGENT_NAME] = agent_name
                 span._span_name = f"run_agent_step {agent_name}"
+            span.process_agent_setup_input(agent_setup)
         else:
             span.process_instance(instance)
             span.process_input(instance, bound_args)

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/llama_index/_handler.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/llama_index/_handler.py
@@ -213,6 +213,8 @@ class _SpanHandler(BaseSpanHandler[_Span], extra="allow"):
 
         if isinstance(result, ToolOutput):
             span._attributes[GEN_AI_TOOL_CALL_RESULT] = to_tool_attribute_value(result.content)
+        elif span._attributes.get(GEN_AI_OPERATION_NAME) == GenAiOperationNameValues.INVOKE_AGENT.value:
+            span.process_agent_output(result)
         span.end()
         return span
 

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/llama_index/_span.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/llama_index/_span.py
@@ -375,16 +375,7 @@ class _Span(BaseSpan):
             self[GEN_AI_INPUT_MESSAGES] = serialize_to_json_string(conversation)
 
     def process_agent_output(self, result: Any) -> None:
-        """Capture the final agent output on the invoke_agent span.
-
-        Two result shapes reach this method:
-        - StopEvent (single-agent parent run / early-stop): final ChatMessage at
-          result.result.response.
-        - AgentOutput (run_agent_step in an AgentWorkflow): ChatMessage at
-          result.response. Only the FINAL answer turn carries real output; an
-          intermediate turn that requests tools has result.tool_calls populated
-          and must be skipped so tool-call turns are not recorded as the output.
-        """
+        """Capture the final agent output on the invoke_agent span."""
         response = getattr(getattr(result, "result", None), "response", None)
         if response is None:
             if getattr(result, "tool_calls", None):

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/llama_index/_span.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/llama_index/_span.py
@@ -359,11 +359,7 @@ class _Span(BaseSpan):
 
     def process_agent_output(self, result: Any) -> None:
         """Capture the final agent output on the invoke_agent span."""
-        if self._attributes.get(GEN_AI_OPERATION_NAME) != GenAiOperationNameValues.INVOKE_AGENT.value:
-            return
-        response = getattr(result, "response", None)
-        if not isinstance(response, ChatMessage):
-            response = getattr(getattr(result, "result", None), "response", None)
+        response = getattr(getattr(result, "result", None), "response", None)
         if not isinstance(response, ChatMessage):
             return
         _, conversation = _format_messages([response])

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/llama_index/_span.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/llama_index/_span.py
@@ -359,7 +359,11 @@ class _Span(BaseSpan):
 
     def process_agent_output(self, result: Any) -> None:
         """Capture the final agent output on the invoke_agent span."""
-        response = getattr(getattr(result, "result", None), "response", None)
+        if self._attributes.get(GEN_AI_OPERATION_NAME) != GenAiOperationNameValues.INVOKE_AGENT.value:
+            return
+        response = getattr(result, "response", None)
+        if not isinstance(response, ChatMessage):
+            response = getattr(getattr(result, "result", None), "response", None)
         if not isinstance(response, ChatMessage):
             return
         _, conversation = _format_messages([response])

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/llama_index/_span.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/llama_index/_span.py
@@ -358,13 +358,7 @@ class _Span(BaseSpan):
                     self[GEN_AI_INPUT_MESSAGES] = serialize_to_json_string(conversation)
 
     def process_agent_setup_input(self, agent_setup: Any) -> None:
-        """Capture agent-step input messages on a run_agent_step invoke_agent span.
-
-        run_agent_step spans are created from the AgentSetup event (instance is
-        None) so the BaseWorkflowAgent process_input path never runs for them.
-        AgentSetup.input is the list of ChatMessages fed to the agent this turn
-        (system prompt + conversation so far).
-        """
+        """Capture agent-step input messages on a run_agent_step invoke_agent span."""
         messages = getattr(agent_setup, "input", None)
         if not messages:
             return

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/llama_index/_span.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/llama_index/_span.py
@@ -349,6 +349,24 @@ class _Span(BaseSpan):
             if kwargs:
                 self[GEN_AI_TOOL_CALL_ARGUMENTS] = to_tool_attribute_value(kwargs)
 
+        if isinstance(instance, BaseWorkflowAgent):
+            start_event = bound_args.arguments.get("start_event")
+            user_msg = start_event.get("user_msg") if hasattr(start_event, "get") else None
+            if user_msg:
+                _, conversation = _format_messages([ChatMessage(role="user", content=user_msg)])
+                if conversation:
+                    self[GEN_AI_INPUT_MESSAGES] = serialize_to_json_string(conversation)
+
+    def process_agent_output(self, result: Any) -> None:
+        """Capture the final agent output on the invoke_agent span."""
+        response = getattr(getattr(result, "result", None), "response", None)
+        if not isinstance(response, ChatMessage):
+            return
+        _, conversation = _format_messages([response])
+        if conversation:
+            conversation[-1].setdefault("finish_reason", "stop")
+            self[GEN_AI_OUTPUT_MESSAGES] = serialize_to_json_string(conversation)
+
     @singledispatchmethod
     def process_instance(self, instance: Any) -> None: ...  # noqa: E704  # pylint: disable=no-self-use
 

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/llama_index/_span.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/llama_index/_span.py
@@ -357,9 +357,39 @@ class _Span(BaseSpan):
                 if conversation:
                     self[GEN_AI_INPUT_MESSAGES] = serialize_to_json_string(conversation)
 
+    def process_agent_setup_input(self, agent_setup: Any) -> None:
+        """Capture agent-step input messages on a run_agent_step invoke_agent span.
+
+        run_agent_step spans are created from the AgentSetup event (instance is
+        None) so the BaseWorkflowAgent process_input path never runs for them.
+        AgentSetup.input is the list of ChatMessages fed to the agent this turn
+        (system prompt + conversation so far).
+        """
+        messages = getattr(agent_setup, "input", None)
+        if not messages:
+            return
+        system_instructions, conversation = _format_messages(messages)
+        if system_instructions:
+            self[GEN_AI_SYSTEM_INSTRUCTIONS] = serialize_to_json_string(system_instructions)
+        if conversation:
+            self[GEN_AI_INPUT_MESSAGES] = serialize_to_json_string(conversation)
+
     def process_agent_output(self, result: Any) -> None:
-        """Capture the final agent output on the invoke_agent span."""
+        """Capture the final agent output on the invoke_agent span.
+
+        Two result shapes reach this method:
+        - StopEvent (single-agent parent run / early-stop): final ChatMessage at
+          result.result.response.
+        - AgentOutput (run_agent_step in an AgentWorkflow): ChatMessage at
+          result.response. Only the FINAL answer turn carries real output; an
+          intermediate turn that requests tools has result.tool_calls populated
+          and must be skipped so tool-call turns are not recorded as the output.
+        """
         response = getattr(getattr(result, "result", None), "response", None)
+        if response is None:
+            if getattr(result, "tool_calls", None):
+                return
+            response = getattr(result, "response", None)
         if not isinstance(response, ChatMessage):
             return
         _, conversation = _format_messages([response])

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/llama_index/test_llama_index_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/llama_index/test_llama_index_instrumentor.py
@@ -372,6 +372,52 @@ class TestLlamaIndexInstrumentor(unittest.TestCase):
         self.assertEqual(span._attributes[GEN_AI_OPERATION_NAME], "invoke_agent")
         otel_span.end()
 
+    def test_process_agent_output_captures_output_messages(self):
+        """Test process_agent_output writes the final agent response to output messages."""
+        from llama_index.core.agent.workflow import AgentOutput
+
+        otel_span = self.tracer.start_span("test")
+        span = self._Span(otel_span=otel_span)
+        span[GEN_AI_OPERATION_NAME] = GenAiOperationNameValues.INVOKE_AGENT.value
+        result = AgentOutput(
+            response=ChatMessage(role=MessageRole.ASSISTANT, content="Greeting complete!"),
+            tool_calls=[],
+            raw=None,
+            current_agent_name="Greeter",
+        )
+        span.process_agent_output(result)
+        self.assertIn(GEN_AI_OUTPUT_MESSAGES, span._attributes)
+        output_messages = json.loads(span._attributes[GEN_AI_OUTPUT_MESSAGES])
+        self.assertEqual(output_messages[0]["role"], "assistant")
+        self.assertEqual(output_messages[0]["parts"][0]["content"], "Greeting complete!")
+        self.assertEqual(output_messages[0]["finish_reason"], "stop")
+        otel_span.end()
+
+    def test_process_agent_output_non_chatmessage_response_ignored(self):
+        """Test process_agent_output does nothing when response is not a ChatMessage."""
+        otel_span = self.tracer.start_span("test")
+        span = self._Span(otel_span=otel_span)
+        span[GEN_AI_OPERATION_NAME] = GenAiOperationNameValues.INVOKE_AGENT.value
+        span.process_agent_output(object())
+        self.assertNotIn(GEN_AI_OUTPUT_MESSAGES, span._attributes)
+        otel_span.end()
+
+    def test_process_agent_output_skips_non_invoke_agent_span(self):
+        """Test process_agent_output does nothing when the span is not an invoke_agent span."""
+        from llama_index.core.agent.workflow import AgentOutput
+
+        otel_span = self.tracer.start_span("test")
+        span = self._Span(otel_span=otel_span)
+        result = AgentOutput(
+            response=ChatMessage(role=MessageRole.ASSISTANT, content="Greeting complete!"),
+            tool_calls=[],
+            raw=None,
+            current_agent_name="Greeter",
+        )
+        span.process_agent_output(result)
+        self.assertNotIn(GEN_AI_OUTPUT_MESSAGES, span._attributes)
+        otel_span.end()
+
     def test_process_instance_default_handler_none(self):
         """Test default process_instance handler with None does nothing."""
         otel_span = self.tracer.start_span("test")
@@ -1666,9 +1712,7 @@ class TestLlamaIndexInstrumentor(unittest.TestCase):
         spans = self.span_exporter.get_finished_spans()
 
         workflow_spans = [s for s in spans if s.attributes.get(GEN_AI_OPERATION_NAME) == OPERATION_INVOKE_WORKFLOW]
-        agent_step_spans = [
-            s for s in spans if s.attributes.get(GEN_AI_OPERATION_NAME) == "invoke_agent" and "run_agent_step" in s.name
-        ]
+        agent_step_spans = [s for s in spans if "run_agent_step" in s.name]
         tool_spans = [s for s in spans if s.attributes.get(GEN_AI_OPERATION_NAME) == "execute_tool"]
 
         self.assertEqual(len(workflow_spans), 1)
@@ -1678,6 +1722,9 @@ class TestLlamaIndexInstrumentor(unittest.TestCase):
         for step_span in agent_step_spans:
             self.assertEqual(step_span.name, "run_agent_step Greeter")
             self.assertEqual(step_span.attributes[GEN_AI_AGENT_NAME], "Greeter")
+            self.assertNotIn(GEN_AI_OPERATION_NAME, step_span.attributes)
+            self.assertNotIn(GEN_AI_INPUT_MESSAGES, step_span.attributes)
+            self.assertNotIn(GEN_AI_OUTPUT_MESSAGES, step_span.attributes)
 
         self.assertEqual(len(tool_spans), 1)
         self.assertIn("greet", tool_spans[0].name)

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/llama_index/test_llama_index_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/llama_index/test_llama_index_instrumentor.py
@@ -372,52 +372,6 @@ class TestLlamaIndexInstrumentor(unittest.TestCase):
         self.assertEqual(span._attributes[GEN_AI_OPERATION_NAME], "invoke_agent")
         otel_span.end()
 
-    def test_process_agent_output_captures_output_messages(self):
-        """Test process_agent_output writes the final agent response to output messages."""
-        from llama_index.core.agent.workflow import AgentOutput
-
-        otel_span = self.tracer.start_span("test")
-        span = self._Span(otel_span=otel_span)
-        span[GEN_AI_OPERATION_NAME] = GenAiOperationNameValues.INVOKE_AGENT.value
-        result = AgentOutput(
-            response=ChatMessage(role=MessageRole.ASSISTANT, content="Greeting complete!"),
-            tool_calls=[],
-            raw=None,
-            current_agent_name="Greeter",
-        )
-        span.process_agent_output(result)
-        self.assertIn(GEN_AI_OUTPUT_MESSAGES, span._attributes)
-        output_messages = json.loads(span._attributes[GEN_AI_OUTPUT_MESSAGES])
-        self.assertEqual(output_messages[0]["role"], "assistant")
-        self.assertEqual(output_messages[0]["parts"][0]["content"], "Greeting complete!")
-        self.assertEqual(output_messages[0]["finish_reason"], "stop")
-        otel_span.end()
-
-    def test_process_agent_output_non_chatmessage_response_ignored(self):
-        """Test process_agent_output does nothing when response is not a ChatMessage."""
-        otel_span = self.tracer.start_span("test")
-        span = self._Span(otel_span=otel_span)
-        span[GEN_AI_OPERATION_NAME] = GenAiOperationNameValues.INVOKE_AGENT.value
-        span.process_agent_output(object())
-        self.assertNotIn(GEN_AI_OUTPUT_MESSAGES, span._attributes)
-        otel_span.end()
-
-    def test_process_agent_output_skips_non_invoke_agent_span(self):
-        """Test process_agent_output does nothing when the span is not an invoke_agent span."""
-        from llama_index.core.agent.workflow import AgentOutput
-
-        otel_span = self.tracer.start_span("test")
-        span = self._Span(otel_span=otel_span)
-        result = AgentOutput(
-            response=ChatMessage(role=MessageRole.ASSISTANT, content="Greeting complete!"),
-            tool_calls=[],
-            raw=None,
-            current_agent_name="Greeter",
-        )
-        span.process_agent_output(result)
-        self.assertNotIn(GEN_AI_OUTPUT_MESSAGES, span._attributes)
-        otel_span.end()
-
     def test_process_instance_default_handler_none(self):
         """Test default process_instance handler with None does nothing."""
         otel_span = self.tracer.start_span("test")
@@ -1712,7 +1666,9 @@ class TestLlamaIndexInstrumentor(unittest.TestCase):
         spans = self.span_exporter.get_finished_spans()
 
         workflow_spans = [s for s in spans if s.attributes.get(GEN_AI_OPERATION_NAME) == OPERATION_INVOKE_WORKFLOW]
-        agent_step_spans = [s for s in spans if "run_agent_step" in s.name]
+        agent_step_spans = [
+            s for s in spans if s.attributes.get(GEN_AI_OPERATION_NAME) == "invoke_agent" and "run_agent_step" in s.name
+        ]
         tool_spans = [s for s in spans if s.attributes.get(GEN_AI_OPERATION_NAME) == "execute_tool"]
 
         self.assertEqual(len(workflow_spans), 1)
@@ -1722,9 +1678,6 @@ class TestLlamaIndexInstrumentor(unittest.TestCase):
         for step_span in agent_step_spans:
             self.assertEqual(step_span.name, "run_agent_step Greeter")
             self.assertEqual(step_span.attributes[GEN_AI_AGENT_NAME], "Greeter")
-            self.assertNotIn(GEN_AI_OPERATION_NAME, step_span.attributes)
-            self.assertNotIn(GEN_AI_INPUT_MESSAGES, step_span.attributes)
-            self.assertNotIn(GEN_AI_OUTPUT_MESSAGES, step_span.attributes)
 
         self.assertEqual(len(tool_spans), 1)
         self.assertIn("greet", tool_spans[0].name)

--- a/contract-tests/images/applications/gen_ai/llamaindex/llamaindex_server.py
+++ b/contract-tests/images/applications/gen_ai/llamaindex/llamaindex_server.py
@@ -145,6 +145,7 @@ class RequestHandler(BaseHTTPRequestHandler):
                 name="TestAgent",
                 description="A test agent that greets and multiplies.",
                 system_prompt="You are a helpful assistant.",
+                streaming=False,
             )
 
             async def run_agent():
@@ -185,6 +186,7 @@ class RequestHandler(BaseHTTPRequestHandler):
                 description="Greets people by name.",
                 system_prompt="You greet people.",
                 can_handoff_to=["Calculator"],
+                streaming=False,
             )
             calculator = FunctionAgent(
                 tools=[multiply],
@@ -192,6 +194,7 @@ class RequestHandler(BaseHTTPRequestHandler):
                 name="Calculator",
                 description="Multiplies numbers.",
                 system_prompt="You multiply numbers.",
+                streaming=False,
             )
             workflow = AgentWorkflow(
                 agents=[greeter, calculator], root_agent="Greeter", workflow_name="multi_agent_workflow"

--- a/contract-tests/tests/test/amazon/gen_ai/llamaindex/llamaindex_test.py
+++ b/contract-tests/tests/test/amazon/gen_ai/llamaindex/llamaindex_test.py
@@ -137,14 +137,10 @@ class LlamaIndexTest(ContractTestBase):
         invoke_agent_spans = []
         execute_tool_spans = []
         chat_spans = []
-        run_agent_step_spans = []
 
         for resource_scope_span in resource_scope_spans:
             span = resource_scope_span.span
             attrs = self._get_attributes_dict(span.attributes)
-
-            if "run_agent_step" in span.name:
-                run_agent_step_spans.append(span)
 
             if attrs.get(GEN_AI_OPERATION_NAME):
                 op_name = attrs[GEN_AI_OPERATION_NAME].string_value
@@ -161,15 +157,9 @@ class LlamaIndexTest(ContractTestBase):
             attrs = self._get_attributes_dict(span.attributes)
             self._assert_str_attribute(attrs, GEN_AI_OPERATION_NAME, GenAiOperationNameValues.INVOKE_AGENT.value)
             self._assert_str_attribute(attrs, GEN_AI_AGENT_NAME, "TestAgent")
-            self._assert_str_attribute(attrs, GEN_AI_AGENT_DESCRIPTION, "A test agent that greets and multiplies.")
-            self._assert_invoke_agent_input_output(attrs)
-
-        for span in run_agent_step_spans:
-            attrs = self._get_attributes_dict(span.attributes)
-            self.assertNotIn(GEN_AI_OPERATION_NAME, attrs)
-            self.assertIn(GEN_AI_AGENT_NAME, attrs)
-            self.assertNotIn(GEN_AI_INPUT_MESSAGES, attrs)
-            self.assertNotIn(GEN_AI_OUTPUT_MESSAGES, attrs)
+            if "run_agent_step" not in span.name:
+                self._assert_str_attribute(attrs, GEN_AI_AGENT_DESCRIPTION, "A test agent that greets and multiplies.")
+                self._assert_invoke_agent_input_output(attrs)
 
         if execute_tool_spans:
             tool_names = set()
@@ -379,7 +369,6 @@ class LlamaIndexTest(ContractTestBase):
             attrs = self._get_attributes_dict(span.attributes)
             self._assert_str_attribute(attrs, GEN_AI_OPERATION_NAME, GenAiOperationNameValues.INVOKE_AGENT.value)
             self.assertIn(GEN_AI_AGENT_NAME, attrs)
-            self._assert_invoke_agent_input_output(attrs)
 
         self.assertGreater(len(chat_spans), 0, "Expected at least one chat span")
 

--- a/contract-tests/tests/test/amazon/gen_ai/llamaindex/llamaindex_test.py
+++ b/contract-tests/tests/test/amazon/gen_ai/llamaindex/llamaindex_test.py
@@ -1,5 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+import json
 from logging import INFO, Logger, getLogger
 from typing import List
 
@@ -136,10 +137,14 @@ class LlamaIndexTest(ContractTestBase):
         invoke_agent_spans = []
         execute_tool_spans = []
         chat_spans = []
+        run_agent_step_spans = []
 
         for resource_scope_span in resource_scope_spans:
             span = resource_scope_span.span
             attrs = self._get_attributes_dict(span.attributes)
+
+            if "run_agent_step" in span.name:
+                run_agent_step_spans.append(span)
 
             if attrs.get(GEN_AI_OPERATION_NAME):
                 op_name = attrs[GEN_AI_OPERATION_NAME].string_value
@@ -156,8 +161,15 @@ class LlamaIndexTest(ContractTestBase):
             attrs = self._get_attributes_dict(span.attributes)
             self._assert_str_attribute(attrs, GEN_AI_OPERATION_NAME, GenAiOperationNameValues.INVOKE_AGENT.value)
             self._assert_str_attribute(attrs, GEN_AI_AGENT_NAME, "TestAgent")
-            if "run_agent_step" not in span.name:
-                self._assert_str_attribute(attrs, GEN_AI_AGENT_DESCRIPTION, "A test agent that greets and multiplies.")
+            self._assert_str_attribute(attrs, GEN_AI_AGENT_DESCRIPTION, "A test agent that greets and multiplies.")
+            self._assert_invoke_agent_input_output(attrs)
+
+        for span in run_agent_step_spans:
+            attrs = self._get_attributes_dict(span.attributes)
+            self.assertNotIn(GEN_AI_OPERATION_NAME, attrs)
+            self.assertIn(GEN_AI_AGENT_NAME, attrs)
+            self.assertNotIn(GEN_AI_INPUT_MESSAGES, attrs)
+            self.assertNotIn(GEN_AI_OUTPUT_MESSAGES, attrs)
 
         if execute_tool_spans:
             tool_names = set()
@@ -216,8 +228,6 @@ class LlamaIndexTest(ContractTestBase):
             self.assertIn(GEN_AI_INPUT_MESSAGES, attrs)
             input_messages = attrs[GEN_AI_INPUT_MESSAGES].string_value
             self.assertIsNotNone(input_messages)
-            import json
-
             messages = json.loads(input_messages)
             self.assertIsInstance(messages, list)
             self.assertGreater(len(messages), 0, "Expected at least one message")
@@ -325,8 +335,6 @@ class LlamaIndexTest(ContractTestBase):
             self.assertIn(GEN_AI_TOOL_DEFINITIONS, attrs)
             tool_defs = attrs[GEN_AI_TOOL_DEFINITIONS].string_value
             self.assertIsNotNone(tool_defs)
-            import json
-
             tools = json.loads(tool_defs)
             self.assertIsInstance(tools, list)
             self.assertEqual(len(tools), 2, "Expected exactly two tool definitions (calculate_sum, multiply)")
@@ -371,8 +379,29 @@ class LlamaIndexTest(ContractTestBase):
             attrs = self._get_attributes_dict(span.attributes)
             self._assert_str_attribute(attrs, GEN_AI_OPERATION_NAME, GenAiOperationNameValues.INVOKE_AGENT.value)
             self.assertIn(GEN_AI_AGENT_NAME, attrs)
+            self._assert_invoke_agent_input_output(attrs)
 
         self.assertGreater(len(chat_spans), 0, "Expected at least one chat span")
+
+    def _assert_invoke_agent_input_output(self, attrs) -> None:
+        self.assertIn(GEN_AI_INPUT_MESSAGES, attrs)
+        self.assertIn(GEN_AI_OUTPUT_MESSAGES, attrs)
+        input_messages = json.loads(attrs[GEN_AI_INPUT_MESSAGES].string_value)
+        output_messages = json.loads(attrs[GEN_AI_OUTPUT_MESSAGES].string_value)
+        self.assertTrue(self._text_parts(input_messages, "user"), "Expected the user input on the invoke_agent span")
+        self.assertTrue(
+            self._text_parts(output_messages, "assistant"), "Expected the agent output on the invoke_agent span"
+        )
+
+    @staticmethod
+    def _text_parts(messages: list, role: str) -> list:
+        return [
+            part["content"]
+            for message in messages
+            if message.get("role") == role
+            for part in message.get("parts", [])
+            if part.get("type") == "text" and part.get("content")
+        ]
 
     @override
     def _assert_metric_attributes(self, resource_scope_metrics, metric_name: str, expected_sum: int, **kwargs) -> None:


### PR DESCRIPTION
Adds `gen_ai.input.messages` / `gen_ai.output.messages` to invoke_agent spans for the LlamaIndex instrumentor so agent spans carry the user input and final agent output, for both single-agent (`FunctionAgent`) and multi-agent (`AgentWorkflow`) runs. Extends the LlamaIndex contract tests to assert this content.