### PR TITLE
fix: redact AWS presigned URL credentials from span attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- fix: redact AWS presigned URL credentials from span attributes
+  ([#840](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/840))
 - fix(genai): capture per-call token usage for Amazon Bedrock (and Anthropic) in crewai and langchain by reading provider-specific usage keys — crewai's Converse `inputTokens`/`outputTokens` and langchain's `ChatBedrockConverse` message `usage_metadata`
   ([#838](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/838))
 - fix(mcp): fall back to HTTP headers for server-side trace context when `params._meta` is absent

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_instrumentation_patch.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_instrumentation_patch.py
@@ -18,6 +18,14 @@ def apply_instrumentation_patches() -> None:  # pylint: disable=too-many-branche
 
     Where possible, automated testing should be run to catch upstream changes resulting in broken patches
     """
+    # Redact AWS SigV4 pre-signed URL credentials from captured HTTP URLs. Applied unconditionally
+    # because it hardens URL sanitization for every HTTP client instrumentation and has no external
+    # dependency of its own.
+    # pylint: disable=import-outside-toplevel
+    from amazon.opentelemetry.distro.patches._url_query_redaction_patches import _apply_url_query_redaction_patches
+
+    _apply_url_query_redaction_patches()
+
     if is_installed("botocore ~= 1.0"):
         # pylint: disable=import-outside-toplevel
         # Delay import to only occur if patches is safe to apply (e.g. the instrumented library is installed).

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_url_query_redaction_patches.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/patches/_url_query_redaction_patches.py
@@ -1,0 +1,48 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Patch for OpenTelemetry HTTP URL query-parameter redaction.
+
+Upstream ``opentelemetry.util.http.PARAMS_TO_REDACT`` omits the SigV4/SigV4a query-string
+authentication parameters, so an AWS presigned URL captured on a raw HTTP client span would leak
+the signature and credential scope via ``url.full`` / ``http.url``. This patch extends that list
+in place; because ``redact_query_parameters`` reads it as a module-level global at call time, the
+new parameters apply to every HTTP instrumentation that calls ``redact_url``.
+
+Upstream redaction blanks the value and keeps the parameter key, so the non-sensitive SigV4
+parameters that presigned URL attribution reads remain intact.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# SigV4/SigV4a query-string authentication parameters that carry sensitive material and are not
+# already in the upstream default list. Parameter names are matched case-sensitively by
+# ``redact_query_parameters`` (it compares against ``parse_qs`` keys), so these must match the
+# exact casing AWS emits.
+_AWS_SIGV4_SENSITIVE_QUERY_PARAMETERS = [
+    "X-Amz-Signature",
+    "X-Amz-Credential",
+    "X-Amz-Security-Token",
+]
+
+
+def _apply_url_query_redaction_patches() -> None:
+    """Extend the upstream sensitive-query-parameter list with AWS SigV4 credentials."""
+    try:
+        # pylint: disable=import-outside-toplevel
+        from opentelemetry.util import http as otel_util_http
+    except ImportError:
+        logger.warning("Failed to apply URL query redaction patch: opentelemetry.util.http not available")
+        return
+
+    params_to_redact = getattr(otel_util_http, "PARAMS_TO_REDACT", None)
+    if params_to_redact is None:
+        logger.warning("Failed to apply URL query redaction patch: PARAMS_TO_REDACT not available")
+        return
+
+    for param in _AWS_SIGV4_SENSITIVE_QUERY_PARAMETERS:
+        if param not in params_to_redact:
+            params_to_redact.append(param)

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/patches/test_url_query_redaction_patches.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/patches/test_url_query_redaction_patches.py
@@ -1,0 +1,104 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for AWS SigV4 pre-signed URL query-parameter redaction patch."""
+
+import unittest
+from unittest.mock import patch
+
+from amazon.opentelemetry.distro.patches._url_query_redaction_patches import (
+    _AWS_SIGV4_SENSITIVE_QUERY_PARAMETERS,
+    _apply_url_query_redaction_patches,
+)
+from opentelemetry.util import http as otel_util_http
+from opentelemetry.util.http import redact_url
+
+
+class TestUrlQueryRedactionPatches(unittest.TestCase):
+    """Test cases for the URL query redaction patch."""
+
+    def setUp(self):
+        # Snapshot the module-level list so each test starts from a clean state and mutations do
+        # not leak between tests (the patch mutates this list in place).
+        self._original_params = list(otel_util_http.PARAMS_TO_REDACT)
+
+    def tearDown(self):
+        otel_util_http.PARAMS_TO_REDACT[:] = self._original_params
+
+    def test_patch_appends_aws_sigv4_parameters(self):
+        _apply_url_query_redaction_patches()
+
+        for param in _AWS_SIGV4_SENSITIVE_QUERY_PARAMETERS:
+            self.assertIn(param, otel_util_http.PARAMS_TO_REDACT)
+
+    def test_patch_is_idempotent(self):
+        _apply_url_query_redaction_patches()
+        after_first = list(otel_util_http.PARAMS_TO_REDACT)
+
+        _apply_url_query_redaction_patches()
+        after_second = list(otel_util_http.PARAMS_TO_REDACT)
+
+        self.assertEqual(after_first, after_second)
+
+    def test_patch_preserves_existing_default_parameters(self):
+        _apply_url_query_redaction_patches()
+
+        for param in self._original_params:
+            self.assertIn(param, otel_util_http.PARAMS_TO_REDACT)
+
+    def test_presigned_url_credentials_blanked_after_patch(self):
+        _apply_url_query_redaction_patches()
+
+        url = (
+            "https://examplebucket.s3.us-east-1.amazonaws.com/test.txt?"
+            "X-Amz-Algorithm=AWS4-HMAC-SHA256&"
+            "X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20260724%2Fus-east-1%2Fs3%2Faws4_request&"
+            "X-Amz-Date=20260724T000000Z&"
+            "X-Amz-Expires=3600&"
+            "X-Amz-SignedHeaders=host&"
+            "X-Amz-Security-Token=FwoGZXIvYXdzEExampleToken&"
+            "X-Amz-Signature=abcdef1234567890"
+        )
+
+        redacted = redact_url(url)
+
+        # Sensitive values are blanked (but keys are retained).
+        self.assertNotIn("abcdef1234567890", redacted)
+        self.assertNotIn("AKIAIOSFODNN7EXAMPLE", redacted)
+        self.assertNotIn("FwoGZXIvYXdzEExampleToken", redacted)
+        self.assertIn("X-Amz-Signature=REDACTED", redacted)
+        self.assertIn("X-Amz-Credential=REDACTED", redacted)
+        self.assertIn("X-Amz-Security-Token=REDACTED", redacted)
+
+    def test_non_sensitive_sigv4_parameters_preserved_after_patch(self):
+        """The parameters pre-signed URL attribution relies on must survive redaction intact."""
+        _apply_url_query_redaction_patches()
+
+        url = (
+            "https://examplebucket.s3.us-east-1.amazonaws.com/test.txt?"
+            "X-Amz-Algorithm=AWS4-HMAC-SHA256&"
+            "X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20260724%2Fus-east-1%2Fs3%2Faws4_request&"
+            "X-Amz-Date=20260724T000000Z&"
+            "X-Amz-Expires=3600&"
+            "X-Amz-SignedHeaders=host&"
+            "X-Amz-Signature=abcdef1234567890"
+        )
+
+        redacted = redact_url(url)
+
+        self.assertIn("X-Amz-Algorithm=AWS4-HMAC-SHA256", redacted)
+        self.assertIn("X-Amz-Date=20260724T000000Z", redacted)
+        self.assertIn("X-Amz-Expires=3600", redacted)
+        self.assertIn("X-Amz-SignedHeaders=host", redacted)
+
+    @patch("amazon.opentelemetry.distro.patches._url_query_redaction_patches.logger")
+    def test_missing_params_to_redact_logs_warning(self, mock_logger):
+        with patch.object(otel_util_http, "PARAMS_TO_REDACT", None):
+            _apply_url_query_redaction_patches()
+
+        mock_logger.warning.assert_called_once()
+        self.assertIn("PARAMS_TO_REDACT", mock_logger.warning.call_args[0][0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

AWS presigned URLs carry SigV4/SigV4a authentication material in the query string. When such a URL is requested through a raw HTTP client (rather than the AWS SDK), the HTTP instrumentation captures the full URL on the span, so the signature and credential scope are exported via `url.full` / `http.url`.

Upstream `opentelemetry.util.http` already redacts a fixed set of sensitive query parameters (`PARAMS_TO_REDACT`), covering the generic presigned-URL credentials (`AWSAccessKeyId`, `Signature`, `sig`, `X-Goog-Signature`), but it omits the `X-Amz-*` SigV4 parameters that AWS SDKs and tooling emit.

Port of the redaction half of aws-observability/aws-otel-java-instrumentation#1419 to Python.

## Changes

- New `patches/_url_query_redaction_patches.py`: extends the upstream `PARAMS_TO_REDACT` list **in place** with `X-Amz-Signature`, `X-Amz-Credential`, and `X-Amz-Security-Token`. Because `redact_query_parameters` reads `PARAMS_TO_REDACT` as a module-level global at call time, extending the existing list object propagates to every HTTP instrumentation that calls `redact_url` (requests, aiohttp-client, httpx, urllib, tornado, ...) without re-wiring each one.
- `patches/_instrumentation_patch.py`: applies the patch unconditionally at instrumentation time.
- Unit tests covering the added parameters, preservation of the upstream defaults, idempotency of the patch, and end-to-end blanking of a presigned URL.
- CHANGELOG entry.

Redaction blanks the **value** (`-> REDACTED`) while preserving the parameter **key**, so the non-sensitive SigV4 parameters (`X-Amz-Algorithm`, `X-Amz-Date`, `X-Amz-Expires`, `X-Amz-SignedHeaders`) remain intact. This is deliberate: a follow-up change adds Application Signals attribution for presigned S3 URLs, which reads those parameters to recognize the request. This PR is independently useful and has no dependency on that follow-up.

## Testing

- `patches` package: 111 passed (including 6 new redaction tests).
- Distro suite: 2361 passed. Pre-existing failures in the `crewai` / `llama_index` instrumentor tests and the `langchain_core` collection error reproduce identically on unmodified `main` and are unrelated to this change.
- `black --check` clean; `pylint` 10.00/10 on the new module.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.