### PR TITLE
feat: wire AlwaysRecordSampler when agent observability is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- feat: wire `AlwaysRecordSampler` when agent observability is enabled so unsampled spans are still recorded and exported
+  ([#844](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/844))
 - fix: redact AWS presigned URL credentials from span attributes
   ([#840](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/840))
 - fix(genai): capture per-call token usage for Amazon Bedrock (and Anthropic) in crewai and langchain by reading provider-specific usage keys — crewai's Converse `inputTokens`/`outputTokens` and langchain's `ChatBedrockConverse` message `usage_metadata`

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
@@ -507,7 +507,7 @@ def _customize_sampler(sampler: Sampler) -> Sampler:
         if parsed_config is not None:
             sampler.set_adaptive_sampling_config(parsed_config)
 
-    if not _is_application_signals_enabled():
+    if not (_is_application_signals_enabled() or is_agent_observability_enabled()):
         return sampler
     return AlwaysRecordSampler(sampler)
 

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py
@@ -147,6 +147,7 @@ class TestAwsOpenTelemetryConfigurator(TestCase):
     def tearDown(self):
         os.environ.pop("OTEL_AWS_APPLICATION_SIGNALS_ENABLED", None)
         os.environ.pop("OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED", None)
+        os.environ.pop("AGENT_OBSERVABILITY_ENABLED", None)
 
     # The probability of this passing once without correct IDs is low, 20 times is inconceivable.
     def test_provide_generate_xray_ids(self):
@@ -467,8 +468,6 @@ class TestAwsOpenTelemetryConfigurator(TestCase):
         os.environ["AGENT_OBSERVABILITY_ENABLED"] = "false"
         self.assertEqual(mock_sampler, _customize_sampler(mock_sampler))
 
-        os.environ.pop("AGENT_OBSERVABILITY_ENABLED", None)
-
     def test_unsampled_span_is_recorded_and_exported_with_agent_observability(self):
         os.environ["AGENT_OBSERVABILITY_ENABLED"] = "true"
 
@@ -489,7 +488,6 @@ class TestAwsOpenTelemetryConfigurator(TestCase):
         self.assertFalse(exported_spans[0].attributes[AWS_TRACE_FLAG_SAMPLED])
 
         processor.shutdown()
-        os.environ.pop("AGENT_OBSERVABILITY_ENABLED", None)
 
     def test_parse_adaptive_sampling_config_valid(self):
         """Tests that _parse_config_string correctly parses a valid configuration"""

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 
 from requests import Session
 
-from amazon.opentelemetry.distro._aws_attribute_keys import AWS_LOCAL_SERVICE, AWS_SERVICE_TYPE
+from amazon.opentelemetry.distro._aws_attribute_keys import AWS_LOCAL_SERVICE, AWS_SERVICE_TYPE, AWS_TRACE_FLAG_SAMPLED
 from amazon.opentelemetry.distro.always_record_sampler import AlwaysRecordSampler
 from amazon.opentelemetry.distro.attribute_propagating_span_processor import AttributePropagatingSpanProcessor
 from amazon.opentelemetry.distro.aws_batch_unsampled_span_processor import BatchUnsampledSpanProcessor
@@ -85,7 +85,8 @@ from opentelemetry.sdk.metrics._internal.export import PeriodicExportingMetricRe
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import Span, SpanProcessor, Tracer, TracerProvider
 from opentelemetry.sdk.trace.export import SpanExporter
-from opentelemetry.sdk.trace.sampling import DEFAULT_ON, Sampler
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.sdk.trace.sampling import ALWAYS_OFF, DEFAULT_ON, Sampler
 from opentelemetry.semconv.resource import ResourceAttributes
 from opentelemetry.trace import get_tracer_provider
 
@@ -454,6 +455,41 @@ class TestAwsOpenTelemetryConfigurator(TestCase):
         self.assertNotEqual(mock_sampler, customized_sampler)
         self.assertIsInstance(customized_sampler, AlwaysRecordSampler)
         self.assertEqual(mock_sampler, customized_sampler._root_sampler)
+
+    def test_customize_sampler_with_agent_observability(self):
+        mock_sampler: Sampler = MagicMock()
+
+        os.environ["AGENT_OBSERVABILITY_ENABLED"] = "true"
+        customized_sampler: Sampler = _customize_sampler(mock_sampler)
+        self.assertIsInstance(customized_sampler, AlwaysRecordSampler)
+        self.assertEqual(mock_sampler, customized_sampler._root_sampler)
+
+        os.environ["AGENT_OBSERVABILITY_ENABLED"] = "false"
+        self.assertEqual(mock_sampler, _customize_sampler(mock_sampler))
+
+        os.environ.pop("AGENT_OBSERVABILITY_ENABLED", None)
+
+    def test_unsampled_span_is_recorded_and_exported_with_agent_observability(self):
+        os.environ["AGENT_OBSERVABILITY_ENABLED"] = "true"
+
+        exporter = InMemorySpanExporter()
+        tracer_provider = TracerProvider(sampler=_customize_sampler(ALWAYS_OFF))
+        processor = BatchUnsampledSpanProcessor(span_exporter=exporter)
+        tracer_provider.add_span_processor(processor)
+
+        with tracer_provider.get_tracer("test").start_as_current_span("unsampled-span") as span:
+            self.assertTrue(span.is_recording())
+            self.assertFalse(span.get_span_context().trace_flags.sampled)
+
+        processor.force_flush()
+
+        exported_spans = exporter.get_finished_spans()
+        self.assertEqual(len(exported_spans), 1)
+        self.assertEqual(exported_spans[0].name, "unsampled-span")
+        self.assertFalse(exported_spans[0].attributes[AWS_TRACE_FLAG_SAMPLED])
+
+        processor.shutdown()
+        os.environ.pop("AGENT_OBSERVABILITY_ENABLED", None)
 
     def test_parse_adaptive_sampling_config_valid(self):
         """Tests that _parse_config_string correctly parses a valid configuration"""


### PR DESCRIPTION
## Description

Wire `AlwaysRecordSampler` when `AGENT_OBSERVABILITY_ENABLED=true`, so unsampled spans stay recording and can still be exported via `BatchUnsampledSpanProcessor`. Previously this only happened when Application Signals was enabled.

## Testing

Unit test for the sampler gate, plus an end-to-end test that emits an unsampled span under `ALWAYS_OFF` and validates it is created, recorded, and exported through `BatchUnsampledSpanProcessor` into an `InMemorySpanExporter`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.