### PR TITLE
Removed chaining of EKS tests

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -128,21 +128,9 @@ jobs:
   # DOCKER DISTRIBUTION LANGUAGE VERSION COVERAGE
   # DEFAULT SETTING: {Python Version}, EKS, AMD64, AL2
   #
-  # The Application Signals addon is cluster-wide. It is installed ONCE by eks-enable-appsignals
-  # before the version jobs fan out in parallel, and removed ONCE by eks-cleanup-appsignals after
-  # they all finish. The per-version jobs no longer install/delete the addon themselves.
-
-  eks-enable-appsignals:
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/eks-enable-appsignals.yml@EKS-test-fix
-    secrets: inherit
-    with:
-      aws-region: us-east-1
-      test-cluster-name: 'e2e-python-adot-test'
-      caller-workflow-name: 'main-build'
 
   eks-py310-amd64:
     if: ${{ always() }}
-    needs: eks-enable-appsignals
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@EKS-test-fix
     secrets: inherit
     with:
@@ -154,7 +142,6 @@ jobs:
 
   eks-py311-amd64:
     if: ${{ always() }}
-    needs: eks-enable-appsignals
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@EKS-test-fix
     secrets: inherit
     with:
@@ -166,7 +153,6 @@ jobs:
 
   eks-py312-amd64:
     if: ${{ always() }}
-    needs: eks-enable-appsignals
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@EKS-test-fix
     secrets: inherit
     with:
@@ -178,7 +164,6 @@ jobs:
 
   eks-py313-amd64:
     if: ${{ always() }}
-    needs: eks-enable-appsignals
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@EKS-test-fix
     secrets: inherit
     with:
@@ -190,7 +175,6 @@ jobs:
 
   eks-py314-amd64:
     if: ${{ always() }}
-    needs: eks-enable-appsignals
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@EKS-test-fix
     secrets: inherit
     with:
@@ -199,18 +183,6 @@ jobs:
       adot-image-name: ${{ inputs.adot-image-name }}
       caller-workflow-name: 'main-build'
       python-version: '3.14'
-
-  eks-cleanup-appsignals:
-    # Runs once after all version jobs. `if: always()` so the shared addon is removed even if some
-    # version jobs failed — otherwise it leaks and the next run's enable races with a lingering addon.
-    if: ${{ always() }}
-    needs: [ eks-py310-amd64, eks-py311-amd64, eks-py312-amd64, eks-py313-amd64, eks-py314-amd64 ]
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/eks-cleanup-appsignals.yml@EKS-test-fix
-    secrets: inherit
-    with:
-      aws-region: us-east-1
-      test-cluster-name: 'e2e-python-adot-test'
-      caller-workflow-name: 'main-build'
 
   #
   # PACKAGED DISTRIBUTION PLATFORM COVERAGE
@@ -332,11 +304,9 @@ jobs:
 
   service-events-eks:
     if: ${{ always() }}
-    # Serialized after the parallel version matrix AND its addon cleanup. This test shares the
-    # cluster/NodePort with the eks-py* jobs and manages its OWN Application Signals addon lifecycle
-    # (via python-eks-service-events-test.yml@main), so it must run after eks-cleanup-appsignals has
-    # removed the shared addon — otherwise the two addon lifecycles collide.
-    needs: eks-cleanup-appsignals
+    # Chain onto the tail of the eks-py* jobs, service-events-eks shares a NodePort with these jobs,
+    # for now we do not parallelize this test to keep things simple
+    needs: eks-py314-amd64
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-service-events-test.yml@main
     secrets: inherit
     with:

--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -142,7 +142,6 @@ jobs:
 
   eks-py311-amd64:
     if: ${{ always() }}
-    needs: eks-py310-amd64
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@main
     secrets: inherit
     with:
@@ -154,7 +153,6 @@ jobs:
 
   eks-py312-amd64:
     if: ${{ always() }}
-    needs: eks-py311-amd64
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@main
     secrets: inherit
     with:
@@ -166,7 +164,6 @@ jobs:
 
   eks-py313-amd64:
     if: ${{ always() }}
-    needs: eks-py312-amd64
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@main
     secrets: inherit
     with:
@@ -178,7 +175,6 @@ jobs:
 
   eks-py314-amd64:
     if: ${{ always() }}
-    needs: eks-py313-amd64
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@main
     secrets: inherit
     with:
