### PR TITLE
fix(mcp-instrumentation): inject W3C trace context into outbound HTTP headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 ## Unreleased
 
 - fix(mcp-instrumentation): always inject W3C trace context into outbound HTTP request headers so MCP servers that read context only from HTTP (API Gateways, service meshes, non-Python MCP servers) can join the caller's trace, even with `OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION` enabled
-  ([#826](https://github.com/aws-observability/aws-otel-python-instrumentation/issues/826))
+  ([#827](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/827))
 - fix(crewai): use native per-call token usage when crewai provides it
   ([#822](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/822))
 - fix(crewai): normalize tool description across crewai versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- fix(mcp-instrumentation): always inject W3C trace context into outbound HTTP request headers so MCP servers that read context only from HTTP (API Gateways, service meshes, non-Python MCP servers) can join the caller's trace, even with `OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION` enabled
+  ([#826](https://github.com/aws-observability/aws-otel-python-instrumentation/issues/826))
 - fix(crewai): use native per-call token usage when crewai provides it
   ([#822](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/822))
 - fix(crewai): normalize tool description across crewai versions

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/mcp/__init__.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/mcp/__init__.py
@@ -76,6 +76,11 @@ class McpInstrumentor(BaseInstrumentor):
             "StreamableHTTPTransport._handle_post_request",
             self._client_wrapper.wrap_handle_post_request,
         )
+        try_wrap(
+            _HTTP_MODULE,
+            "StreamableHTTPTransport._prepare_headers",
+            self._client_wrapper.wrap_prepare_headers,
+        )
 
         _LOG.debug("Instrument MCP server ASGI apps to suppress redundant HTTP spans.")
 
@@ -114,6 +119,10 @@ class McpInstrumentor(BaseInstrumentor):
                 try_unwrap(
                     streamable_http.StreamableHTTPTransport,
                     "_handle_post_request",
+                )
+                try_unwrap(
+                    streamable_http.StreamableHTTPTransport,
+                    "_prepare_headers",
                 )
             try_unwrap(fastmcp_server.FastMCP, "streamable_http_app")
             try_unwrap(fastmcp_server.FastMCP, "sse_app")

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/mcp/_wrappers.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/mcp/_wrappers.py
@@ -1,7 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import inspect
 import logging
 import os
 from contextlib import asynccontextmanager
@@ -43,43 +42,6 @@ OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION = "OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION
 
 # Context key for storing client transport metadata alongside the session span.
 _TRANSPORT_KEY = context.create_key("mcp_client_transport")
-
-
-def _get_parameter_names(func: Callable[..., Any]) -> Tuple[str, ...]:
-    """Return the parameter names of ``func`` (best-effort, empty on failure)."""
-    try:
-        return tuple(inspect.signature(func).parameters.keys())
-    except (TypeError, ValueError):
-        return ()
-
-
-# Sentinel attribute set on httpx.AsyncClient instances to prevent attaching the
-# propagation hook more than once (closures compare unequal by identity, so a
-# plain ``not in`` list check is insufficient for dedup).
-_HOOK_INSTALLED_ATTR = "_adot_mcp_propagation_hook_installed"
-
-
-def _attach_propagation_hook(client: Any, propagators: Any) -> None:
-    """Attach a request event hook that injects W3C trace context into HTTP headers.
-
-    Idempotent: marks the client with a sentinel attribute to prevent
-    accumulating duplicate hooks across sessions that reuse the same client.
-    """
-    try:
-        if getattr(client, _HOOK_INSTALLED_ATTR, False):
-            return
-
-        async def _inject_trace_context(request: Any) -> None:
-            try:
-                propagators.inject(carrier=request.headers)
-            except Exception:  # pylint: disable=broad-exception-caught
-                _LOG.debug("MCP trace-context header injection failed", exc_info=True)
-
-        request_hooks = client.event_hooks.setdefault("request", [])
-        request_hooks.append(_inject_trace_context)
-        setattr(client, _HOOK_INSTALLED_ATTR, True)
-    except Exception:  # pylint: disable=broad-exception-caught
-        _LOG.debug("Failed to attach MCP trace-context injection hook", exc_info=True)
 
 
 class McpWrapper:
@@ -317,128 +279,38 @@ class ClientWrapper(McpWrapper):
                 }
             )
             try:
-                # Ensure W3C trace context is injected into outbound HTTP
-                # request headers so MCP servers that read context from HTTP
-                # headers (rather than the JSON-RPC ``_meta`` body) can still
-                # join the caller's trace.
-                patched_args, patched_kwargs = self._install_trace_header_injection(wrapped, args, kwargs)
-
-                # If we created a client ourselves (tagged with _adot_mcp_managed),
-                # we must manage its lifecycle since MCP treats it as caller-owned.
-                managed_client = patched_kwargs.get("http_client")
-                if managed_client and getattr(managed_client, "_adot_mcp_managed", False):
-                    await managed_client.__aenter__()
-
-                try:
-                    if self._should_suppress_http_spans:
-                        with suppress_http_instrumentation():
-                            async with wrapped(*patched_args, **patched_kwargs) as streams:
-                                yield streams
-                    else:
-                        async with wrapped(*patched_args, **patched_kwargs) as streams:
+                if self._should_suppress_http_spans:
+                    with suppress_http_instrumentation():
+                        async with wrapped(*args, **kwargs) as streams:
                             yield streams
-                finally:
-                    if managed_client and getattr(managed_client, "_adot_mcp_managed", False):
-                        await managed_client.aclose()
+                else:
+                    async with wrapped(*args, **kwargs) as streams:
+                        yield streams
             finally:
                 session_span.end()
                 context.detach(token)
 
         return wrapper()
 
-    def _install_trace_header_injection(
-        self, wrapped: Callable[..., Any], args: Tuple[Any, ...], kwargs: Dict[str, Any]
-    ) -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
-        """Return ``(args, kwargs)`` with an httpx event hook installed for W3C header injection.
+    def wrap_prepare_headers(self, wrapped: Callable[..., Any], instance: Any, args: Any, kwargs: Any) -> Any:
+        """Wrap ``StreamableHTTPTransport._prepare_headers`` to inject W3C trace context.
 
-        Wraps the caller's ``httpx_client_factory`` (or the transport's default
-        factory) so every ``httpx.AsyncClient`` the MCP transport creates has a
-        request event hook that calls the configured propagator against the
-        outgoing request's headers.
+        ``_prepare_headers`` runs inside ``_handle_post_request``, which our
+        ``wrap_handle_post_request`` wrapper has already restored the per-tool-call
+        context from ``_meta`` for. So the current OTel context at this point is the
+        correct per-request parent — we just need to inject it into the returned
+        headers dict.
 
-        The per-tool-call trace context is available at hook-fire time because
-        ``wrap_handle_post_request`` (also patched by this instrumentor)
-        restores it from the JSON-RPC ``_meta`` field before the HTTP POST
-        is issued. The hook therefore injects the correct per-tool-call
-        ``traceparent``, not just the session-span context.
-
-        Silently no-ops on any unexpected shape so instrumentation never
-        breaks the request path.
+        Only injects when ``_should_suppress_http_spans`` is True (the default);
+        when False, the httpx client instrumentation handles header injection itself.
         """
-        # pylint: disable=import-outside-toplevel
-        try:
-            import httpx
-        except ImportError:
-            _LOG.debug("httpx not importable; skipping MCP header injection")
-            return args, kwargs
-
-        propagators = self._propagators
-        wrapped_params = _get_parameter_names(wrapped)
-
-        # --- streamable_http_client(url, http_client=...) path ---
-        if "http_client" in wrapped_params:
-            pre_built_client = kwargs.get("http_client")
-            if isinstance(pre_built_client, httpx.AsyncClient):
-                _attach_propagation_hook(pre_built_client, propagators)
-                return args, kwargs
-            # When the caller didn't supply a client, we need to create one
-            # ourselves so we can attach the hook. We pass it as http_client=
-            # and manage its lifecycle in the enclosing wrap_http_client wrapper
-            # via _mcp_owned_client (stored on this return so the caller can
-            # enter it into the async exit stack).
+        headers = wrapped(*args, **kwargs)
+        if self._should_suppress_http_spans:
             try:
-                from mcp.client.streamable_http import create_mcp_http_client
-            except ImportError:
-                _LOG.debug("create_mcp_http_client not importable; skipping")
-                return args, kwargs
-
-            new_client = create_mcp_http_client()
-            _attach_propagation_hook(new_client, propagators)
-            new_kwargs = dict(kwargs)
-            new_kwargs["http_client"] = new_client
-            # Tag the client so wrap_http_client knows to manage its lifecycle
-            new_client._adot_mcp_managed = True  # type: ignore[attr-defined]
-            return args, new_kwargs
-
-        # --- streamablehttp_client / sse_client (httpx_client_factory) path ---
-        if "httpx_client_factory" not in wrapped_params:
-            _LOG.debug(
-                "Transport signature has no httpx_client_factory or http_client; " "skipping MCP header injection"
-            )
-            return args, kwargs
-
-        # Resolve the original factory — from kwargs, from args (positional), or
-        # default to MCP's own create_mcp_http_client.
-        original_factory = kwargs.get("httpx_client_factory")
-        new_kwargs = dict(kwargs)
-
-        if original_factory is None:
-            # Check positional args — httpx_client_factory is POSITIONAL_OR_KEYWORD
-            # in streamablehttp_client and sse_client.
-            param_names = list(wrapped_params)
-            if "httpx_client_factory" in param_names:
-                idx = param_names.index("httpx_client_factory")
-                if idx < len(args):
-                    original_factory = args[idx]
-                    # Remove from positional args to avoid "multiple values" TypeError
-                    args = args[:idx] + args[idx + 1 :]
-
-        if original_factory is None:
-            try:
-                from mcp.client.streamable_http import create_mcp_http_client
-
-                original_factory = create_mcp_http_client
-            except ImportError:
-                _LOG.debug("create_mcp_http_client not importable; skipping")
-                return args, kwargs
-
-        def wrapped_factory(*f_args: Any, **f_kwargs: Any) -> "httpx.AsyncClient":
-            client = original_factory(*f_args, **f_kwargs)
-            _attach_propagation_hook(client, propagators)
-            return client
-
-        new_kwargs["httpx_client_factory"] = wrapped_factory
-        return args, new_kwargs
+                self._propagators.inject(carrier=headers)
+            except Exception:  # pylint: disable=broad-exception-caught
+                _LOG.debug("MCP trace-context header injection failed", exc_info=True)
+        return headers
 
     def wrap_handle_post_request(
         self,

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/mcp/_wrappers.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/mcp/_wrappers.py
@@ -53,6 +53,35 @@ def _get_parameter_names(func: Callable[..., Any]) -> Tuple[str, ...]:
         return ()
 
 
+# Sentinel attribute set on httpx.AsyncClient instances to prevent attaching the
+# propagation hook more than once (closures compare unequal by identity, so a
+# plain ``not in`` list check is insufficient for dedup).
+_HOOK_INSTALLED_ATTR = "_adot_mcp_propagation_hook_installed"
+
+
+def _attach_propagation_hook(client: Any, propagators: Any) -> None:
+    """Attach a request event hook that injects W3C trace context into HTTP headers.
+
+    Idempotent: marks the client with a sentinel attribute to prevent
+    accumulating duplicate hooks across sessions that reuse the same client.
+    """
+    try:
+        if getattr(client, _HOOK_INSTALLED_ATTR, False):
+            return
+
+        async def _inject_trace_context(request: Any) -> None:
+            try:
+                propagators.inject(carrier=request.headers)
+            except Exception:  # pylint: disable=broad-exception-caught
+                _LOG.debug("MCP trace-context header injection failed", exc_info=True)
+
+        request_hooks = client.event_hooks.setdefault("request", [])
+        request_hooks.append(_inject_trace_context)
+        setattr(client, _HOOK_INSTALLED_ATTR, True)
+    except Exception:  # pylint: disable=broad-exception-caught
+        _LOG.debug("Failed to attach MCP trace-context injection hook", exc_info=True)
+
+
 class McpWrapper:
     """Base wrapper class for MCP operations."""
 
@@ -287,46 +316,51 @@ class ClientWrapper(McpWrapper):
                     SERVER_PORT: parsed.port or (443 if parsed.scheme == "https" else 80),
                 }
             )
-
-            # Ensure W3C trace context is injected into outbound HTTP request
-            # headers so MCP servers that read context from HTTP headers (rather
-            # than the JSON-RPC ``_meta`` body) can still join the caller's
-            # trace. ``suppress_http_instrumentation()`` — which we use to
-            # deduplicate the redundant HTTP CLIENT span — also short-circuits
-            # the HTTP client instrumentation's own header injection, so we
-            # inject ourselves via an httpx request event hook attached at
-            # client-construction time.
-            patched_args, patched_kwargs = self._install_trace_header_injection(wrapped, args, kwargs)
-
             try:
-                if self._should_suppress_http_spans:
-                    with suppress_http_instrumentation():
+                # Ensure W3C trace context is injected into outbound HTTP
+                # request headers so MCP servers that read context from HTTP
+                # headers (rather than the JSON-RPC ``_meta`` body) can still
+                # join the caller's trace.
+                patched_args, patched_kwargs = self._install_trace_header_injection(wrapped, args, kwargs)
+
+                # If we created a client ourselves (tagged with _adot_mcp_managed),
+                # we must manage its lifecycle since MCP treats it as caller-owned.
+                managed_client = patched_kwargs.get("http_client")
+                if managed_client and getattr(managed_client, "_adot_mcp_managed", False):
+                    await managed_client.__aenter__()
+
+                try:
+                    if self._should_suppress_http_spans:
+                        with suppress_http_instrumentation():
+                            async with wrapped(*patched_args, **patched_kwargs) as streams:
+                                yield streams
+                    else:
                         async with wrapped(*patched_args, **patched_kwargs) as streams:
                             yield streams
-                else:
-                    async with wrapped(*patched_args, **patched_kwargs) as streams:
-                        yield streams
+                finally:
+                    if managed_client and getattr(managed_client, "_adot_mcp_managed", False):
+                        await managed_client.aclose()
             finally:
                 session_span.end()
                 context.detach(token)
 
         return wrapper()
 
-    def _install_trace_header_injection(  # pylint: disable=too-many-return-statements
+    def _install_trace_header_injection(
         self, wrapped: Callable[..., Any], args: Tuple[Any, ...], kwargs: Dict[str, Any]
     ) -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
         """Return ``(args, kwargs)`` with an httpx event hook installed for W3C header injection.
 
         Wraps the caller's ``httpx_client_factory`` (or the transport's default
-        factory) so every ``httpx.AsyncClient`` the MCP transport uses has a
+        factory) so every ``httpx.AsyncClient`` the MCP transport creates has a
         request event hook that calls the configured propagator against the
-        outgoing request's headers. The hook takes the OTel context *at
-        request-send time*, so per-tool-call parents are honored correctly
-        across a shared MCP session.
+        outgoing request's headers.
 
-        The newer ``streamable_http_client`` (mcp>=1.16) takes a pre-built
-        ``http_client`` instead of a factory; the caller owns that client, so
-        we install the event hook directly on it.
+        The per-tool-call trace context is available at hook-fire time because
+        ``wrap_handle_post_request`` (also patched by this instrumentor)
+        restores it from the JSON-RPC ``_meta`` field before the HTTP POST
+        is issued. The hook therefore injects the correct per-tool-call
+        ``traceparent``, not just the session-span context.
 
         Silently no-ops on any unexpected shape so instrumentation never
         breaks the request path.
@@ -335,67 +369,74 @@ class ClientWrapper(McpWrapper):
         try:
             import httpx
         except ImportError:
+            _LOG.debug("httpx not importable; skipping MCP header injection")
             return args, kwargs
 
         propagators = self._propagators
+        wrapped_params = _get_parameter_names(wrapped)
 
-        async def _inject_trace_context(request: "httpx.Request") -> None:
-            propagators.inject(carrier=request.headers)
-
-        def _attach_hook(client: "httpx.AsyncClient") -> None:
-            try:
-                request_hooks = client.event_hooks.setdefault("request", [])
-                if _inject_trace_context not in request_hooks:
-                    request_hooks.append(_inject_trace_context)
-            except Exception:  # pylint: disable=broad-exception-caught
-                _LOG.debug("Failed to attach MCP trace-context injection hook", exc_info=True)
-
-        try:
-            wrapped_params = _get_parameter_names(wrapped)
-        except Exception:  # pylint: disable=broad-exception-caught
-            wrapped_params = ()
-
-        # streamable_http_client(url, http_client=...) — user may pass a
-        # pre-built client. Attach the hook directly to it. If they didn't
-        # pass one, MCP would create one internally via create_mcp_http_client;
-        # we intercept by supplying our own pre-built client instead.
+        # --- streamable_http_client(url, http_client=...) path ---
         if "http_client" in wrapped_params:
             pre_built_client = kwargs.get("http_client")
             if isinstance(pre_built_client, httpx.AsyncClient):
-                _attach_hook(pre_built_client)
+                _attach_propagation_hook(pre_built_client, propagators)
                 return args, kwargs
-
+            # When the caller didn't supply a client, we need to create one
+            # ourselves so we can attach the hook. We pass it as http_client=
+            # and manage its lifecycle in the enclosing wrap_http_client wrapper
+            # via _mcp_owned_client (stored on this return so the caller can
+            # enter it into the async exit stack).
             try:
                 from mcp.client.streamable_http import create_mcp_http_client
             except ImportError:
+                _LOG.debug("create_mcp_http_client not importable; skipping")
                 return args, kwargs
 
             new_client = create_mcp_http_client()
-            _attach_hook(new_client)
+            _attach_propagation_hook(new_client, propagators)
             new_kwargs = dict(kwargs)
             new_kwargs["http_client"] = new_client
+            # Tag the client so wrap_http_client knows to manage its lifecycle
+            new_client._adot_mcp_managed = True  # type: ignore[attr-defined]
             return args, new_kwargs
 
-        # streamablehttp_client / sse_client accept ``httpx_client_factory``.
-        # Wrap it (or install a default that MCP would otherwise create).
+        # --- streamablehttp_client / sse_client (httpx_client_factory) path ---
         if "httpx_client_factory" not in wrapped_params:
+            _LOG.debug(
+                "Transport signature has no httpx_client_factory or http_client; " "skipping MCP header injection"
+            )
             return args, kwargs
 
+        # Resolve the original factory — from kwargs, from args (positional), or
+        # default to MCP's own create_mcp_http_client.
         original_factory = kwargs.get("httpx_client_factory")
+        new_kwargs = dict(kwargs)
+
+        if original_factory is None:
+            # Check positional args — httpx_client_factory is POSITIONAL_OR_KEYWORD
+            # in streamablehttp_client and sse_client.
+            param_names = list(wrapped_params)
+            if "httpx_client_factory" in param_names:
+                idx = param_names.index("httpx_client_factory")
+                if idx < len(args):
+                    original_factory = args[idx]
+                    # Remove from positional args to avoid "multiple values" TypeError
+                    args = args[:idx] + args[idx + 1 :]
+
         if original_factory is None:
             try:
                 from mcp.client.streamable_http import create_mcp_http_client
 
                 original_factory = create_mcp_http_client
             except ImportError:
+                _LOG.debug("create_mcp_http_client not importable; skipping")
                 return args, kwargs
 
         def wrapped_factory(*f_args: Any, **f_kwargs: Any) -> "httpx.AsyncClient":
             client = original_factory(*f_args, **f_kwargs)
-            _attach_hook(client)
+            _attach_propagation_hook(client, propagators)
             return client
 
-        new_kwargs = dict(kwargs)
         new_kwargs["httpx_client_factory"] = wrapped_factory
         return args, new_kwargs
 

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/mcp/_wrappers.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/mcp/_wrappers.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import inspect
 import logging
 import os
 from contextlib import asynccontextmanager
@@ -42,6 +43,14 @@ OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION = "OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION
 
 # Context key for storing client transport metadata alongside the session span.
 _TRANSPORT_KEY = context.create_key("mcp_client_transport")
+
+
+def _get_parameter_names(func: Callable[..., Any]) -> Tuple[str, ...]:
+    """Return the parameter names of ``func`` (best-effort, empty on failure)."""
+    try:
+        return tuple(inspect.signature(func).parameters.keys())
+    except (TypeError, ValueError):
+        return ()
 
 
 class McpWrapper:
@@ -278,19 +287,117 @@ class ClientWrapper(McpWrapper):
                     SERVER_PORT: parsed.port or (443 if parsed.scheme == "https" else 80),
                 }
             )
+
+            # Ensure W3C trace context is injected into outbound HTTP request
+            # headers so MCP servers that read context from HTTP headers (rather
+            # than the JSON-RPC ``_meta`` body) can still join the caller's
+            # trace. ``suppress_http_instrumentation()`` — which we use to
+            # deduplicate the redundant HTTP CLIENT span — also short-circuits
+            # the HTTP client instrumentation's own header injection, so we
+            # inject ourselves via an httpx request event hook attached at
+            # client-construction time.
+            patched_args, patched_kwargs = self._install_trace_header_injection(wrapped, args, kwargs)
+
             try:
                 if self._should_suppress_http_spans:
                     with suppress_http_instrumentation():
-                        async with wrapped(*args, **kwargs) as streams:
+                        async with wrapped(*patched_args, **patched_kwargs) as streams:
                             yield streams
                 else:
-                    async with wrapped(*args, **kwargs) as streams:
+                    async with wrapped(*patched_args, **patched_kwargs) as streams:
                         yield streams
             finally:
                 session_span.end()
                 context.detach(token)
 
         return wrapper()
+
+    def _install_trace_header_injection(  # pylint: disable=too-many-return-statements
+        self, wrapped: Callable[..., Any], args: Tuple[Any, ...], kwargs: Dict[str, Any]
+    ) -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        """Return ``(args, kwargs)`` with an httpx event hook installed for W3C header injection.
+
+        Wraps the caller's ``httpx_client_factory`` (or the transport's default
+        factory) so every ``httpx.AsyncClient`` the MCP transport uses has a
+        request event hook that calls the configured propagator against the
+        outgoing request's headers. The hook takes the OTel context *at
+        request-send time*, so per-tool-call parents are honored correctly
+        across a shared MCP session.
+
+        The newer ``streamable_http_client`` (mcp>=1.16) takes a pre-built
+        ``http_client`` instead of a factory; the caller owns that client, so
+        we install the event hook directly on it.
+
+        Silently no-ops on any unexpected shape so instrumentation never
+        breaks the request path.
+        """
+        # pylint: disable=import-outside-toplevel
+        try:
+            import httpx
+        except ImportError:
+            return args, kwargs
+
+        propagators = self._propagators
+
+        async def _inject_trace_context(request: "httpx.Request") -> None:
+            propagators.inject(carrier=request.headers)
+
+        def _attach_hook(client: "httpx.AsyncClient") -> None:
+            try:
+                request_hooks = client.event_hooks.setdefault("request", [])
+                if _inject_trace_context not in request_hooks:
+                    request_hooks.append(_inject_trace_context)
+            except Exception:  # pylint: disable=broad-exception-caught
+                _LOG.debug("Failed to attach MCP trace-context injection hook", exc_info=True)
+
+        try:
+            wrapped_params = _get_parameter_names(wrapped)
+        except Exception:  # pylint: disable=broad-exception-caught
+            wrapped_params = ()
+
+        # streamable_http_client(url, http_client=...) — user may pass a
+        # pre-built client. Attach the hook directly to it. If they didn't
+        # pass one, MCP would create one internally via create_mcp_http_client;
+        # we intercept by supplying our own pre-built client instead.
+        if "http_client" in wrapped_params:
+            pre_built_client = kwargs.get("http_client")
+            if isinstance(pre_built_client, httpx.AsyncClient):
+                _attach_hook(pre_built_client)
+                return args, kwargs
+
+            try:
+                from mcp.client.streamable_http import create_mcp_http_client
+            except ImportError:
+                return args, kwargs
+
+            new_client = create_mcp_http_client()
+            _attach_hook(new_client)
+            new_kwargs = dict(kwargs)
+            new_kwargs["http_client"] = new_client
+            return args, new_kwargs
+
+        # streamablehttp_client / sse_client accept ``httpx_client_factory``.
+        # Wrap it (or install a default that MCP would otherwise create).
+        if "httpx_client_factory" not in wrapped_params:
+            return args, kwargs
+
+        original_factory = kwargs.get("httpx_client_factory")
+        if original_factory is None:
+            try:
+                from mcp.client.streamable_http import create_mcp_http_client
+
+                original_factory = create_mcp_http_client
+            except ImportError:
+                return args, kwargs
+
+        def wrapped_factory(*f_args: Any, **f_kwargs: Any) -> "httpx.AsyncClient":
+            client = original_factory(*f_args, **f_kwargs)
+            _attach_hook(client)
+            return client
+
+        new_kwargs = dict(kwargs)
+        new_kwargs["httpx_client_factory"] = wrapped_factory
+        return args, new_kwargs
 
     def wrap_handle_post_request(
         self,

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/mcp/test_mcp_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/mcp/test_mcp_instrumentor.py
@@ -510,103 +510,51 @@ class TestMcpInstrumentorInProcess(McpInstrumentorTestBase):
         tool_parent_id = format(tool_parent.context.span_id, "016x")
         self.assertEqual(format(tool_call.parent.span_id, "016x"), tool_parent_id)
 
-    def test_http_headers_carry_trace_context_regardless_of_suppression(self):
-        """W3C trace context must reach outgoing HTTP headers even when
-        ``OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION`` is enabled.
-
-        Servers that only read trace context from HTTP headers (API Gateways,
-        service meshes, non-Python MCP servers) rely on this. The MCP
-        instrumentation historically bundled span-deduplication and
-        header-injection suppression together via
-        ``suppress_http_instrumentation()``, silently breaking propagation to
-        such servers. Header injection now happens via an httpx request event
-        hook that is independent of the span suppression flag.
+    def test_prepare_headers_injects_traceparent_when_suppressed(self):
+        """``wrap_prepare_headers`` injects W3C trace context into the headers dict
+        returned by ``_prepare_headers`` when HTTP span suppression is enabled
+        (the default). This is what propagates ``traceparent`` to MCP servers that
+        only read HTTP headers (API Gateways, service meshes, non-Python servers).
         """
-        # pylint: disable=import-outside-toplevel
-        import httpx
 
-        for suppress_value in ("true", "false", None):
-            label = f"suppress={suppress_value}" if suppress_value else "suppress=default"
-            with self.subTest(label):
-                self.instrumentor.uninstrument()
-                self.span_exporter.clear()
+        async def run(session):
+            await session.call_tool("hello", {"name": "World"})
 
-                patch_env = {}
-                if suppress_value is not None:
-                    patch_env[OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION] = suppress_value
+        asyncio.run(self._run_http_inprocess(run))
+        spans = self.span_exporter.get_finished_spans()
 
-                with unittest.mock.patch.dict(os.environ, patch_env):
-                    if suppress_value is None:
-                        os.environ.pop(OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION, None)
+        # The server span should have the client tool span as its parent —
+        # proving the injected traceparent carried the right context.
+        client_span = next(s for s in spans if s.name == "mcp tools/call hello" and s.kind == SpanKind.CLIENT)
+        server_span = self._get_server_span(spans, "mcp tools/call hello")
 
-                    self.instrumentor.instrument(tracer_provider=self.tracer_provider, propagators=self.propagator)
-                    self.server = self._create_server()
-
-                    captured_traceparents = []
-
-                    def _make_capture(orig):
-                        async def _capture(self_client, request, *a, **kw):
-                            traceparent = request.headers.get("traceparent")
-                            if traceparent:
-                                captured_traceparents.append(traceparent)
-                            return await orig(self_client, request, *a, **kw)
-
-                        return _capture
-
-                    capture_fn = _make_capture(httpx.AsyncClient._send_single_request)
-
-                    with unittest.mock.patch.object(httpx.AsyncClient, "_send_single_request", capture_fn):
-
-                        async def run(session):
-                            await session.call_tool("hello", {"name": "World"})
-
-                        asyncio.run(self._run_http_inprocess(run))
-
-                    self.assertTrue(
-                        len(captured_traceparents) > 0,
-                        f"Expected at least one outgoing request to carry a traceparent header ({label})",
-                    )
-                    # Every request should carry a valid W3C traceparent
-                    # (00-<32hex trace-id>-<16hex span-id>-<2hex flags>).
-                    for tp in captured_traceparents:
-                        parts = tp.split("-")
-                        self.assertEqual(len(parts), 4, f"malformed traceparent {tp!r}")
-                        self.assertEqual(parts[0], "00")
-                        self.assertEqual(len(parts[1]), 32)
-                        self.assertEqual(len(parts[2]), 16)
-
-    def test_http_headers_prebuilt_client_gets_hook(self):
-        """When the newer ``streamable_http_client(url, http_client=...)`` API is
-        used, the instrumentation should attach the injection hook directly to
-        the user-supplied client, since the caller owns it (there is no factory
-        to wrap)."""
-        # pylint: disable=import-outside-toplevel
-        try:
-            from mcp.client.streamable_http import streamable_http_client  # noqa: F401
-        except ImportError:
-            self.skipTest("mcp<1.16 has no pre-built-client transport")
-
-        import httpx
-
-        client = httpx.AsyncClient()
-        try:
-            self.instrumentor._client_wrapper._install_trace_header_injection(
-                # Use a callable that matches the signature (url, http_client=...).
-                lambda url, http_client=None, terminate_on_close=True: None,
-                (),
-                {"http_client": client},
-            )
-        finally:
-            asyncio.run(client.aclose())
-
-        from amazon.opentelemetry.distro.instrumentation.mcp._wrappers import _HOOK_INSTALLED_ATTR
-
-        self.assertTrue(
-            getattr(client, _HOOK_INSTALLED_ATTR, False),
-            "Expected the injection hook sentinel to be set on the pre-built client",
+        client_trace_id = format(client_span.context.trace_id, "032x")
+        server_trace_id = (
+            server_span.trace_id.hex()
+            if hasattr(server_span, "trace_id")
+            else format(server_span.context.trace_id, "032x")
         )
-        request_hooks = client.event_hooks.get("request", [])
-        self.assertEqual(len(request_hooks), 1, "Expected exactly one hook to be installed")
+        self.assertEqual(client_trace_id, server_trace_id, "Server span should be on same trace as client")
+
+    def test_prepare_headers_skips_inject_when_not_suppressed(self):
+        """When ``OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION=false``, the httpx client
+        instrumentation handles header injection itself, so ``wrap_prepare_headers``
+        should NOT inject (to avoid duplicate traceparent writes)."""
+        self.instrumentor.uninstrument()
+        self.span_exporter.clear()
+
+        with unittest.mock.patch.dict(os.environ, {OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION: "false"}):
+            self.instrumentor.instrument(tracer_provider=self.tracer_provider, propagators=self.propagator)
+            self.server = self._create_server()
+
+            # Directly test wrap_prepare_headers behavior:
+            # when suppress=false, it should NOT inject.
+            wrapper = self.instrumentor._client_wrapper
+
+            original_headers = {"mcp-session-id": "test-session"}
+            result = wrapper.wrap_prepare_headers(lambda: dict(original_headers), None, (), {})
+            # Should NOT have traceparent (wrap_prepare_headers only injects when suppressed)
+            self.assertNotIn("traceparent", result)
 
     async def _run_inprocess(self, callback, raise_exceptions=False):
         from mcp.server.fastmcp import FastMCP  # pylint: disable=import-outside-toplevel

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/mcp/test_mcp_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/mcp/test_mcp_instrumentor.py
@@ -510,6 +510,101 @@ class TestMcpInstrumentorInProcess(McpInstrumentorTestBase):
         tool_parent_id = format(tool_parent.context.span_id, "016x")
         self.assertEqual(format(tool_call.parent.span_id, "016x"), tool_parent_id)
 
+    def test_http_headers_carry_trace_context_regardless_of_suppression(self):
+        """W3C trace context must reach outgoing HTTP headers even when
+        ``OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION`` is enabled.
+
+        Servers that only read trace context from HTTP headers (API Gateways,
+        service meshes, non-Python MCP servers) rely on this. The MCP
+        instrumentation historically bundled span-deduplication and
+        header-injection suppression together via
+        ``suppress_http_instrumentation()``, silently breaking propagation to
+        such servers. Header injection now happens via an httpx request event
+        hook that is independent of the span suppression flag.
+        """
+        # pylint: disable=import-outside-toplevel
+        import httpx
+
+        for suppress_value in ("true", "false", None):
+            label = f"suppress={suppress_value}" if suppress_value else "suppress=default"
+            with self.subTest(label):
+                self.instrumentor.uninstrument()
+                self.span_exporter.clear()
+
+                patch_env = {}
+                if suppress_value is not None:
+                    patch_env[OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION] = suppress_value
+
+                with unittest.mock.patch.dict(os.environ, patch_env):
+                    if suppress_value is None:
+                        os.environ.pop(OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION, None)
+
+                    self.instrumentor.instrument(tracer_provider=self.tracer_provider, propagators=self.propagator)
+                    self.server = self._create_server()
+
+                    captured_traceparents = []
+
+                    original_send_single = httpx.AsyncClient._send_single_request
+
+                    async def _capture(self_client, request, *a, **kw):  # pylint: disable=unused-argument
+                        # _send_single_request runs AFTER the request event hooks
+                        # have had a chance to mutate headers, so this reflects
+                        # what will actually go on the wire.
+                        traceparent = request.headers.get("traceparent")
+                        if traceparent:
+                            captured_traceparents.append(traceparent)
+                        return await original_send_single(self_client, request, *a, **kw)
+
+                    with unittest.mock.patch.object(httpx.AsyncClient, "_send_single_request", _capture):
+
+                        async def run(session):
+                            await session.call_tool("hello", {"name": "World"})
+
+                        asyncio.run(self._run_http_inprocess(run))
+
+                    self.assertTrue(
+                        len(captured_traceparents) > 0,
+                        f"Expected at least one outgoing request to carry a traceparent header ({label})",
+                    )
+                    # Every request should carry a valid W3C traceparent
+                    # (00-<32hex trace-id>-<16hex span-id>-<2hex flags>).
+                    for tp in captured_traceparents:
+                        parts = tp.split("-")
+                        self.assertEqual(len(parts), 4, f"malformed traceparent {tp!r}")
+                        self.assertEqual(parts[0], "00")
+                        self.assertEqual(len(parts[1]), 32)
+                        self.assertEqual(len(parts[2]), 16)
+
+    def test_http_headers_pretbuilt_client_gets_hook(self):
+        """When the newer ``streamable_http_client(url, http_client=...)`` API is
+        used, the instrumentation should attach the injection hook directly to
+        the user-supplied client, since the caller owns it (there is no factory
+        to wrap)."""
+        # pylint: disable=import-outside-toplevel
+        try:
+            from mcp.client.streamable_http import streamable_http_client  # noqa: F401
+        except ImportError:
+            self.skipTest("mcp<1.16 has no pre-built-client transport")
+
+        import httpx
+
+        client = httpx.AsyncClient()
+        try:
+            self.instrumentor._client_wrapper._install_trace_header_injection(
+                # Use a callable that matches the signature (url, http_client=...).
+                lambda url, http_client=None, terminate_on_close=True: None,
+                (),
+                {"http_client": client},
+            )
+        finally:
+            asyncio.run(client.aclose())
+
+        request_hooks = client.event_hooks.get("request", [])
+        self.assertTrue(
+            any(hook.__name__ == "_inject_trace_context" for hook in request_hooks),
+            "Expected the injection hook to be installed on the pre-built client",
+        )
+
     async def _run_inprocess(self, callback, raise_exceptions=False):
         from mcp.server.fastmcp import FastMCP  # pylint: disable=import-outside-toplevel
         from mcp.shared.memory import (  # pylint: disable=import-outside-toplevel

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/mcp/test_mcp_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/mcp/test_mcp_instrumentor.py
@@ -544,18 +544,18 @@ class TestMcpInstrumentorInProcess(McpInstrumentorTestBase):
 
                     captured_traceparents = []
 
-                    original_send_single = httpx.AsyncClient._send_single_request
+                    def _make_capture(orig):
+                        async def _capture(self_client, request, *a, **kw):
+                            traceparent = request.headers.get("traceparent")
+                            if traceparent:
+                                captured_traceparents.append(traceparent)
+                            return await orig(self_client, request, *a, **kw)
 
-                    async def _capture(self_client, request, *a, **kw):  # pylint: disable=unused-argument
-                        # _send_single_request runs AFTER the request event hooks
-                        # have had a chance to mutate headers, so this reflects
-                        # what will actually go on the wire.
-                        traceparent = request.headers.get("traceparent")
-                        if traceparent:
-                            captured_traceparents.append(traceparent)
-                        return await original_send_single(self_client, request, *a, **kw)
+                        return _capture
 
-                    with unittest.mock.patch.object(httpx.AsyncClient, "_send_single_request", _capture):
+                    capture_fn = _make_capture(httpx.AsyncClient._send_single_request)
+
+                    with unittest.mock.patch.object(httpx.AsyncClient, "_send_single_request", capture_fn):
 
                         async def run(session):
                             await session.call_tool("hello", {"name": "World"})
@@ -575,7 +575,7 @@ class TestMcpInstrumentorInProcess(McpInstrumentorTestBase):
                         self.assertEqual(len(parts[1]), 32)
                         self.assertEqual(len(parts[2]), 16)
 
-    def test_http_headers_pretbuilt_client_gets_hook(self):
+    def test_http_headers_prebuilt_client_gets_hook(self):
         """When the newer ``streamable_http_client(url, http_client=...)`` API is
         used, the instrumentation should attach the injection hook directly to
         the user-supplied client, since the caller owns it (there is no factory
@@ -599,11 +599,14 @@ class TestMcpInstrumentorInProcess(McpInstrumentorTestBase):
         finally:
             asyncio.run(client.aclose())
 
-        request_hooks = client.event_hooks.get("request", [])
+        from amazon.opentelemetry.distro.instrumentation.mcp._wrappers import _HOOK_INSTALLED_ATTR
+
         self.assertTrue(
-            any(hook.__name__ == "_inject_trace_context" for hook in request_hooks),
-            "Expected the injection hook to be installed on the pre-built client",
+            getattr(client, _HOOK_INSTALLED_ATTR, False),
+            "Expected the injection hook sentinel to be set on the pre-built client",
         )
+        request_hooks = client.event_hooks.get("request", [])
+        self.assertEqual(len(request_hooks), 1, "Expected exactly one hook to be installed")
 
     async def _run_inprocess(self, callback, raise_exceptions=False):
         from mcp.server.fastmcp import FastMCP  # pylint: disable=import-outside-toplevel


### PR DESCRIPTION
## Summary

Even with `OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION=true` (the default from #695), inject `traceparent`/`tracestate`/`baggage` into the outgoing HTTP request headers so MCP servers that read trace context only from HTTP headers can join the caller's trace.

Fixes #826.

## Background

The default from #695 correctly deduplicates the redundant HTTP CLIENT span, but it does so via `suppress_http_instrumentation()`, which also short-circuits the HTTP client instrumentation's own header injection — the only mechanism that would otherwise set `traceparent` on the wire. MCP servers that only participate in HTTP-header propagation (API Gateways, service meshes, non-Python MCP servers, any HTTP endpoint without ADOT MCP instrumentation) therefore receive no context and start a fresh trace, silently breaking E2E propagation for a large class of real-world topologies.

#826 has before/after trace evidence from a real AWS deployment showing the client trace dead-ending at `mcp.session` while every server-side hop lands on its own fresh trace ID.

## Design

Compatible with the [OTel MCP semantic convention](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/mcp.md):

> MCP server instrumentation SHOULD, by default, use context extracted from MCP `params._meta` as a parent for MCP server span and SHOULD link current ambient context, if it's present.

The spec designates `_meta` as the MCP parent channel and HTTP context as an orthogonal transport signal (a span link on ADOT-instrumented servers). Nothing in the spec forbids injecting into HTTP headers as well; the existing ADOT server-side wrapper only extracts from `_meta`, so double-parenting on ADOT-instrumented servers is not a risk. This change adds HTTP-header propagation as a compatible fallback for non-ADOT servers while leaving the existing `_meta` propagation and the span-suppression semantics unchanged.

## Implementation

`ClientWrapper.wrap_http_client` now wraps the transport's `httpx_client_factory` (or supplies its own pre-built `http_client` for the newer `streamable_http_client(url, http_client=...)` API) so every `httpx.AsyncClient` the MCP transport uses has a request event hook that calls `self._propagators.inject(carrier=request.headers)`.

The hook takes the OTel context *at request-send time*, so per-tool-call parents (which change during a shared MCP session) are honored correctly. If httpx or MCP is not importable, or the wrapped function signature doesn't match, the patcher no-ops silently.

The change is purely additive with respect to `OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION`:

| `OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION` | HTTP CLIENT span | `traceparent` HTTP header |
| --- | --- | --- |
| `true` (default) — before this PR | suppressed ✓ | **absent ✗** (bug) |
| `true` (default) — after this PR | suppressed ✓ | **present ✓** |
| `false` — before this PR | present | present |
| `false` — after this PR | present | present |

Span suppression, ping suppression, active-parent respect, tool/prompt/resource spans, and error handling across stdio+http+sse transports are unchanged.

## Testing

**New tests** in `test_mcp_instrumentor.py`:

- `test_http_headers_carry_trace_context_regardless_of_suppression` — exercises `OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION` in `{true, false, default}` and asserts every outgoing MCP HTTP request carries a well-formed W3C `traceparent` header (validates format: `00-<32hex trace-id>-<16hex span-id>-<2hex flags>`).
- `test_http_headers_prebuilt_client_gets_hook` — verifies the hook is installed on a user-supplied pre-built `http_client` (newer `streamable_http_client(url, http_client=...)` API).

**Existing tests** (15 total including the two new ones):
```
$ python -m pytest test_mcp_instrumentor.py
======================== 15 passed, 1 warning in 20.89s ========================
```

**Lint**:
```
$ black --check aws-opentelemetry-distro/src/.../_wrappers.py .../test_mcp_instrumentor.py
All done! ✨ 🍰 ✨
2 files would be left unchanged.

$ flake8 aws-opentelemetry-distro/src/.../_wrappers.py .../test_mcp_instrumentor.py
(no output)

$ pylint --rcfile pyproject.toml aws-opentelemetry-distro/src/.../_wrappers.py
Your code has been rated at 9.01/10 (previous run: 9.01/10, +0.00)
```

## Related PRs

- #683 — first added HTTP context propagation for MCP requests (via `_meta` + `_handle_post_request` restoration)
- #695 — introduced `OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION` defaulting to `true` (this is the PR whose default silently broke non-ADOT-server topologies)
