### PR TITLE
Add best-effort public ECR image signing to release workflow

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -519,3 +519,61 @@ jobs:
              ${{ env.WHEEL_ARTIFACT_NAME }}.sha256 \
              layer.zip \
              layer.zip.sha256
+
+  # Best-effort signing of the released public ECR image. Runs last, after all
+  # publishing is done, and every step is continue-on-error so a signing failure
+  # never fails the release run or affects already-published artifacts.
+  sign-public-ecr-image:
+    runs-on: ubuntu-latest
+    needs: publish-github
+    steps:
+      - name: Configure AWS Credentials for public ECR
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_ECR_RELEASE }}
+          aws-region: ${{ env.AWS_PUBLIC_ECR_REGION }}
+
+      # Install notation CLI with AWS Signer plugin
+      - name: Install notation CLI with AWS Signer plugin
+        continue-on-error: true
+        run: |
+          curl -Lo aws-signer-notation-cli_amd64.deb https://d2hvyiie56hcat.cloudfront.net/linux/amd64/installer/deb/latest/aws-signer-notation-cli_amd64.deb
+          sudo dpkg -i aws-signer-notation-cli_amd64.deb
+          notation version
+          notation plugin ls
+
+      # Query ECR signing profile ARN
+      - name: Query ECR Signing Profile ARN
+        id: ecr-signing-profile
+        continue-on-error: true
+        run: |
+          PROFILE_ARN=$(aws signer get-signing-profile --region ${{ env.AWS_PUBLIC_ECR_REGION }} --profile-name ADOTECRSigningProfile --query "arn" --output text) || PROFILE_ARN=""
+          if [ -n "$PROFILE_ARN" ] && [ "$PROFILE_ARN" != "None" ]; then
+            echo "profile_arn=$PROFILE_ARN" >> $GITHUB_OUTPUT
+            echo "Found ECR signing profile: $PROFILE_ARN"
+          else
+            echo "ECR signing profile 'ADOTECRSigningProfile' not found or lookup failed; skipping image signing."
+            exit 0
+          fi
+
+      # Login to Public ECR
+      - name: Log in to AWS public ECR
+        if: steps.ecr-signing-profile.outputs.profile_arn != ''
+        continue-on-error: true
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 #v3.5.0
+        with:
+          registry: public.ecr.aws
+
+      # Sign Public ECR Image
+      - name: Sign Public ECR Image
+        if: steps.ecr-signing-profile.outputs.profile_arn != ''
+        continue-on-error: true
+        run: |
+          # Sign the released public ECR image
+          notation sign ${{ env.RELEASE_PUBLIC_REPOSITORY }}:v${{ env.VERSION }} \
+            --plugin com.amazonaws.signer.notation.plugin \
+            --id ${{ steps.ecr-signing-profile.outputs.profile_arn }}
+          echo "Successfully signed public ECR image"
+          echo "Image: ${{ env.RELEASE_PUBLIC_REPOSITORY }}:v${{ env.VERSION }}"
+          echo "Profile ARN: ${{ steps.ecr-signing-profile.outputs.profile_arn }}"


### PR DESCRIPTION
## Description

Adds a `sign-public-ecr-image` job that signs the released public ECR image with notation and the AWS Signer plugin, mirroring the Java release workflow.

## Design

- The job runs **last** (`needs: publish-github`), after all publishing is done.
- **Every step is `continue-on-error: true`**, so a signing failure never fails the release run or affects already-published artifacts (PyPI, ECR image, Lambda layers, GitHub release).
- The profile ARN is looked up with `get-signing-profile` (scoped `signer:GetSigningProfile`) rather than an account-wide `list-signing-profiles`.
- Uses the existing `AWS_ROLE_ARN_ECR_RELEASE` role (the same role that pushes the public ECR image), which has been granted the AWS Signer permissions.

If the `ADOTECRSigningProfile` profile is not found, signing is skipped gracefully.