@@ -294,10 +290,8 @@ jobs:
 
   service-events-eks:
     if: ${{ always() }}
-    # Chain onto the tail of the eks-py* jobs: they all target e2e-python-adot-test and the
-    # sample-app Service binds cluster-wide NodePort 30100, which this SE test also uses. Running
-    # in parallel would collide on that port ("provided port is already allocated"), so serialize
-    # after the last eks-py* job, matching how eks-py311..314 chain via needs.
+    # Chain onto the tail of the eks-py* jobs, service-events-eks shares a NodePort with these jobs,
+    # for now we do not parallelize this test to keep things simple
     needs: eks-py314-amd64
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-service-events-test.yml@main
     secrets: inherit

--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -131,6 +131,8 @@ jobs:
 
   eks-py310-amd64:
     if: ${{ always() }}
+    # Run after service-events-eks so it gets the clean (default-image) operator it needs first.
+    needs: service-events-eks
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@EKS-test-fix
     secrets: inherit
     with:
@@ -142,6 +144,8 @@ jobs:
 
   eks-py311-amd64:
     if: ${{ always() }}
+    # Run after service-events-eks so it gets the clean (default-image) operator it needs first.
+    needs: service-events-eks
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@EKS-test-fix
     secrets: inherit
     with:
@@ -153,6 +157,8 @@ jobs:
 
   eks-py312-amd64:
     if: ${{ always() }}
+    # Run after service-events-eks so it gets the clean (default-image) operator it needs first.
+    needs: service-events-eks
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@EKS-test-fix
     secrets: inherit
     with:
@@ -164,6 +170,8 @@ jobs:
 
   eks-py313-amd64:
     if: ${{ always() }}
+    # Run after service-events-eks so it gets the clean (default-image) operator it needs first.
+    needs: service-events-eks
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@EKS-test-fix
     secrets: inherit
     with:
@@ -175,6 +183,8 @@ jobs:
 
   eks-py314-amd64:
     if: ${{ always() }}
+    # Run after service-events-eks so it gets the clean (default-image) operator it needs first.
+    needs: service-events-eks
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@EKS-test-fix
     secrets: inherit
     with:
@@ -303,10 +313,13 @@ jobs:
       staging-wheel-name: ${{ inputs.staging-wheel-name }}
 
   service-events-eks:
-    if: ${{ always() }}
-    # Chain onto the tail of the eks-py* jobs, service-events-eks shares a NodePort with these jobs,
-    # for now we do not parallelize this test to keep things simple
-    needs: eks-py314-amd64
+    # Runs FIRST, alone, before the parallel eks-py* jobs (which declare `needs: service-events-eks`).
+    # service-events uses the shared patch_image_and_check_diff action, which asserts the operator's
+    # ADOT image *changed* (default -> staging). That only holds on an operator still at the default
+    # image. The parallel eks-py* jobs patch the shared cluster-wide operator to the staging image and
+    # intentionally do not revert it (revert would break sibling jobs), so if service-events ran after
+    # them it would see the operator already on staging and the diff check would fail. Running it first,
+    # exclusively, gives it the clean operator state it expects without modifying the test itself.
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-service-events-test.yml@main
     secrets: inherit
     with:

--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -128,9 +128,21 @@ jobs:
   # DOCKER DISTRIBUTION LANGUAGE VERSION COVERAGE
   # DEFAULT SETTING: {Python Version}, EKS, AMD64, AL2
   #
+  # The Application Signals addon is cluster-wide. It is installed ONCE by eks-enable-appsignals
+  # before the version jobs fan out in parallel, and removed ONCE by eks-cleanup-appsignals after
+  # they all finish. The per-version jobs no longer install/delete the addon themselves.
+
+  eks-enable-appsignals:
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/eks-enable-appsignals.yml@EKS-test-fix
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      test-cluster-name: 'e2e-python-adot-test'
+      caller-workflow-name: 'main-build'
 
   eks-py310-amd64:
     if: ${{ always() }}
+    needs: eks-enable-appsignals
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@EKS-test-fix
     secrets: inherit
     with:
@@ -142,6 +154,7 @@ jobs:
 
   eks-py311-amd64:
     if: ${{ always() }}
+    needs: eks-enable-appsignals
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@EKS-test-fix
     secrets: inherit
     with:
