### PR TITLE
fix(genai): capture Bedrock/Anthropic token-usage key variants in crewai and langchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- fix(genai): capture per-call token usage for Amazon Bedrock (and Anthropic) in crewai and langchain by reading provider-specific usage keys — crewai's Converse `inputTokens`/`outputTokens` and langchain's `ChatBedrockConverse` message `usage_metadata`
+  ([#838](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/838))
 - fix(mcp): fall back to HTTP headers for server-side trace context when `params._meta` is absent
   ([#829](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/829))
 - fix(mcp-instrumentation): always inject W3C trace context into outbound HTTP request headers so MCP servers that read context only from HTTP (API Gateways, service meshes, non-Python MCP servers) can join the caller's trace, even with `OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION` enabled

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/crewai/_event_handler.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/crewai/_event_handler.py
@@ -402,8 +402,18 @@ class OpenTelemetryEventHandler:
         prev_prompt_tokens, prev_completion_tokens = self._event_id_to_token_usage.pop(event.started_event_id) or (0, 0)
         event_usage = getattr(event, "usage", None)
         if isinstance(event_usage, dict):
-            input_tokens = event_usage.get("prompt_tokens") or 0
-            output_tokens = event_usage.get("completion_tokens") or 0
+            input_tokens = (
+                event_usage.get("prompt_tokens")
+                or event_usage.get("inputTokens")
+                or event_usage.get("input_tokens")
+                or 0
+            )
+            output_tokens = (
+                event_usage.get("completion_tokens")
+                or event_usage.get("outputTokens")
+                or event_usage.get("output_tokens")
+                or 0
+            )
         else:
             usage: "UsageMetrics" = source.get_token_usage_summary()
             input_tokens = usage.prompt_tokens - prev_prompt_tokens

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/langchain/callback_handler.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/langchain/callback_handler.py
@@ -173,15 +173,9 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
             return
         span, _ = entry
         llm_output: dict | None = response.llm_output
-        usage: dict = (llm_output.get("token_usage") or llm_output.get("usage") or {}) if llm_output else {}
         model: str | None = (llm_output.get("model_name") or llm_output.get("model_id")) if llm_output else None
         response_id: str | None = llm_output.get("id") if llm_output else None
-        input_tokens: int | None = (
-            usage.get("prompt_tokens") or usage.get("input_token_count") or usage.get("input_tokens")
-        )
-        output_tokens: int | None = (
-            usage.get("completion_tokens") or usage.get("generated_token_count") or usage.get("output_tokens")
-        )
+        input_tokens, output_tokens = self._extract_token_usage(response)
 
         if response.generations:
             output_messages = self._format_lc_llm_output(response.generations)
@@ -200,6 +194,35 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
         self._set_span_attribute(span, GEN_AI_USAGE_OUTPUT_TOKENS, output_tokens)
 
         self._end_span(run_id)
+
+    @staticmethod
+    def _extract_token_usage(response: LLMResult) -> tuple[int | None, int | None]:
+        llm_output = response.llm_output
+        usage: dict = (llm_output.get("token_usage") or llm_output.get("usage") or {}) if llm_output else {}
+
+        usage_metadata: dict = {}
+        for batch in response.generations:
+            for gen in batch:
+                message_usage = getattr(getattr(gen, "message", None), "usage_metadata", None)
+                if message_usage:
+                    usage_metadata = message_usage
+                    break
+            if usage_metadata:
+                break
+
+        input_tokens: int | None = (
+            usage.get("prompt_tokens")
+            or usage.get("input_token_count")
+            or usage.get("input_tokens")
+            or usage_metadata.get("input_tokens")
+        )
+        output_tokens: int | None = (
+            usage.get("completion_tokens")
+            or usage.get("generated_token_count")
+            or usage.get("output_tokens")
+            or usage_metadata.get("output_tokens")
+        )
+        return input_tokens, output_tokens
 
     def on_llm_error(self, error: BaseException, *, run_id: UUID, **kwargs: Any) -> None:
         self._handle_error(error, run_id, **kwargs)

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/crewai/test_crewai_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/crewai/test_crewai_instrumentor.py
@@ -224,6 +224,41 @@ class TestCrewAIInstrumentor(TestCase):
         self.assertEqual(chat_span.attributes[GEN_AI_USAGE_INPUT_TOKENS], 123)
         self.assertEqual(chat_span.attributes[GEN_AI_USAGE_OUTPUT_TOKENS], 45)
 
+    def test_per_call_token_usage_provider_key_variants(self):
+        if "usage" not in LLMCallCompletedEvent.model_fields:
+            self.skipTest("crewai <1.13.0 does not report per-call usage on LLMCallCompletedEvent")
+
+        variants = [
+            ("openai", {"prompt_tokens": 11, "completion_tokens": 22}),
+            ("bedrock", {"inputTokens": 33, "outputTokens": 44, "totalTokens": 77}),
+            ("anthropic", {"input_tokens": 55, "output_tokens": 66}),
+        ]
+        for name, usage in variants:
+            with self.subTest(provider=name):
+                self.span_exporter.clear()
+                llm = LLM(model="openai/gpt-4", is_litellm=True)
+                start_event = LLMCallStartedEvent(call_id="c1", messages=[{"role": "user", "content": "hi"}])
+                crewai_event_bus.emit(llm, start_event)
+                crewai_event_bus.emit(
+                    llm,
+                    LLMCallCompletedEvent(
+                        call_id="c1",
+                        response="Hello",
+                        call_type=LLMCallType.LLM_CALL,
+                        started_event_id=start_event.event_id,
+                        usage=usage,
+                    ),
+                )
+
+                chat_span = self._find_span("chat")
+                self.assertIsNotNone(chat_span)
+                expected_input = usage.get("prompt_tokens") or usage.get("inputTokens") or usage.get("input_tokens")
+                expected_output = (
+                    usage.get("completion_tokens") or usage.get("outputTokens") or usage.get("output_tokens")
+                )
+                self.assertEqual(chat_span.attributes[GEN_AI_USAGE_INPUT_TOKENS], expected_input)
+                self.assertEqual(chat_span.attributes[GEN_AI_USAGE_OUTPUT_TOKENS], expected_output)
+
     def test_crew_kickoff_error_handling(self):
         mock_llm = MagicMock(spec=LLM)
         mock_llm.provider = "openai"

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/langchain/test_langchain_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/langchain/test_langchain_instrumentor.py
@@ -815,6 +815,88 @@ class TestLangChainInstrumentor(TestCase):
         chat_spans = [s for s in spans if "chat" in s.name]
         self.assertGreater(len(chat_spans), 0)
 
+    def test_token_usage_provider_key_variants(self):
+        from langchain_aws import ChatBedrock, ChatBedrockConverse
+        from langchain_openai import ChatOpenAI
+
+        def result_with_llm_output(usage):
+            return ChatResult(
+                generations=[
+                    ChatGeneration(message=AIMessage(content="Hello!"), generation_info={"finish_reason": "stop"})
+                ],
+                llm_output={"model_name": "test", "token_usage": usage},
+            )
+
+        def result_with_usage_metadata(usage_metadata):
+            return ChatResult(
+                generations=[
+                    ChatGeneration(
+                        message=AIMessage(content="Hello!", usage_metadata=usage_metadata),
+                        generation_info={"finish_reason": "stop"},
+                    )
+                ],
+                llm_output=None,
+            )
+
+        # (model class, init kwargs, fake result matching that provider's real usage shape, expected in/out)
+        cases = [
+            (
+                ChatOpenAI,
+                {"api_key": "fake"},
+                result_with_llm_output({"prompt_tokens": 11, "completion_tokens": 22}),
+                11,
+                22,
+            ),
+            (
+                ChatBedrock,
+                {"model_id": "test", "region_name": "us-east-1"},
+                result_with_llm_output({"prompt_tokens": 33, "completion_tokens": 44}),
+                33,
+                44,
+            ),
+            (
+                ChatBedrockConverse,
+                {"model": "test", "region_name": "us-east-1"},
+                result_with_usage_metadata({"input_tokens": 55, "output_tokens": 66, "total_tokens": 121}),
+                55,
+                66,
+            ),
+        ]
+
+        try:
+            from langchain_ibm import ChatWatsonx
+
+            cases.append(
+                (
+                    ChatWatsonx,
+                    {
+                        "model_id": "test",
+                        "url": "https://us-south.ml.cloud.ibm.com",
+                        "apikey": "fake",
+                        "project_id": "p",
+                    },
+                    result_with_llm_output({"input_token_count": 77, "generated_token_count": 88}),
+                    77,
+                    88,
+                )
+            )
+        except ImportError:
+            pass
+
+        for model_cls, init_kwargs, fake_result, expected_input, expected_output in cases:
+            with self.subTest(model=model_cls.__name__):
+                self.span_exporter.clear()
+                llm = model_cls(**init_kwargs)
+                with patch.object(type(llm), "_generate", return_value=fake_result):
+                    llm.invoke("Say hello")
+
+                spans = self.span_exporter.get_finished_spans()
+                chat_spans = [s for s in spans if "chat" in s.name]
+                self.assertGreaterEqual(len(chat_spans), 1, f"No chat span for {model_cls.__name__}")
+                attrs = chat_spans[0].attributes
+                self.assertEqual(attrs[GEN_AI_USAGE_INPUT_TOKENS], expected_input)
+                self.assertEqual(attrs[GEN_AI_USAGE_OUTPUT_TOKENS], expected_output)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
CrewAI only read the OpenAI-style token keys (`prompt_tokens`/`completion_tokens`), so per-call token usage was dropped on spans from providers that use different key names, most notably Amazon Bedrock (`inputTokens`/`outputTokens`). LangChain read token usage only from `llm_output`, which `ChatBedrockConverse` leaves empty (usage lands on each message's `usage_metadata` instead), so Bedrock Converse tokens were dropped there too. Extends CrewAI to read the Bedrock/Anthropic key variants and LangChain to fall back to `usage_metadata`, verified end-to-end against live Amazon Bedrock (CrewAI, ChatBedrock, and ChatBedrockConverse) plus unit tests covering OpenAI, Bedrock, Anthropic, and watsonx.