### PR TITLE
Sign ECR image by digest to avoid referrers fallback tag

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -570,10 +570,18 @@ jobs:
         if: steps.ecr-signing-profile.outputs.profile_arn != ''
         continue-on-error: true
         run: |
-          # Sign the released public ECR image
-          notation sign ${{ env.RELEASE_PUBLIC_REPOSITORY }}:v${{ env.VERSION }} \
+          # notation needs a digest ref to store the signature via the Referrers API,
+          # which avoids publishing the extra "sha256-<digest>" fallback tag.
+          DIGEST=$(aws ecr-public describe-image-tags \
+            --repository-name adot-autoinstrumentation-python \
+            --region ${{ env.AWS_PUBLIC_ECR_REGION }} \
+            --query "imageTagDetails[?imageTag=='v${{ env.VERSION }}'].imageDetail.imageDigest | [0]" \
+            --output text)
+          if [ -z "$DIGEST" ] || [ "$DIGEST" = "None" ]; then
+            echo "Could not resolve a digest for v${{ env.VERSION }}; skipping image signing."
+            exit 0
+          fi
+          notation sign ${{ env.RELEASE_PUBLIC_REPOSITORY }}@${DIGEST} \
+            --force-referrers-tag=false \
             --plugin com.amazonaws.signer.notation.plugin \
             --id ${{ steps.ecr-signing-profile.outputs.profile_arn }}
-          echo "Successfully signed public ECR image"
-          echo "Image: ${{ env.RELEASE_PUBLIC_REPOSITORY }}:v${{ env.VERSION }}"
-          echo "Profile ARN: ${{ steps.ecr-signing-profile.outputs.profile_arn }}"


### PR DESCRIPTION
## Description

When signing the public ECR image, notation was publishing an extra `sha256-<digest>` **referrers fallback tag** into the repository. That tag shows up in the ECR Public Gallery's tag list (which is AWS-managed and not filterable on our side), polluting the list of ADOT SDK image versions users see.

## Changes

- Sign the image **by digest** with `--force-referrers-tag=false`, so the signature is stored via the OCI **Referrers API** (verified to be supported by public ECR) instead of a fallback tag. No `sha256-<digest>` tag is published.
- Resolve the `v<version>` tag to a digest with `aws ecr-public describe-image-tags` — uses the existing `ecr-public:DescribeImageTags` permission, **no IAM change needed**.
- Skip signing gracefully if the digest can't be resolved.

## Verification

Tested end-to-end in a personal AWS account against a real public ECR repo: with `--force-referrers-tag=false` + digest reference, **no fallback tag was created** and the signature remained discoverable via the Referrers API (`notation verify` path unaffected).