@@ -153,6 +166,7 @@ jobs:
 
   eks-py312-amd64:
     if: ${{ always() }}
+    needs: eks-enable-appsignals
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@EKS-test-fix
     secrets: inherit
     with:
@@ -164,6 +178,7 @@ jobs:
 
   eks-py313-amd64:
     if: ${{ always() }}
+    needs: eks-enable-appsignals
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@EKS-test-fix
     secrets: inherit
     with:
@@ -175,6 +190,7 @@ jobs:
 
   eks-py314-amd64:
     if: ${{ always() }}
+    needs: eks-enable-appsignals
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@EKS-test-fix
     secrets: inherit
     with:
@@ -183,6 +199,18 @@ jobs:
       adot-image-name: ${{ inputs.adot-image-name }}
       caller-workflow-name: 'main-build'
       python-version: '3.14'
+
+  eks-cleanup-appsignals:
+    # Runs once after all version jobs. `if: always()` so the shared addon is removed even if some
+    # version jobs failed — otherwise it leaks and the next run's enable races with a lingering addon.
+    if: ${{ always() }}
+    needs: [ eks-py310-amd64, eks-py311-amd64, eks-py312-amd64, eks-py313-amd64, eks-py314-amd64 ]
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/eks-cleanup-appsignals.yml@EKS-test-fix
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      test-cluster-name: 'e2e-python-adot-test'
+      caller-workflow-name: 'main-build'
 
   #
   # PACKAGED DISTRIBUTION PLATFORM COVERAGE
@@ -304,9 +332,11 @@ jobs:
 
   service-events-eks:
     if: ${{ always() }}
-    # Chain onto the tail of the eks-py* jobs, service-events-eks shares a NodePort with these jobs,
-    # for now we do not parallelize this test to keep things simple
-    needs: eks-py314-amd64
+    # Serialized after the parallel version matrix AND its addon cleanup. This test shares the
+    # cluster/NodePort with the eks-py* jobs and manages its OWN Application Signals addon lifecycle
+    # (via python-eks-service-events-test.yml@main), so it must run after eks-cleanup-appsignals has
+    # removed the shared addon — otherwise the two addon lifecycles collide.
+    needs: eks-cleanup-appsignals
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-service-events-test.yml@main
     secrets: inherit
     with:

--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -131,7 +131,7 @@ jobs:
 
   eks-py310-amd64:
     if: ${{ always() }}
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@main
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@EKS-test-fix
     secrets: inherit
     with:
       aws-region: us-east-1
@@ -142,7 +142,7 @@ jobs:
 
   eks-py311-amd64:
     if: ${{ always() }}
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@main
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@EKS-test-fix
     secrets: inherit
     with:
       aws-region: us-east-1
@@ -153,7 +153,7 @@ jobs:
 
   eks-py312-amd64:
     if: ${{ always() }}
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@main
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@EKS-test-fix
     secrets: inherit
     with:
       aws-region: us-east-1
@@ -164,7 +164,7 @@ jobs:
 
   eks-py313-amd64:
     if: ${{ always() }}
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@main
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@EKS-test-fix
     secrets: inherit
     with:
       aws-region: us-east-1
@@ -175,7 +175,7 @@ jobs:
 
   eks-py314-amd64:
     if: ${{ always() }}
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@main
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@EKS-test-fix
     secrets: inherit
     with:
       aws-region: us-east-1

--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -131,8 +131,6 @@ jobs:
 
   eks-py310-amd64:
     if: ${{ always() }}
-    # Run after service-events-eks so it gets the clean (default-image) operator it needs first.
-    needs: service-events-eks
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@EKS-test-fix
     secrets: inherit
     with:
@@ -144,8 +142,6 @@ jobs:
 
   eks-py311-amd64:
     if: ${{ always() }}
-    # Run after service-events-eks so it gets the clean (default-image) operator it needs first.
-    needs: service-events-eks
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@EKS-test-fix
     secrets: inherit
     with:
@@ -157,8 +153,6 @@ jobs:
 
   eks-py312-amd64:
     if: ${{ always() }}
-    # Run after service-events-eks so it gets the clean (default-image) operator it needs first.
-    needs: service-events-eks
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@EKS-test-fix
     secrets: inherit
     with:
@@ -170,8 +164,6 @@ jobs:
 
   eks-py313-amd64:
     if: ${{ always() }}
