### PR TITLE
feat(genai): gate tool-call content extraction behind opt-in flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- feat(genai): gate gen_ai.tool.call.arguments/result extraction behind AWS_GENAI_LATEST_LLO_CONTENT_EXTRACTION_OPT_IN (default off)
+  ([#831](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/831))
 - feat(genai): capture user input and agent output on llama_index invoke_agent spans
   ([#824](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/824))
 - fix(crewai): use native per-call token usage when crewai provides it

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_utils.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_utils.py
@@ -13,6 +13,7 @@ _logger: Logger = getLogger(__name__)
 AGENT_OBSERVABILITY_ENABLED = "AGENT_OBSERVABILITY_ENABLED"
 OTEL_METRICS_ADD_APPLICATION_SIGNALS_DIMENSIONS = "OTEL_METRICS_ADD_APPLICATION_SIGNALS_DIMENSIONS"
 AWS_GENAI_CONTENT_EXTRACTION_OPT_OUT = "AWS_GENAI_CONTENT_EXTRACTION_OPT_OUT"
+AWS_GENAI_LATEST_LLO_CONTENT_EXTRACTION_OPT_IN = "AWS_GENAI_LATEST_LLO_CONTENT_EXTRACTION_OPT_IN"
 
 
 def is_installed(req: str) -> bool:
@@ -43,6 +44,11 @@ def is_agent_observability_enabled() -> bool:
 def is_genai_content_extraction_opted_out() -> bool:
     """Has the user opted out of GenAI content extraction from spans?"""
     return os.environ.get(AWS_GENAI_CONTENT_EXTRACTION_OPT_OUT, "false").lower() == "true"
+
+
+def is_genai_latest_llo_content_extraction_opted_in() -> bool:
+    """Has the user opted in to extracting the latest (experimental) LLO content?"""
+    return os.environ.get(AWS_GENAI_LATEST_LLO_CONTENT_EXTRACTION_OPT_IN, "false").lower() == "true"
 
 
 def should_add_application_signals_dimensions() -> bool:

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/llo_handler.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/llo_handler.py
@@ -5,6 +5,7 @@ import re
 from enum import Enum
 from typing import Any, Dict, List, Optional, Sequence, TypedDict
 
+from amazon.opentelemetry.distro._utils import is_genai_latest_llo_content_extraction_opted_in
 from opentelemetry._events import Event
 from opentelemetry.attributes import BoundedAttributes
 from opentelemetry.sdk._events import EventLoggerProvider
@@ -37,6 +38,7 @@ class PatternConfig(TypedDict, total=False):
     role: Optional[str]
     default_role: Optional[str]
     source: str
+    is_experimental: bool
 
 
 LLO_PATTERNS: Dict[str, PatternConfig] = {
@@ -186,11 +188,13 @@ LLO_PATTERNS: Dict[str, PatternConfig] = {
         "type": PatternType.DIRECT,
         "role": ROLE_TOOL,
         "source": "input",
+        "is_experimental": True,
     },
     "gen_ai.tool.call.result": {
         "type": PatternType.DIRECT,
         "role": ROLE_TOOL,
         "source": "output",
+        "is_experimental": True,
     },
 }
 
@@ -238,7 +242,12 @@ class LLOHandler:
         self._regex_patterns = []
         self._pattern_configs = {}
 
+        experimental_opted_in = is_genai_latest_llo_content_extraction_opted_in()
+
         for pattern_key, config in LLO_PATTERNS.items():
+            if config.get("is_experimental") and not experimental_opted_in:
+                continue
+
             if config["type"] == PatternType.DIRECT:
                 self._exact_match_patterns.add(pattern_key)
                 self._pattern_configs[pattern_key] = config

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/llo_handler/test_llo_handler_base.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/llo_handler/test_llo_handler_base.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Base test utilities for LLO Handler tests."""
+
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
@@ -19,10 +20,16 @@ class LLOHandlerTestBase(TestCase):
         self.event_logger_provider_mock = MagicMock()
         self.event_logger_provider_mock.get_event_logger.return_value = self.event_logger_mock
 
+        self.llo_handler = self._create_handler()
+
+    def _create_handler(self, env=None):
         with patch(
             "amazon.opentelemetry.distro.llo_handler.EventLoggerProvider", return_value=self.event_logger_provider_mock
         ):
-            self.llo_handler = LLOHandler(self.logger_provider_mock)
+            if env is not None:
+                with patch.dict("os.environ", env):
+                    return LLOHandler(self.logger_provider_mock)
+            return LLOHandler(self.logger_provider_mock)
 
     @staticmethod
     def _create_mock_span(attributes=None, kind=SpanKind.INTERNAL, preserve_none=False):

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/llo_handler/test_llo_handler_collection.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/llo_handler/test_llo_handler_collection.py
@@ -46,11 +46,9 @@ class TestLLOHandlerCollection(LLOHandlerTestBase):
         self.assertEqual(message["role"], "user")
         self.assertEqual(message["source"], "prompt")
 
-    def test_collect_gen_ai_tool_call_content(self):
-        """
-        Verify gen_ai.tool.call.arguments/result are collected with role=tool and routed by source
-        (arguments -> input, result -> output).
-        """
+    def test_collect_gen_ai_tool_call_content_when_enabled(self):
+        """Verify tool.call.arguments/result are collected (args -> input, result -> output) when opted in."""
+        handler = self._create_handler(env={"AWS_GENAI_LATEST_LLO_CONTENT_EXTRACTION_OPT_IN": "true"})
         attributes = {
             "gen_ai.tool.call.arguments": '{"city": "Paris"}',
             "gen_ai.tool.call.result": "72F and sunny",
@@ -58,7 +56,7 @@ class TestLLOHandlerCollection(LLOHandlerTestBase):
 
         span = self._create_mock_span(attributes)
 
-        messages = self.llo_handler._collect_all_llo_messages(span, attributes)
+        messages = handler._collect_all_llo_messages(span, attributes)
 
         by_content = {msg["content"]: msg for msg in messages}
         self.assertIn('{"city": "Paris"}', by_content)
@@ -71,6 +69,21 @@ class TestLLOHandlerCollection(LLOHandlerTestBase):
         result_message = by_content["72F and sunny"]
         self.assertEqual(result_message["role"], "tool")
         self.assertEqual(result_message["source"], "output")
+
+    def test_collect_gen_ai_tool_call_content_disabled_by_default(self):
+        """Verify tool.call.arguments/result are NOT collected when the opt-in flag is unset (default)."""
+        attributes = {
+            "gen_ai.tool.call.arguments": '{"city": "Paris"}',
+            "gen_ai.tool.call.result": "72F and sunny",
+        }
+
+        span = self._create_mock_span(attributes)
+
+        messages = self.llo_handler._collect_all_llo_messages(span, attributes)
+
+        contents = {msg["content"] for msg in messages}
+        self.assertNotIn('{"city": "Paris"}', contents)
+        self.assertNotIn("72F and sunny", contents)
 
     def test_collect_gen_ai_prompt_messages_assistant_role(self):
         """

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/llo_handler/test_llo_handler_patterns.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/llo_handler/test_llo_handler_patterns.py
@@ -124,8 +124,15 @@ class TestLLOHandlerPatterns(LLOHandlerTestBase):
         self.assertTrue(self.llo_handler._is_llo_attribute("gen_ai.input.messages"))
         self.assertTrue(self.llo_handler._is_llo_attribute("gen_ai.output.messages"))
         self.assertTrue(self.llo_handler._is_llo_attribute("gen_ai.system_instructions"))
-        self.assertTrue(self.llo_handler._is_llo_attribute("gen_ai.tool.call.arguments"))
-        self.assertTrue(self.llo_handler._is_llo_attribute("gen_ai.tool.call.result"))
+
+    def test_is_llo_attribute_tool_call_content_gated_by_capture_flag(self):
+        """Verify tool.call.arguments/result are recognized as LLO attributes only when opted in."""
+        self.assertFalse(self.llo_handler._is_llo_attribute("gen_ai.tool.call.arguments"))
+        self.assertFalse(self.llo_handler._is_llo_attribute("gen_ai.tool.call.result"))
+
+        handler = self._create_handler(env={"AWS_GENAI_LATEST_LLO_CONTENT_EXTRACTION_OPT_IN": "true"})
+        self.assertTrue(handler._is_llo_attribute("gen_ai.tool.call.arguments"))
+        self.assertTrue(handler._is_llo_attribute("gen_ai.tool.call.result"))
 
     def test_is_llo_attribute_otel_genai_patterns_no_match(self):
         """

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_utils.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_utils.py
@@ -9,10 +9,12 @@ from unittest.mock import MagicMock, patch
 from amazon.opentelemetry.distro._utils import (
     AGENT_OBSERVABILITY_ENABLED,
     AWS_GENAI_CONTENT_EXTRACTION_OPT_OUT,
+    AWS_GENAI_LATEST_LLO_CONTENT_EXTRACTION_OPT_IN,
     get_aws_region,
     get_aws_session,
     is_agent_observability_enabled,
     is_genai_content_extraction_opted_out,
+    is_genai_latest_llo_content_extraction_opted_in,
     is_installed,
 )
 
@@ -201,3 +203,26 @@ class TestUtils(TestCase):
         if AWS_GENAI_CONTENT_EXTRACTION_OPT_OUT in os.environ:
             del os.environ[AWS_GENAI_CONTENT_EXTRACTION_OPT_OUT]
         self.assertFalse(is_genai_content_extraction_opted_out())
+
+    def test_is_genai_latest_llo_content_extraction_opted_in_various_values(self):
+        os.environ[AWS_GENAI_LATEST_LLO_CONTENT_EXTRACTION_OPT_IN] = "true"
+        self.assertTrue(is_genai_latest_llo_content_extraction_opted_in())
+
+        os.environ[AWS_GENAI_LATEST_LLO_CONTENT_EXTRACTION_OPT_IN] = "True"
+        self.assertTrue(is_genai_latest_llo_content_extraction_opted_in())
+
+        os.environ[AWS_GENAI_LATEST_LLO_CONTENT_EXTRACTION_OPT_IN] = "TRUE"
+        self.assertTrue(is_genai_latest_llo_content_extraction_opted_in())
+
+        os.environ[AWS_GENAI_LATEST_LLO_CONTENT_EXTRACTION_OPT_IN] = "false"
+        self.assertFalse(is_genai_latest_llo_content_extraction_opted_in())
+
+        os.environ[AWS_GENAI_LATEST_LLO_CONTENT_EXTRACTION_OPT_IN] = "False"
+        self.assertFalse(is_genai_latest_llo_content_extraction_opted_in())
+
+        os.environ[AWS_GENAI_LATEST_LLO_CONTENT_EXTRACTION_OPT_IN] = ""
+        self.assertFalse(is_genai_latest_llo_content_extraction_opted_in())
+
+        if AWS_GENAI_LATEST_LLO_CONTENT_EXTRACTION_OPT_IN in os.environ:
+            del os.environ[AWS_GENAI_LATEST_LLO_CONTENT_EXTRACTION_OPT_IN]
+        self.assertFalse(is_genai_latest_llo_content_extraction_opted_in())


### PR DESCRIPTION
## Description

Follow-up to #816. That PR added `gen_ai.tool.call.arguments` and `gen_ai.tool.call.result` to the LLO pattern registry, so the distro extracts tool-call arguments/results off `execute_tool` spans into Gen AI events **and strips them from the span**.

Two reasons to gate this:

1. **Behavior change.** Before #816 these attributes stayed on the span; consumers reading them directly break on upgrade.

## Change

- New env var **`AWS_GENAI_LATEST_LLO_CONTENT_EXTRACTION_OPT_IN`** (default **off**), read via `is_genai_latest_llo_content_extraction_opted_in()` in `_utils.py`.
- New `is_experimental` marker on `PatternConfig`; the two `gen_ai.tool.call.*` patterns are tagged with it.
- `_build_pattern_matchers` skips experimental patterns unless the user opts in. Skipping means the attribute is **neither extracted nor stripped** — it stays on the span, restoring pre-#816 behavior.
- Future opt-in/sensitive attributes reuse the same flag by marking their pattern experimental — no new plumbing.

## Testing

- `is_genai_latest_llo_content_extraction_opted_in()` boolean parsing (`test_utils.py`).
- Tool-call content collected + routed only when opted in; not collected by default (`test_llo_handler_collection.py`).
- `_is_llo_attribute` recognizes the two attributes only when opted in (`test_llo_handler_patterns.py`).
- Full `llo_handler` + `test_utils` suites pass (99 tests); black/isort/flake8/pylint clean.

## Notes for reviewers

- Enforcement is inside the pattern registry (not the exporter-wide gate), so only tool-call content is affected — prompts/completions are untouched.
- Open question: a plain boolean vs. a `no_content`/`span_only`/`event_only`/`span_and_event` mode (upstream `openai-agents-v2` uses the latter). Went with a boolean for simplicity; happy to revisit.