### PR TITLE
Key incident-snapshot dedup hash on operation + throw-site origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 - fix(crewai): normalize tool description across crewai versions
   ([#821](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/821))
+- fix(serviceevents): key the incident-snapshot dedup hash on operation + bounded throw-site origin (`module/path.function`)
+  ([#825](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/825))
 - fix(crewai): report per-call LLM token usage instead of cumulative total
   ([#806](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/806))
 - fix(genai): serialize tool call arguments/results and blob bytes to match OTel util-genai (primitives kept native, bytes base64-encoded)

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/ast_transformation.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/ast_transformation.py
@@ -50,10 +50,14 @@ def _is_docstring_expr(node: ast.stmt) -> bool:
     return isinstance(node.value, ast.Str) and isinstance(node.value.s, str)  # type: ignore[attr-defined]
 
 
-def _file_path_to_module_path(file_path: str) -> str:
+def file_path_to_module_path(file_path: str) -> str:
     """Convert a file path to a module-style path for function naming.
 
     Strips the .py extension and handles __init__.py by using the parent directory.
+
+    Public seam: the incident-snapshot collector file-qualifies dedup-hash origins with this same
+    normalization, so the composite name it builds matches ``build_function_name``. Keep the two in
+    lockstep — a change here rotates every dedup hash.
 
     Examples:
         'indico/modules/foo/bar.py' → 'indico/modules/foo/bar'
@@ -72,6 +76,10 @@ def _file_path_to_module_path(file_path: str) -> str:
         path = path[:-9]
 
     return path
+
+
+# Backward-compatible alias for the pre-public underscore name.
+_file_path_to_module_path = file_path_to_module_path
 
 
 def build_function_name(function_name: str, file_path: str, lineno: int, is_async: bool = False) -> str:
@@ -99,7 +107,7 @@ def build_function_name(function_name: str, file_path: str, lineno: int, is_asyn
         >>> build_function_name("my_func", "myapp/server.py", 42)
         "myapp/server.my_func"
     """
-    module_path = _file_path_to_module_path(file_path)
+    module_path = file_path_to_module_path(file_path)
     composite_name = f"{module_path}.{function_name}"
 
     # Register the function in the global registry (thread-safe)

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/collectors/incident_snapshot_collector.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/serviceevents/collectors/incident_snapshot_collector.py
@@ -25,7 +25,7 @@ import uuid
 from collections import deque
 from typing import Dict, List, Optional, Pattern, Set, Tuple
 
-from amazon.opentelemetry.distro.serviceevents.ast_transformation import get_function_info
+from amazon.opentelemetry.distro.serviceevents.ast_transformation import file_path_to_module_path, get_function_info
 from amazon.opentelemetry.distro.serviceevents.collectors.base_collector import BaseCollector
 from amazon.opentelemetry.distro.serviceevents.models import (
     CallPathEntry,
@@ -39,6 +39,10 @@ from amazon.opentelemetry.distro.serviceevents.python_monitor import _ServiceEve
 from amazon.opentelemetry.distro.serviceevents.utils import get_instance_id
 
 logger = logging.getLogger(__name__)
+
+# Matches a Python traceback frame line: File "<path>", line N, in <func>. Used ONLY to derive the
+# file-qualified origin for the dedup hash from a captured traceback string (never emitted).
+_TRACEBACK_FRAME_RE = re.compile(r'^\s*File\s+"([^"]*)",\s+line\s+\d+,\s+in\s+(\S+)', re.MULTILINE)
 
 # too-many-lines: this collector owns the full incident pipeline (trigger detection,
 # per-endpoint latency thresholds, dedup + rate limiting, fork-safe state reset, trace
@@ -349,13 +353,15 @@ class IncidentSnapshotCollector(BaseCollector):
             return None
 
         # Generate error hash for deduplication. The processor passes exception=None (like Java) and
-        # defers exception detail to the collector, so recover the error identity (type + message)
-        # from the investigation data — already seeded from the span's exception event for
-        # uninstrumented 5xx — BEFORE hashing. Without this the hash would collapse to route-only and
-        # two distinct errors on the same route would deduplicate together. Latency incidents have no
-        # exception → (None, None) → route-only hash, matching the pre-refactor behavior.
-        exc_type, exc_message = self._recover_error_identity(exception)
-        error_hash = self._error_hash(route, exc_type, exc_message)
+        # defers exception detail to the collector, so recover the error identity (type + throw-site
+        # function) from the investigation data — already seeded from the span's exception event for
+        # uninstrumented 5xx — BEFORE hashing. Without this the hash would collapse to operation-only
+        # and two distinct errors on the same operation would deduplicate together. The function name
+        # (not the unbounded message) keeps the key bounded. The key uses the full operation
+        # (<method> <route>) so different methods on one route are distinct incidents, matching Java.
+        # Latency incidents have no exception → (None, None) → operation-only hash.
+        exc_type, origin_function = self._recover_error_identity(exception)
+        error_hash = self._error_hash(operation, exc_type, origin_function)
 
         # Claim the batch slot atomically FIRST (one snapshot per error type per collection
         # interval). The check-and-add under the lock is the serialization point that lets exactly
@@ -531,12 +537,12 @@ class IncidentSnapshotCollector(BaseCollector):
                 if pending is None or pending.telemetry_correlation.trace_id is not None:
                     return
                 replacement.snapshot_id = pending.snapshot_id
-                # Preserve the original operation too. The dedup hash keys on route (not method), so a
-                # GET and a POST to the same route with the same error share a hash and can upgrade
-                # each other. The endpoint exemplar is filed under the FIRST occurrence's operation
-                # key; rebuilding operation from THIS occurrence's method would make the swapped
-                # snapshot's operation disagree with the endpoint summary that references its
-                # snapshot_id. Keep the first occurrence's operation.
+                # Preserve the original operation too. The dedup hash keys on operation
+                # (``<method> <route>``), so only occurrences sharing an operation (e.g. two GET
+                # /api/x with the same error) share a hash and can upgrade each other. The endpoint
+                # exemplar is filed under the FIRST occurrence's operation key; rebuilding operation
+                # from THIS occurrence would make the swapped snapshot's operation disagree with the
+                # endpoint summary that references its snapshot_id. Keep the first occurrence's operation.
                 replacement.operation = pending.operation
                 try:
                     idx = self._pending_snapshots.index(pending)
@@ -698,55 +704,140 @@ class IncidentSnapshotCollector(BaseCollector):
             return True
 
     def _recover_error_identity(self, exception: Optional[Exception]) -> Tuple[Optional[str], Optional[str]]:
-        """Recover the (exception_type, exception_message) that keys the dedup hash.
+        """Recover the (exception_type, origin) that keys the dedup hash.
 
         The endpoint span processor passes ``exception=None`` (like Java) and defers exception detail
         to the collector, so the dedup key must be recovered from the same investigation data the
-        snapshot body uses. Without this the hash would collapse to route-only and two distinct
-        errors on the same route would deduplicate together (defeating per-error incident coverage).
+        snapshot body uses. Without this the hash would collapse to operation-only and two distinct
+        errors on the same operation would deduplicate together (defeating per-error incident coverage).
 
-        * When an explicit ``exception`` object is supplied (legacy/manual callers), use it directly.
+        The second element is the *file-qualified throw-site origin* (``module/path.function``), not
+        the exception message. The message is unbounded — it routinely embeds request-specific data
+        (IDs, timestamps, values) — so keying on it lets a single recurring error spawn a distinct
+        hash per occurrence, defeating dedup and churning the per-window hash map against its size
+        cap. The origin is bounded (finite functions per service) and stable across deploys. It is
+        file-qualified so two same-named functions in different modules don't collide into one
+        incident, mirroring the composite name the AST monitor assigns instrumented frames (see
+        ``build_function_name``) and Java's ``class.method``.
+
+        This value is used ONLY for the dedup hash. Customer-consumed telemetry (the endpoint error
+        breakdown key and the snapshot body ``function_name``) is left untouched — those still carry
+        the bare/monitor-recorded name, so this change does not alter emitted data.
+
+        * When an explicit ``exception`` object is supplied (legacy/manual callers), take the type
+          from it and the origin from the last frame of its traceback (the raise site).
         * Otherwise PEEK the per-request investigation data — the AST monitor's captured exception,
-          or the span's exception event seeded into it by the processor for uninstrumented 5xx.
-        * A latency incident (no exception anywhere) returns ``(None, None)`` → route-only hash,
+          or the span's exception event seeded into it by the processor for uninstrumented 5xx —
+          and file-qualify the producer-recorded thrower (``function_name``) against the captured
+          ``traceback_info`` string.
+        * A latency incident (no exception anywhere) returns ``(None, None)`` → operation-only hash,
           matching the pre-refactor behavior for slow requests.
 
         Best-effort and guarded: hashing must never crash the host, so any failure degrades to
-        ``(None, None)`` (route-only), the safe default.
+        ``(None, None)`` (operation-only), the safe default.
         """
         try:
             if exception is not None:
-                return type(exception).__name__, str(exception)
+                return type(exception).__name__, self._origin_from_traceback(exception.__traceback__)
             inv_data = self._monitor_state.peek_investigation_data()
             exc_data = inv_data.get("exception") if inv_data else None
             if isinstance(exc_data, dict) and exc_data.get("name"):
-                return exc_data.get("name"), exc_data.get("message") or ""
+                origin = self._origin_from_traceback_str(
+                    exc_data.get("traceback_info"),
+                    exc_data.get("function_name"),
+                    exc_data.get("message"),
+                )
+                return exc_data.get("name"), origin
         except Exception:  # pylint: disable=broad-exception-caught  # telemetry must never crash host app
             logger.debug("Failed to recover error identity for dedup hash", exc_info=True)
         return None, None
 
     @staticmethod
-    def _error_hash(route: str, exc_type: Optional[str], exc_message: Optional[str]) -> str:
-        """Hash the dedup key from route + recovered exception type/message.
+    def _origin_from_traceback(tb) -> str:
+        """Return the file-qualified origin at the raise site of a traceback object.
 
-        Keyed ``route:<route>`` for latency (no exception) or ``route:<route>|exc:<type>:<message>``
-        for errors, matching the documented per-SDK key (see SERVICE_EVENTS_INCIDENT_RATE_LIMITING.md)
-        and the Node distro's ``generateErrorHash``.
+        Walks to the last frame (``tb_next`` chain) — Python appends frames innermost-last, so the
+        final frame is where the exception was raised — and builds ``module/path.function`` from that
+        frame's filename + code name (same normalization as ``build_function_name``). Returns ``""``
+        if no traceback is attached.
+        """
+        if tb is None:
+            return ""
+        while tb.tb_next is not None:
+            tb = tb.tb_next
+        frame = tb.tb_frame
+        return f"{file_path_to_module_path(frame.f_code.co_filename)}.{frame.f_code.co_name}"
+
+    @staticmethod
+    def _origin_from_traceback_str(
+        stacktrace: Optional[str], func_name: Optional[str], message: Optional[str] = None
+    ) -> str:
+        """File-qualify the producer-recorded thrower against a formatted Python traceback string.
+
+        ``func_name`` is the thrower the producer already recorded — a composite
+        ``module/path.function`` from the AST monitor (derived from instrumented frame metadata, not
+        string-parsed) or a bare name from the span-event path. A composite name matches no frame's
+        ``in <func>`` clause (frames carry bare names) and is returned unchanged. A bare name is
+        file-qualified by locating the LAST frame whose ``in <func>`` equals it — the raise site under
+        recursion — and prepending that frame's module path, yielding ``module/path.function``.
+
+        ``format_exception`` renders the ``<Type>: <message>`` trailer AFTER the frames, so any
+        ``File "...", line N, in x`` text embedded in the message sits past the real frames. Anchoring
+        on the recorded ``func_name`` already ignores frames with a different name; passing the
+        ``message`` additionally truncates the scan before the trailer, so a message that embeds a
+        frame reusing the recorded name (e.g. a wrapped error quoting its own traceback) still cannot
+        inject a per-request origin and reintroduce the unbounded-key proliferation this change
+        removes. Returns the bare name unchanged if its frame can't be located, or ``""`` if the
+        producer recorded no thrower.
+        """
+        if not func_name:
+            return ""
+        if not stacktrace:
+            return func_name
+        frame_region = stacktrace
+        if message:
+            # Drop the trailing "<Type>: <message>" block so message text isn't scanned as a frame.
+            trailer_index = stacktrace.rfind(message)
+            if trailer_index != -1:
+                frame_region = stacktrace[:trailer_index]
+        file_path = ""
+        for match in _TRACEBACK_FRAME_RE.finditer(frame_region):
+            if match.group(2) == func_name:
+                file_path = match.group(1)  # keep the last match — the raise site under recursion
+        if not file_path:
+            return func_name
+        return f"{file_path_to_module_path(file_path)}.{func_name}"
+
+    @staticmethod
+    def _error_hash(operation: str, exc_type: Optional[str], origin: Optional[str]) -> str:
+        """Hash the dedup key from operation + recovered exception type/origin.
+
+        Keyed ``op:<operation>`` for latency (no exception) or ``op:<operation>|exc:<type>:<origin>``
+        for errors, following the same ``op:``/``|exc:`` scheme as the Java and Node distros.
+        ``operation`` is the full ``<method> <route>`` (e.g. ``GET /api/users``), so different HTTP
+        methods on one route are distinct incidents. The file-qualified origin (not the message)
+        keeps the key bounded — see ``_recover_error_identity``.
+
+        Hashes are compared only within a distro, never across them, so the strings need not be
+        byte-identical between distros — and they are not: when the origin is unresolvable this distro
+        emits a trailing ``:`` (empty origin), whereas Java omits the ``:origin`` segment entirely.
         """
         if not exc_type:
-            hash_input = f"route:{route}"
+            hash_input = f"op:{operation}"
         else:
-            hash_input = f"route:{route}|exc:{exc_type}:{exc_message or ''}"
+            hash_input = f"op:{operation}|exc:{exc_type}:{origin or ''}"
         return hashlib.md5(hash_input.encode("utf-8")).hexdigest()
 
-    def _generate_error_hash(self, route: str, exception: Optional[Exception]) -> str:
+    def _generate_error_hash(self, operation: str, exception: Optional[Exception]) -> str:
         """Backward-compatible hash entry point taking an exception object directly.
 
         Retained for callers/tests that pass an explicit exception; delegates to ``_error_hash``.
+        ``operation`` is the full ``<method> <route>`` label.
         """
         if exception is None:
-            return self._error_hash(route, None, None)
-        return self._error_hash(route, type(exception).__name__, str(exception))
+            return self._error_hash(operation, None, None)
+        origin = self._origin_from_traceback(exception.__traceback__)
+        return self._error_hash(operation, type(exception).__name__, origin)
 
     def _is_within_dedup_limit(self, error_hash: str) -> bool:
         """True if emitting this error now would NOT exceed the per-period same-error cap.

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/collectors/test_incident_snapshot_collector.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/serviceevents/collectors/test_incident_snapshot_collector.py
@@ -6,6 +6,7 @@ import time
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
+from amazon.opentelemetry.distro.serviceevents.ast_transformation import _file_path_to_module_path
 from amazon.opentelemetry.distro.serviceevents.collectors.incident_snapshot_collector import IncidentSnapshotCollector
 from amazon.opentelemetry.distro.serviceevents.models import (
     CallPathEntry,
@@ -256,19 +257,77 @@ class TestGenerateErrorHash(TestCase):
         _ServiceEventsMonitorState._instance = None
 
     def test_with_exception(self):
-        """Test hash with exception type and message."""
+        """Test hash with exception type and file-qualified throw-site origin (not the message)."""
         collector = IncidentSnapshotCollector(
             flush_interval_ms=10000,
             duration_threshold_ms=1000,
             max_per_period=100,
         )
 
-        exc = ValueError("test error")
-        result = collector._generate_error_hash("/api/users", exc)
+        def raise_here():
+            raise ValueError("test error")
 
-        expected_input = "route:/api/users|exc:ValueError:test error"
+        try:
+            raise_here()
+        except ValueError as exc:
+            result = collector._generate_error_hash("GET /api/users", exc)
+
+        # Keyed on op:<operation> + type + file-qualified origin (module/path.function), NOT the
+        # message, so it stays bounded. The origin is derived from this test file's path so same-named
+        # functions in other modules can't collide.
+        origin = f"{_file_path_to_module_path(__file__)}.raise_here"
+        expected_input = f"op:GET /api/users|exc:ValueError:{origin}"
         expected = hashlib.md5(expected_input.encode("utf-8")).hexdigest()
         self.assertEqual(result, expected)
+
+    def test_message_variations_share_one_hash(self):
+        """Two occurrences of the same error with request-specific messages must collide.
+
+        This is the property the fix restores: the unbounded message no longer leaks into the key,
+        so a recurring error dedups regardless of per-request detail in its message.
+        """
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=100,
+        )
+
+        def raise_here(msg):
+            raise ValueError(msg)
+
+        hashes = set()
+        for msg in ("user 1 not found", "user 2 not found", "user 3 not found"):
+            try:
+                raise_here(msg)
+            except ValueError as exc:
+                hashes.add(collector._generate_error_hash("/api/users", exc))
+
+        self.assertEqual(len(hashes), 1)
+
+    def test_different_functions_different_hashes(self):
+        """Same exception type raised from different functions must NOT dedup together."""
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=100,
+        )
+
+        def raise_a():
+            raise ValueError("boom")
+
+        def raise_b():
+            raise ValueError("boom")
+
+        try:
+            raise_a()
+        except ValueError as exc:
+            hash_a = collector._generate_error_hash("/api/users", exc)
+        try:
+            raise_b()
+        except ValueError as exc:
+            hash_b = collector._generate_error_hash("/api/users", exc)
+
+        self.assertNotEqual(hash_a, hash_b)
 
     def test_without_exception(self):
         """Test hash without exception (slow request)."""
@@ -278,9 +337,9 @@ class TestGenerateErrorHash(TestCase):
             max_per_period=100,
         )
 
-        result = collector._generate_error_hash("/api/users", None)
+        result = collector._generate_error_hash("GET /api/users", None)
 
-        expected_input = "route:/api/users"
+        expected_input = "op:GET /api/users"
         expected = hashlib.md5(expected_input.encode("utf-8")).hexdigest()
         self.assertEqual(result, expected)
 
@@ -292,9 +351,91 @@ class TestGenerateErrorHash(TestCase):
             max_per_period=100,
         )
 
-        hash1 = collector._generate_error_hash("/api/users", None)
-        hash2 = collector._generate_error_hash("/api/items", None)
+        hash1 = collector._generate_error_hash("GET /api/users", None)
+        hash2 = collector._generate_error_hash("GET /api/items", None)
         self.assertNotEqual(hash1, hash2)
+
+    def test_different_methods_same_route_different_hashes(self):
+        """Different HTTP methods on one route are distinct incidents (operation-keyed, like Java)."""
+        collector = IncidentSnapshotCollector(
+            flush_interval_ms=10000,
+            duration_threshold_ms=1000,
+            max_per_period=100,
+        )
+
+        hash_get = collector._generate_error_hash("GET /api/users", None)
+        hash_post = collector._generate_error_hash("POST /api/users", None)
+        self.assertNotEqual(hash_get, hash_post)
+
+
+class TestOriginFromTracebackStr(TestCase):
+    """Test the seeded-exception origin parser: file-qualifies the producer-recorded thrower."""
+
+    def setUp(self):
+        _ServiceEventsMonitorState._instance = None
+
+    @staticmethod
+    def _collector():
+        return IncidentSnapshotCollector(flush_interval_ms=10000, duration_threshold_ms=1000, max_per_period=100)
+
+    def test_file_qualifies_bare_thrower_from_matching_frame(self):
+        collector = self._collector()
+        tb = 'Traceback (most recent call last):\n  File "app/db.py", line 5, in query_orders\nDbError: boom'
+        self.assertEqual(collector._origin_from_traceback_str(tb, "query_orders"), "app/db.query_orders")
+
+    def test_message_embedded_fake_frame_cannot_hijack_origin(self):
+        # The exception message quotes a traceback fragment (request-specific). The anchored lookup
+        # keys on the recorded thrower name, so the injected frame is ignored — no per-request origin.
+        collector = self._collector()
+        tb = (
+            "Traceback (most recent call last):\n"
+            '  File "app/db.py", line 5, in query_orders\n'
+            'DbError: lookup failed for\n  File "/req/12345.py", line 1, in do'
+        )
+        self.assertEqual(collector._origin_from_traceback_str(tb, "query_orders"), "app/db.query_orders")
+
+    def test_message_embedding_same_named_frame_cannot_hijack_origin(self):
+        # Harder injection: the message trailer embeds a frame reusing the RECORDED thrower name
+        # (query_orders) with a request-specific path. Passing the message truncates the scan before
+        # the trailer (format_exception renders it last), so the real frame — not the injected one —
+        # file-qualifies the origin. Without the message-strip, last-match-wins would pick /req/...
+        collector = self._collector()
+        message = 'lookup failed\n  File "/req/12345.py", line 1, in query_orders'
+        tb = (
+            "Traceback (most recent call last):\n" '  File "app/db.py", line 5, in query_orders\n' f"DbError: {message}"
+        )
+        self.assertEqual(collector._origin_from_traceback_str(tb, "query_orders", message), "app/db.query_orders")
+
+    def test_composite_thrower_name_passes_through_unchanged(self):
+        # The AST monitor records a composite module/path.function that matches no bare frame clause;
+        # it is already file-qualified, so it is returned as-is.
+        collector = self._collector()
+        tb = 'Traceback (most recent call last):\n  File "app/db.py", line 5, in query_orders\nDbError: boom'
+        self.assertEqual(collector._origin_from_traceback_str(tb, "app/db.query_orders"), "app/db.query_orders")
+
+    def test_unlocatable_thrower_falls_back_to_bare_name(self):
+        collector = self._collector()
+        tb = 'Traceback (most recent call last):\n  File "app/db.py", line 5, in something_else\nDbError: boom'
+        self.assertEqual(collector._origin_from_traceback_str(tb, "query_orders"), "query_orders")
+
+    def test_no_thrower_recorded_returns_empty(self):
+        collector = self._collector()
+        self.assertEqual(collector._origin_from_traceback_str("whatever", None), "")
+
+    def test_no_traceback_returns_bare_thrower(self):
+        collector = self._collector()
+        self.assertEqual(collector._origin_from_traceback_str(None, "query_orders"), "query_orders")
+
+    def test_recursion_takes_last_matching_frame(self):
+        # Same function recurses; the LAST matching frame is the raise site.
+        collector = self._collector()
+        tb = (
+            "Traceback (most recent call last):\n"
+            '  File "app/a.py", line 1, in recurse\n'
+            '  File "app/b.py", line 2, in recurse\n'
+            "RecursionError: boom"
+        )
+        self.assertEqual(collector._origin_from_traceback_str(tb, "recurse"), "app/b.recurse")
 
 
 class TestCheckDeduplication(TestCase):
@@ -871,14 +1012,25 @@ class TestDedupKeysOnRecoveredErrorIdentity(TestCase):
         return collector, emitter
 
     @staticmethod
-    def _seed_exception(collector, name, message):
+    def _seed_exception(collector, name, message, file_path="app/handler.py", func="handle"):
         # Mirror the processor seeding the span's exception event into per-request investigation
         # data for an uninstrumented 5xx (exception=None reaches the collector). _recover_error_identity
-        # PEEKs this to key the dedup hash on type+message rather than route-only.
+        # PEEKs this to key the dedup hash on type + file-qualified origin (parsed from traceback_info)
+        # rather than operation-only. The message is captured for the snapshot body but is deliberately NOT
+        # part of the dedup key. function_name here is the customer-consumed value (left untouched by
+        # the hash) — the hash derives its origin from traceback_info instead.
+        traceback_info = (
+            f'Traceback (most recent call last):\n  File "{file_path}", line 1, in {func}\n{name}: {message}'
+        )
         collector._monitor_state._investigation_data.set(
             {
                 "call_path": [],
-                "exception": {"name": name, "message": message, "function_name": "app.handler"},
+                "exception": {
+                    "name": name,
+                    "message": message,
+                    "function_name": func,
+                    "traceback_info": traceback_info,
+                },
             }
         )
 
@@ -896,30 +1048,56 @@ class TestDedupKeysOnRecoveredErrorIdentity(TestCase):
         collector.collect()
         self.assertEqual(emitter.emit_incident_snapshot.call_count, 2)
 
-    def test_two_distinct_messages_same_type_same_route_both_emit(self):
+    def test_two_distinct_messages_same_type_and_function_same_route_deduplicate(self):
+        # Same type + same origin function, differing only in request-specific message text, must
+        # now collide (the message is no longer part of the key). This is the unbounded-key fix.
         collector, emitter = self._make_collector()
-        self._seed_exception(collector, "DbError", "timeout on shard A")
+        self._seed_exception(collector, "DbError", "timeout on shard A", file_path="app/db.py", func="query_orders")
         self.assertIsNotNone(collector.process_potential_incident("/orders", "POST", 500, 10.0, None, self._rd()))
         collector.collect()
-        self._seed_exception(collector, "DbError", "timeout on shard B")
+        self._seed_exception(collector, "DbError", "timeout on shard B", file_path="app/db.py", func="query_orders")
+        self.assertIsNone(collector.process_potential_incident("/orders", "POST", 500, 10.0, None, self._rd()))
+        collector.collect()
+        self.assertEqual(emitter.emit_incident_snapshot.call_count, 1)
+
+    def test_same_type_same_function_name_distinct_modules_both_emit(self):
+        # Same exception type + same bare function name but in DIFFERENT modules must NOT dedup
+        # together — the file-qualified origin keeps them apart (the collision the qualification fixes).
+        collector, emitter = self._make_collector()
+        self._seed_exception(collector, "DbError", "timeout", file_path="app/orders.py", func="handle")
+        self.assertIsNotNone(collector.process_potential_incident("/orders", "POST", 500, 10.0, None, self._rd()))
+        collector.collect()
+        self._seed_exception(collector, "DbError", "timeout", file_path="app/users.py", func="handle")
         self.assertIsNotNone(collector.process_potential_incident("/orders", "POST", 500, 10.0, None, self._rd()))
         collector.collect()
         self.assertEqual(emitter.emit_incident_snapshot.call_count, 2)
 
-    def test_same_error_type_and_message_same_route_deduplicates(self):
+    def test_same_type_distinct_functions_same_route_both_emit(self):
+        # Same exception type raised from two different functions on one route are distinct
+        # incidents — the origin function keeps them apart now that the message is gone.
         collector, emitter = self._make_collector()
-        self._seed_exception(collector, "DbError", "timeout")
+        self._seed_exception(collector, "DbError", "timeout", file_path="app/db.py", func="query_orders")
         self.assertIsNotNone(collector.process_potential_incident("/orders", "POST", 500, 10.0, None, self._rd()))
         collector.collect()
-        self._seed_exception(collector, "DbError", "timeout")
+        self._seed_exception(collector, "DbError", "timeout", file_path="app/db.py", func="write_orders")
+        self.assertIsNotNone(collector.process_potential_incident("/orders", "POST", 500, 10.0, None, self._rd()))
+        collector.collect()
+        self.assertEqual(emitter.emit_incident_snapshot.call_count, 2)
+
+    def test_same_error_type_and_function_same_route_deduplicates(self):
+        collector, emitter = self._make_collector()
+        self._seed_exception(collector, "DbError", "timeout", file_path="app/db.py", func="query_orders")
+        self.assertIsNotNone(collector.process_potential_incident("/orders", "POST", 500, 10.0, None, self._rd()))
+        collector.collect()
+        self._seed_exception(collector, "DbError", "timeout", file_path="app/db.py", func="query_orders")
         # Same recovered identity → same hash → period-deduplicated (max_same_error=1).
         self.assertIsNone(collector.process_potential_incident("/orders", "POST", 500, 10.0, None, self._rd()))
         collector.collect()
         self.assertEqual(emitter.emit_incident_snapshot.call_count, 1)
 
-    def test_latency_incident_no_exception_keys_route_only(self):
+    def test_latency_incident_no_exception_keys_operation_only(self):
         collector, emitter = self._make_collector()
-        # No investigation exception; two slow 2xx on the same route dedup together (route-only).
+        # No investigation exception; two slow 2xx on the same operation dedup together (operation-only).
         self.assertIsNotNone(collector.process_potential_incident("/slow", "GET", 200, 6000.0, None, self._rd()))
         collector.collect()
         self.assertIsNone(collector.process_potential_incident("/slow", "GET", 200, 6000.0, None, self._rd()))
@@ -946,8 +1124,23 @@ class TestRateLimitedRequestDoesNotPoisonDedup(TestCase):
             max_per_period=1,
             max_same_error=1,
         )
-        err_a = ValueError("A")
-        err_b = ValueError("B")
+
+        # Two DISTINCT errors: same type, but raised from different functions so they hash apart
+        # under the type+origin-function key (the message is no longer part of the key).
+        def raise_a():
+            raise ValueError("A")
+
+        def raise_b():
+            raise ValueError("B")
+
+        try:
+            raise_a()
+        except ValueError as e:
+            err_a = e
+        try:
+            raise_b()
+        except ValueError as e:
+            err_b = e
         rd = {"headers": {}, "args": {}}
         self.assertIsNotNone(collector.process_potential_incident("/x", "GET", 500, 10.0, err_a, rd))
         # Second distinct error: passes dedup but the rate window (1) is full → rejected.
@@ -1007,21 +1200,22 @@ class TestEndpointExemplarTracksUpgrade(TestCase):
         self.assertIsNotNone(upgraded.telemetry_correlation.trace_id)
 
     def test_upgrade_preserves_first_occurrence_operation(self):
-        # The dedup hash keys on route (not method), so GET /api/x and POST /api/x with the same error
-        # share a hash. The exemplar is filed under the FIRST occurrence's operation, so the swapped
-        # snapshot must keep the first occurrence's operation, not adopt the upgrader's method.
+        # Two occurrences of the same error on the same operation (GET /api/x) share a hash: the first
+        # is unsampled, the second sampled. The sampled one upgrades the pending snapshot in place; the
+        # exemplar (held by reference by the endpoint collector) is filed under the first occurrence, so
+        # the swapped snapshot must keep the first occurrence's operation and snapshot_id.
         collector = self._make_collector()
         err = ValueError("boom")
         exemplar = collector.process_potential_incident("/api/x", "GET", 500, 50.0, err, {"headers": {}, "args": {}})
         self.assertIsNotNone(exemplar)
         self.assertEqual(exemplar["operation"], "GET /api/x")
-        # Sampled POST occurrence of the same error upgrades the pending (unsampled) GET snapshot.
+        # Sampled occurrence of the same error+operation upgrades the pending (unsampled) snapshot.
         collector.process_potential_incident(
-            "/api/x", "POST", 500, 50.0, err, {"headers": {}, "args": {}, "trace_id": 0xAA, "span_id": 0xBB}
+            "/api/x", "GET", 500, 50.0, err, {"headers": {}, "args": {}, "trace_id": 0xAA, "span_id": 0xBB}
         )
         self.assertEqual(len(collector._pending_snapshots), 1)
         upgraded = collector._pending_snapshots[0]
-        # operation stays 'GET /api/x' (the exemplar's filed operation), NOT 'POST /api/x'.
+        # operation stays 'GET /api/x' (the exemplar's filed operation) and snapshot_id is preserved.
         self.assertEqual(upgraded.operation, "GET /api/x")
         self.assertEqual(upgraded.snapshot_id, exemplar["snapshot_id"])
 
@@ -1477,7 +1671,9 @@ class TestProcessPotentialIncidentBranches(TestCase):
         mock_collect.return_value = MagicMock()
         collector = self._make_collector()
 
-        error_hash = collector._generate_error_hash("/api/users", ValueError("dup"))
+        # Pre-seed with the SAME operation process_potential_incident computes internally
+        # (operation = "<method> <route>" = "GET /api/users").
+        error_hash = collector._generate_error_hash("GET /api/users", ValueError("dup"))
         with collector._error_hashes_lock:
             collector._current_batch_hashes.add(error_hash)
 


### PR DESCRIPTION
The incident-snapshot deduplication hash keyed on bare route + exception
message. The message is unbounded — it embeds request-specific data (IDs,
timestamps, values) — so a single recurring error spawned a distinct hash
per occurrence, defeating dedup and churning the per-window hash map against
its size cap.

Key on the full operation (<method> <route>) so different HTTP methods on one
route are distinct incidents (matching Java), and replace the message with a
bounded file-qualified throw-site origin (module/path.function). The origin is
recovered from investigation data ONLY for the internal hash — customer-consumed
telemetry (error breakdown key, snapshot body function_name) is left byte-for-byte
unchanged.

For the seeded (uninstrumented-5xx) path the origin is anchored on the
producer-recorded thrower name and the scan is truncated before the message
trailer, so a message embedding File "...", in <func> text cannot inject a
per-request origin. Promote _file_path_to_module_path to a public
file_path_to_module_path (underscore name kept as an alias) since the hash now
depends on it staying in lockstep with build_function_name.

## Testing
- Unit: full serviceevents pytest suite passes (incl. new `TestOriginFromTracebackStr`: message-embedded fake-frame + same-named-frame injection, composite passthrough, recursion).
- Contract: serviceevents contract tests green (48/48; flask/django/django-uwsgi incl. dedup cap).
- Lint: black / isort / flake8 / pylint clean.
- E2E: EC2 dev-loop against live CloudWatch — 5/5 Service Events validators pass.