-    # Run after service-events-eks so it gets the clean (default-image) operator it needs first.
-    needs: service-events-eks
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@EKS-test-fix
     secrets: inherit
     with:
@@ -183,8 +175,6 @@ jobs:
 
   eks-py314-amd64:
     if: ${{ always() }}
-    # Run after service-events-eks so it gets the clean (default-image) operator it needs first.
-    needs: service-events-eks
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@EKS-test-fix
     secrets: inherit
     with:
@@ -313,14 +303,17 @@ jobs:
       staging-wheel-name: ${{ inputs.staging-wheel-name }}
 
   service-events-eks:
-    # Runs FIRST, alone, before the parallel eks-py* jobs (which declare `needs: service-events-eks`).
-    # service-events uses the shared patch_image_and_check_diff action, which asserts the operator's
-    # ADOT image *changed* (default -> staging). That only holds on an operator still at the default
-    # image. The parallel eks-py* jobs patch the shared cluster-wide operator to the staging image and
-    # intentionally do not revert it (revert would break sibling jobs), so if service-events ran after
-    # them it would see the operator already on staging and the diff check would fail. Running it first,
-    # exclusively, gives it the clean operator state it expects without modifying the test itself.
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-service-events-test.yml@main
+    if: ${{ always() }}
+    # Runs LAST, after ALL parallel eks-py* jobs complete, so no parallel job is alive when it tears
+    # down and rebuilds shared cluster state. service-events uses the shared patch_image_and_check_diff
+    # action (asserts the operator ADOT image changed default -> staging) and its own teardown fully
+    # removes/reinstalls the amazon-cloudwatch-observability addon -- behavior that is only safe when it
+    # runs exclusively. Gating on all five eks-py jobs guarantees exclusivity; it then rebuilds the addon
+    # from scratch (operator back to default image) exactly as it did in the original sequential design,
+    # so no changes to the service-events test itself are needed.
+    needs: [ eks-py310-amd64, eks-py311-amd64, eks-py312-amd64, eks-py313-amd64, eks-py314-amd64 ]
+    # TESTING: pinned to EKS-test-fix for the addon-rebuild step; REVERT to @main before merge.
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-service-events-test.yml@EKS-test-fix
     secrets: inherit
     with:
       aws-region: us-east-1

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -570,10 +570,18 @@ jobs:
         if: steps.ecr-signing-profile.outputs.profile_arn != ''
         continue-on-error: true
         run: |
-          # Sign the released public ECR image
-          notation sign ${{ env.RELEASE_PUBLIC_REPOSITORY }}:v${{ env.VERSION }} \
+          # notation needs a digest ref to store the signature via the Referrers API,
+          # which avoids publishing the extra "sha256-<digest>" fallback tag.
+          DIGEST=$(aws ecr-public describe-image-tags \
+            --repository-name adot-autoinstrumentation-python \
+            --region ${{ env.AWS_PUBLIC_ECR_REGION }} \
+            --query "imageTagDetails[?imageTag=='v${{ env.VERSION }}'].imageDetail.imageDigest | [0]" \
+            --output text)
+          if [ -z "$DIGEST" ] || [ "$DIGEST" = "None" ]; then
+            echo "Could not resolve a digest for v${{ env.VERSION }}; skipping image signing."
+            exit 0
+          fi
+          notation sign ${{ env.RELEASE_PUBLIC_REPOSITORY }}@${DIGEST} \
+            --force-referrers-tag=false \
             --plugin com.amazonaws.signer.notation.plugin \
             --id ${{ steps.ecr-signing-profile.outputs.profile_arn }}
-          echo "Successfully signed public ECR image"
-          echo "Image: ${{ env.RELEASE_PUBLIC_REPOSITORY }}:v${{ env.VERSION }}"
-          echo "Profile ARN: ${{ steps.ecr-signing-profile.outputs.profile_arn }}"


### PR DESCRIPTION
*Issue #, if available:*
EKS tests run sequentially because we reuse the same cluster for all language versions supported, for ADOT Python. EKS tests are currently hard-coded to executed sequentially as a result.

*Description of changes:*
In order to accommodate the changes made in the testing framework repository (PR: https://github.com/aws-observability/aws-application-signals-test-framework/pull/668) we would need to remove the hardcoded order of sequential test execution. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

