### PR TITLE
Fix main build and add cleanup workflow to main build

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -328,8 +328,7 @@ jobs:
   eks-cleanup:
     if: ${{ always() }}
     needs: [ eks-py310-amd64, eks-py311-amd64, eks-py312-amd64, eks-py313-amd64, eks-py314-amd64, service-events-eks ]
-    # TESTING: pinned to the fix branch; REVERT to @main before merge.
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/eks-cleanup-app-signals.yml@fix-python-se-addon-irsa
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/eks-cleanup-app-signals.yml@main
     secrets: inherit
     with:
       test-cluster-name: 'e2e-python-adot-test'

--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -350,3 +350,8 @@ jobs:
   #   (see: https://github.com/aws-observability/aws-application-signals-test-framework/blob/main/.github/workflows/validate-e2e-tests-are-accounted-for.yml)
   validate-all-tests-are-accounted-for:
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/validate-e2e-tests-are-accounted-for.yml@main
+    with:
+      # eks-cleanup-app-signals.yml is a cluster-teardown workflow, not a test cell, so it is not in
+      # the expected-tests glob (no python- prefix / not *-test.yml). Exclude it so this validation
+      # does not flag it as an "unaccounted-for test".
+      exclusions: 'eks-cleanup-app-signals.yml'

--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -310,8 +310,7 @@ jobs:
     # removes/reinstalls the amazon-cloudwatch-observability addon -- behavior that is only safe when it
     # runs exclusively.
     needs: [ eks-py310-amd64, eks-py311-amd64, eks-py312-amd64, eks-py313-amd64, eks-py314-amd64 ]
-    # TESTING: pinned to the addon-safe fix branch to validate the IRSA fix; REVERT to @main before merge.
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-service-events-test.yml@fix-python-se-addon-irsa
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-service-events-test.yml@main
     secrets: inherit
     with:
       aws-region: us-east-1
@@ -323,8 +322,7 @@ jobs:
   # Tear down App Signals from the shared EKS cluster LAST, after every EKS job (all eks-py* and
   # service-events-eks) has finished. Gating on all of them guarantees the cluster is idle, so
   # deleting the shared addon + cloudwatch-agent IRSA is safe (restores the original pre-parallel
-  # cleanup behavior). always() so it runs even if a test failed; the reusable workflow also refuses
-  # if any ns-* test namespaces are still present.
+  # cleanup behavior).
   eks-cleanup:
     if: ${{ always() }}
     needs: [ eks-py310-amd64, eks-py311-amd64, eks-py312-amd64, eks-py313-amd64, eks-py314-amd64, service-events-eks ]

--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -320,6 +320,21 @@ jobs:
       caller-workflow-name: 'main-build'
       python-version: '3.10'
 
+  # Tear down App Signals from the shared EKS cluster LAST, after every EKS job (all eks-py* and
+  # service-events-eks) has finished. Gating on all of them guarantees the cluster is idle, so
+  # deleting the shared addon + cloudwatch-agent IRSA is safe (restores the original pre-parallel
+  # cleanup behavior). always() so it runs even if a test failed; the reusable workflow also refuses
+  # if any ns-* test namespaces are still present.
+  eks-cleanup:
+    if: ${{ always() }}
+    needs: [ eks-py310-amd64, eks-py311-amd64, eks-py312-amd64, eks-py313-amd64, eks-py314-amd64, service-events-eks ]
+    # TESTING: pinned to the fix branch; REVERT to @main before merge.
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/eks-cleanup-app-signals.yml@fix-python-se-addon-irsa
+    secrets: inherit
+    with:
+      test-cluster-name: 'e2e-python-adot-test'
+      aws-region: us-east-1
+
   # This validation is to ensure that all test workflows relevant to this repo are actually
   # being used in this repo, which is referring to all the other jobs in this file.
   #

--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -310,7 +310,8 @@ jobs:
     # removes/reinstalls the amazon-cloudwatch-observability addon -- behavior that is only safe when it
     # runs exclusively.
     needs: [ eks-py310-amd64, eks-py311-amd64, eks-py312-amd64, eks-py313-amd64, eks-py314-amd64 ]
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-service-events-test.yml@main
+    # TESTING: pinned to the addon-safe fix branch to validate the IRSA fix; REVERT to @main before merge.
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-service-events-test.yml@fix-python-se-addon-irsa
     secrets: inherit
     with:
       aws-region: us-east-1


### PR DESCRIPTION
Add a new workflow that calls clean-app-signals.sh (since this script is now entirely removed from eks tests).

I add this because previously when eks tests were wholly sequential, each test had the entire cluster to itself so each test would call enable-app-signals.sh and clean-app-signals.sh. Now that EKS tests run in parallel we can no longer reset without causing issues. In the short term, removing calls to clean-app-signals.sh allows for our build to pass but I am worried about long term effects of never cleaning up our cluster.

Thats why I add this final job once all EKS tests have completed to clean up the cluster.


successful runs:https://github.com/aws-observability/aws-otel-python-instrumentation/actions/runs/30499340766, https://github.com/aws-observability/aws-otel-python-instrumentation/actions/runs/30499340766

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

