### PR TITLE
Python eks parallel pipeline

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -366,16 +366,6 @@ jobs:
   # - Update the `validate-e2e-tests-are-accounted-for` job to change which "workflow files are expected to be used by this repo"
   #   (see: https://github.com/aws-observability/aws-application-signals-test-framework/blob/main/.github/workflows/validate-e2e-tests-are-accounted-for.yml)
   validate-all-tests-are-accounted-for:
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/validate-e2e-tests-are-accounted-for.yml@main
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/validate-e2e-tests-are-accounted-for.yml@python-eks-parallel-pipeline
     with:
-      # The validator strict-equality-compares TESTS_EXPECTED (framework files matching python-*test.yml)
-      # against TESTS_ACTUALLY_USED (every framework workflow this file `uses:`). Exclusions are applied
-      # to BOTH sides, so anything not in both lists must be excluded:
-      #   - python-eks-test.yml       : sequential EKS workflow. Expected (matches python-*test.yml) but
-      #                                 this repo uses python-eks-parallel-test.yml instead, so it is
-      #                                 never in USED -> exclude to drop it from EXPECTED.
-      #   - eks-setup-app-signals.yml : used here, but does NOT match python-*test.yml, so never in
-      #   - eks-cleanup-app-signals.yml EXPECTED -> exclude to drop them from USED.
-      # (python-eks-parallel-test.yml itself needs NO exclusion: it matches python-*test.yml AND is used,
-      #  so it is in both lists once the framework branch is merged.)
       exclusions: 'python-eks-test.yml,eks-setup-app-signals.yml,eks-cleanup-app-signals.yml'

--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -125,19 +125,98 @@ jobs:
       staging-wheel-name: ${{ inputs.staging-wheel-name }}
 
 
-  # --- Python EKS E2E (setup -> parallel versions -> cleanup) -----------------------------------
-  # The entire EKS flow lives in one reusable workflow (python-eks-e2e.yml) so it re-runs as a
-  # single unit. Re-running just this job (e.g. "Re-run failed jobs") re-executes setup -> eks-py* ->
-  # cleanup together, INCLUDING the shared-cluster setup the version tests depend on, WITHOUT
-  # re-running the rest of this suite. service-events-eks still runs after, on the cold cluster.
-  eks-e2e:
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-e2e.yml@python-eks-parallel-pipeline
+  # --- Python EKS pipeline: service-events (first) -> setup -> parallel versions -> cleanup ------
+  # service-events-eks runs FIRST on a cold cluster: the UNCHANGED shared SE workflow self-installs
+  # and tears down App Signals and binds NodePort 30100, so it must not overlap the parallel eks-py*
+  # jobs. eks-setup waits for SE (needs) but runs regardless of SE's result (if: !cancelled()), so a
+  # SE failure can't block the version tests. Keeping SE UPSTREAM means re-running the eks-setup job
+  # re-runs setup -> eks-py* -> cleanup WITHOUT dragging service-events along.
+  service-events-eks:
+    if: ${{ always() }}
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-service-events-test.yml@main
     secrets: inherit
     with:
-      adot-image-name: ${{ inputs.adot-image-name }}
       aws-region: us-east-1
       test-cluster-name: 'e2e-python-adot-test'
+      adot-image-name: ${{ inputs.adot-image-name }}
       caller-workflow-name: 'main-build'
+      python-version: '3.10'
+
+  eks-setup:
+    needs: service-events-eks
+    if: ${{ !cancelled() }}
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/eks-setup-app-signals.yml@python-eks-parallel-pipeline
+    secrets: inherit
+    with:
+      test-cluster-name: 'e2e-python-adot-test'
+      aws-region: us-east-1
+
+  eks-py310-amd64:
+    needs: eks-setup
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@python-eks-parallel-pipeline
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      test-cluster-name: 'e2e-python-adot-test'
+      adot-image-name: ${{ inputs.adot-image-name }}
+      caller-workflow-name: 'main-build'
+      python-version: '3.10'
+
+  eks-py311-amd64:
+    needs: eks-setup
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@python-eks-parallel-pipeline
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      test-cluster-name: 'e2e-python-adot-test'
+      adot-image-name: ${{ inputs.adot-image-name }}
+      caller-workflow-name: 'main-build'
+      python-version: '3.11'
+
+  eks-py312-amd64:
+    needs: eks-setup
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@python-eks-parallel-pipeline
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      test-cluster-name: 'e2e-python-adot-test'
+      adot-image-name: ${{ inputs.adot-image-name }}
+      caller-workflow-name: 'main-build'
+      python-version: '3.12'
+
+  eks-py313-amd64:
+    needs: eks-setup
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@python-eks-parallel-pipeline
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      test-cluster-name: 'e2e-python-adot-test'
+      adot-image-name: ${{ inputs.adot-image-name }}
+      caller-workflow-name: 'main-build'
+      python-version: '3.13'
+
+  eks-py314-amd64:
+    needs: eks-setup
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@python-eks-parallel-pipeline
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      test-cluster-name: 'e2e-python-adot-test'
+      adot-image-name: ${{ inputs.adot-image-name }}
+      caller-workflow-name: 'main-build'
+      python-version: '3.14'
+
+  # Tear down cluster-wide App Signals state once, after ALL parallel eks-py* jobs finish.
+  # always() so a failed version job still triggers teardown; gated on eks-setup success so it never
+  # tries to clean up state that was never installed.
+  eks-cleanup:
+    if: ${{ always() && needs.eks-setup.result == 'success' }}
+    needs: [ eks-setup, eks-py310-amd64, eks-py311-amd64, eks-py312-amd64, eks-py313-amd64, eks-py314-amd64 ]
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/eks-cleanup-app-signals.yml@python-eks-parallel-pipeline
+    secrets: inherit
+    with:
+      test-cluster-name: 'e2e-python-adot-test'
+      aws-region: us-east-1
 
   #
   # PACKAGED DISTRIBUTION PLATFORM COVERAGE
@@ -257,23 +336,6 @@ jobs:
       caller-workflow-name: 'main-build'
       staging-wheel-name: ${{ inputs.staging-wheel-name }}
 
-  service-events-eks:
-    if: ${{ always() }}
-    # Runs LAST, after the eks-e2e flow (which ends with its own cleanup). Service Events uses the
-    # UNCHANGED shared workflow, which installs and tears down App Signals itself — safe only with
-    # exclusive cluster access. eks-e2e's cleanup runs first so SE inherits a cold cluster and
-    # self-provisions, exactly as it does standalone. SE also binds cluster-wide NodePort 30100, so
-    # it must not overlap any parallel eks-py* job.
-    needs: eks-e2e
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-service-events-test.yml@main
-    secrets: inherit
-    with:
-      aws-region: us-east-1
-      test-cluster-name: 'e2e-python-adot-test'
-      adot-image-name: ${{ inputs.adot-image-name }}
-      caller-workflow-name: 'main-build'
-      python-version: '3.10'
-
   # This validation is to ensure that all test workflows relevant to this repo are actually
   # being used in this repo, which is referring to all the other jobs in this file.
   #
@@ -290,8 +352,4 @@ jobs:
   validate-all-tests-are-accounted-for:
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/validate-e2e-tests-are-accounted-for.yml@python-eks-parallel-pipeline
     with:
-      # python-eks-parallel-test.yml is now used INSIDE python-eks-e2e.yml (not referenced directly
-      # here), and python-eks-e2e.yml is an orchestrator, not a test file. The validation only scans
-      # direct `uses:` in this file, so both are excluded to keep it green. python-eks-test.yml is the
-      # sequential test this repo doesn't use; setup/cleanup are not test files.
-      exclusions: 'python-eks-test.yml,python-eks-parallel-test.yml,python-eks-e2e.yml,eks-setup-app-signals.yml,eks-cleanup-app-signals.yml'
+      exclusions: 'python-eks-test.yml,eks-setup-app-signals.yml,eks-cleanup-app-signals.yml'

--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -124,23 +124,12 @@ jobs:
       cpu-architecture: 'x86_64'
       staging-wheel-name: ${{ inputs.staging-wheel-name }}
 
-  #
-  # DOCKER DISTRIBUTION LANGUAGE VERSION COVERAGE
-  # DEFAULT SETTING: {Python Version}, EKS, AMD64, AL2
-  #
 
   # --- Parallel Python EKS pipeline -------------------------------------------------------------
   # Shape: eks-setup -> [eks-py310..314 concurrently] -> eks-cleanup -> service-events-eks
-  #
-  # These jobs use python-eks-PARALLEL-test.yml, a fork of python-eks-test.yml owned by this repo.
-  # The sequential python-eks-test.yml is unchanged and still used by other repos. The parallel
-  # workflow only asserts shared App Signals state; installing/tearing it down is owned by the
-  # eks-setup / eks-cleanup bookend jobs so 5 concurrent jobs on one cluster don't race.
 
-  # Install the cluster-wide App Signals addon + cloudwatch-agent IRSA SA exactly once, before the
-  # version fan-out. Gates every eks-py* job so none starts until shared state is ready.
   eks-setup:
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/eks-setup-app-signals.yml@python-eks-parallel-pipeline
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/eks-setup-app-signals.yml@main
     secrets: inherit
     with:
       test-cluster-name: 'e2e-python-adot-test'
@@ -149,7 +138,7 @@ jobs:
   eks-py310-amd64:
     needs: eks-setup
     if: ${{ always() && needs.eks-setup.result == 'success' }}
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@python-eks-parallel-pipeline
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@main
     secrets: inherit
     with:
       aws-region: us-east-1
@@ -161,7 +150,7 @@ jobs:
   eks-py311-amd64:
     needs: eks-setup
     if: ${{ always() && needs.eks-setup.result == 'success' }}
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@python-eks-parallel-pipeline
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@main
     secrets: inherit
     with:
       aws-region: us-east-1
@@ -173,7 +162,7 @@ jobs:
   eks-py312-amd64:
     needs: eks-setup
     if: ${{ always() && needs.eks-setup.result == 'success' }}
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@python-eks-parallel-pipeline
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@main
     secrets: inherit
     with:
       aws-region: us-east-1
@@ -185,7 +174,7 @@ jobs:
   eks-py313-amd64:
     needs: eks-setup
     if: ${{ always() && needs.eks-setup.result == 'success' }}
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@python-eks-parallel-pipeline
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@main
     secrets: inherit
     with:
       aws-region: us-east-1
@@ -197,7 +186,7 @@ jobs:
   eks-py314-amd64:
     needs: eks-setup
     if: ${{ always() && needs.eks-setup.result == 'success' }}
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@python-eks-parallel-pipeline
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@main
     secrets: inherit
     with:
       aws-region: us-east-1
@@ -330,7 +319,7 @@ jobs:
   eks-cleanup:
     if: ${{ always() && needs.eks-setup.result == 'success' }}
     needs: [ eks-setup, eks-py310-amd64, eks-py311-amd64, eks-py312-amd64, eks-py313-amd64, eks-py314-amd64 ]
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/eks-cleanup-app-signals.yml@python-eks-parallel-pipeline
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/eks-cleanup-app-signals.yml@main
     secrets: inherit
     with:
       test-cluster-name: 'e2e-python-adot-test'
@@ -366,6 +355,6 @@ jobs:
   # - Update the `validate-e2e-tests-are-accounted-for` job to change which "workflow files are expected to be used by this repo"
   #   (see: https://github.com/aws-observability/aws-application-signals-test-framework/blob/main/.github/workflows/validate-e2e-tests-are-accounted-for.yml)
   validate-all-tests-are-accounted-for:
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/validate-e2e-tests-are-accounted-for.yml@python-eks-parallel-pipeline
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/validate-e2e-tests-are-accounted-for.yml@main
     with:
       exclusions: 'python-eks-test.yml,eks-setup-app-signals.yml,eks-cleanup-app-signals.yml'

--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -144,7 +144,7 @@ jobs:
   eks-setup:
     needs: service-events-eks
     if: ${{ !cancelled() }}
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/eks-setup-app-signals.yml@python-eks-parallel-pipeline
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/eks-setup-app-signals.yml@main
     secrets: inherit
     with:
       test-cluster-name: 'e2e-python-adot-test'
@@ -152,7 +152,7 @@ jobs:
 
   eks-py310-amd64:
     needs: eks-setup
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-shared-cluster-test.yml@python-eks-parallel-pipeline
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-shared-cluster-test.yml@main
     secrets: inherit
     with:
       aws-region: us-east-1
@@ -163,7 +163,7 @@ jobs:
 
   eks-py311-amd64:
     needs: eks-setup
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-shared-cluster-test.yml@python-eks-parallel-pipeline
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-shared-cluster-test.yml@main
     secrets: inherit
     with:
       aws-region: us-east-1
@@ -174,7 +174,7 @@ jobs:
 
   eks-py312-amd64:
     needs: eks-setup
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-shared-cluster-test.yml@python-eks-parallel-pipeline
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-shared-cluster-test.yml@main
     secrets: inherit
     with:
       aws-region: us-east-1
@@ -185,7 +185,7 @@ jobs:
 
   eks-py313-amd64:
     needs: eks-setup
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-shared-cluster-test.yml@python-eks-parallel-pipeline
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-shared-cluster-test.yml@main
     secrets: inherit
     with:
       aws-region: us-east-1
@@ -196,7 +196,7 @@ jobs:
 
   eks-py314-amd64:
     needs: eks-setup
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-shared-cluster-test.yml@python-eks-parallel-pipeline
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-shared-cluster-test.yml@main
     secrets: inherit
     with:
       aws-region: us-east-1
@@ -211,7 +211,7 @@ jobs:
   eks-cleanup:
     if: ${{ always() }}
     needs: [ eks-setup, eks-py310-amd64, eks-py311-amd64, eks-py312-amd64, eks-py313-amd64, eks-py314-amd64 ]
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/eks-cleanup-app-signals.yml@python-eks-parallel-pipeline
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/eks-cleanup-app-signals.yml@main
     secrets: inherit
     with:
       test-cluster-name: 'e2e-python-adot-test'
@@ -349,6 +349,6 @@ jobs:
   # - Update the `validate-e2e-tests-are-accounted-for` job to change which "workflow files are expected to be used by this repo"
   #   (see: https://github.com/aws-observability/aws-application-signals-test-framework/blob/main/.github/workflows/validate-e2e-tests-are-accounted-for.yml)
   validate-all-tests-are-accounted-for:
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/validate-e2e-tests-are-accounted-for.yml@python-eks-parallel-pipeline
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/validate-e2e-tests-are-accounted-for.yml@main
     with:
       exclusions: 'python-eks-test.yml,eks-setup-app-signals.yml,eks-cleanup-app-signals.yml'

--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -129,7 +129,7 @@ jobs:
   # Shape: eks-setup -> [eks-py310..314 concurrently] -> eks-cleanup -> service-events-eks
 
   eks-setup:
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/eks-setup-app-signals.yml@main
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/eks-setup-app-signals.yml@python-eks-parallel-pipeline
     secrets: inherit
     with:
       test-cluster-name: 'e2e-python-adot-test'
@@ -138,7 +138,7 @@ jobs:
   eks-py310-amd64:
     needs: eks-setup
     if: ${{ always() && needs.eks-setup.result == 'success' }}
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@main
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@python-eks-parallel-pipeline
     secrets: inherit
     with:
       aws-region: us-east-1
@@ -150,7 +150,7 @@ jobs:
   eks-py311-amd64:
     needs: eks-setup
     if: ${{ always() && needs.eks-setup.result == 'success' }}
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@main
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@python-eks-parallel-pipeline
     secrets: inherit
     with:
       aws-region: us-east-1
@@ -162,7 +162,7 @@ jobs:
   eks-py312-amd64:
     needs: eks-setup
     if: ${{ always() && needs.eks-setup.result == 'success' }}
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@main
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@python-eks-parallel-pipeline
     secrets: inherit
     with:
       aws-region: us-east-1
@@ -174,7 +174,7 @@ jobs:
   eks-py313-amd64:
     needs: eks-setup
     if: ${{ always() && needs.eks-setup.result == 'success' }}
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@main
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@python-eks-parallel-pipeline
     secrets: inherit
     with:
       aws-region: us-east-1
@@ -186,7 +186,7 @@ jobs:
   eks-py314-amd64:
     needs: eks-setup
     if: ${{ always() && needs.eks-setup.result == 'success' }}
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@main
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@python-eks-parallel-pipeline
     secrets: inherit
     with:
       aws-region: us-east-1
@@ -319,7 +319,7 @@ jobs:
   eks-cleanup:
     if: ${{ always() && needs.eks-setup.result == 'success' }}
     needs: [ eks-setup, eks-py310-amd64, eks-py311-amd64, eks-py312-amd64, eks-py313-amd64, eks-py314-amd64 ]
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/eks-cleanup-app-signals.yml@main
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/eks-cleanup-app-signals.yml@python-eks-parallel-pipeline
     secrets: inherit
     with:
       test-cluster-name: 'e2e-python-adot-test'
@@ -355,6 +355,6 @@ jobs:
   # - Update the `validate-e2e-tests-are-accounted-for` job to change which "workflow files are expected to be used by this repo"
   #   (see: https://github.com/aws-observability/aws-application-signals-test-framework/blob/main/.github/workflows/validate-e2e-tests-are-accounted-for.yml)
   validate-all-tests-are-accounted-for:
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/validate-e2e-tests-are-accounted-for.yml@main
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/validate-e2e-tests-are-accounted-for.yml@python-eks-parallel-pipeline
     with:
       exclusions: 'python-eks-test.yml,eks-setup-app-signals.yml,eks-cleanup-app-signals.yml'

--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -368,7 +368,14 @@ jobs:
   validate-all-tests-are-accounted-for:
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/validate-e2e-tests-are-accounted-for.yml@main
     with:
-      # python-eks-test.yml is the SEQUENTIAL EKS workflow. This repo intentionally uses
-      # python-eks-parallel-test.yml instead (still validated, since it also matches python-*test.yml),
-      # so exclude the sequential one from the "expected but unused" check.
-      exclusions: 'python-eks-test.yml'
+      # The validator strict-equality-compares TESTS_EXPECTED (framework files matching python-*test.yml)
+      # against TESTS_ACTUALLY_USED (every framework workflow this file `uses:`). Exclusions are applied
+      # to BOTH sides, so anything not in both lists must be excluded:
+      #   - python-eks-test.yml       : sequential EKS workflow. Expected (matches python-*test.yml) but
+      #                                 this repo uses python-eks-parallel-test.yml instead, so it is
+      #                                 never in USED -> exclude to drop it from EXPECTED.
+      #   - eks-setup-app-signals.yml : used here, but does NOT match python-*test.yml, so never in
+      #   - eks-cleanup-app-signals.yml EXPECTED -> exclude to drop them from USED.
+      # (python-eks-parallel-test.yml itself needs NO exclusion: it matches python-*test.yml AND is used,
+      #  so it is in both lists once the framework branch is merged.)
+      exclusions: 'python-eks-test.yml,eks-setup-app-signals.yml,eks-cleanup-app-signals.yml'

--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -129,9 +129,27 @@ jobs:
   # DEFAULT SETTING: {Python Version}, EKS, AMD64, AL2
   #
 
+  # --- Parallel Python EKS pipeline -------------------------------------------------------------
+  # Shape: eks-setup -> [eks-py310..314 concurrently] -> eks-cleanup -> service-events-eks
+  #
+  # These jobs use python-eks-PARALLEL-test.yml, a fork of python-eks-test.yml owned by this repo.
+  # The sequential python-eks-test.yml is unchanged and still used by other repos. The parallel
+  # workflow only asserts shared App Signals state; installing/tearing it down is owned by the
+  # eks-setup / eks-cleanup bookend jobs so 5 concurrent jobs on one cluster don't race.
+
+  # Install the cluster-wide App Signals addon + cloudwatch-agent IRSA SA exactly once, before the
+  # version fan-out. Gates every eks-py* job so none starts until shared state is ready.
+  eks-setup:
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/eks-setup-app-signals.yml@python-eks-parallel-pipeline
+    secrets: inherit
+    with:
+      test-cluster-name: 'e2e-python-adot-test'
+      aws-region: us-east-1
+
   eks-py310-amd64:
-    if: ${{ always() }}
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@main
+    needs: eks-setup
+    if: ${{ always() && needs.eks-setup.result == 'success' }}
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@python-eks-parallel-pipeline
     secrets: inherit
     with:
       aws-region: us-east-1
@@ -141,9 +159,9 @@ jobs:
       python-version: '3.10'
 
   eks-py311-amd64:
-    if: ${{ always() }}
-    needs: eks-py310-amd64
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@main
+    needs: eks-setup
+    if: ${{ always() && needs.eks-setup.result == 'success' }}
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@python-eks-parallel-pipeline
     secrets: inherit
     with:
       aws-region: us-east-1
@@ -153,9 +171,9 @@ jobs:
       python-version: '3.11'
 
   eks-py312-amd64:
-    if: ${{ always() }}
-    needs: eks-py311-amd64
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@main
+    needs: eks-setup
+    if: ${{ always() && needs.eks-setup.result == 'success' }}
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@python-eks-parallel-pipeline
     secrets: inherit
     with:
       aws-region: us-east-1
@@ -165,9 +183,9 @@ jobs:
       python-version: '3.12'
 
   eks-py313-amd64:
-    if: ${{ always() }}
-    needs: eks-py312-amd64
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@main
+    needs: eks-setup
+    if: ${{ always() && needs.eks-setup.result == 'success' }}
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@python-eks-parallel-pipeline
     secrets: inherit
     with:
       aws-region: us-east-1
@@ -177,9 +195,9 @@ jobs:
       python-version: '3.13'
 
   eks-py314-amd64:
-    if: ${{ always() }}
-    needs: eks-py313-amd64
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test.yml@main
+    needs: eks-setup
+    if: ${{ always() && needs.eks-setup.result == 'success' }}
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@python-eks-parallel-pipeline
     secrets: inherit
     with:
       aws-region: us-east-1
@@ -306,13 +324,25 @@ jobs:
       caller-workflow-name: 'main-build'
       staging-wheel-name: ${{ inputs.staging-wheel-name }}
 
+  # Tear down cluster-wide App Signals state once, after ALL parallel eks-py* jobs finish.
+  # if: always() so a failed version job still triggers teardown; gated on every eks-py* so it never
+  # runs while a version job is still using the cluster.
+  eks-cleanup:
+    if: ${{ always() && needs.eks-setup.result == 'success' }}
+    needs: [ eks-setup, eks-py310-amd64, eks-py311-amd64, eks-py312-amd64, eks-py313-amd64, eks-py314-amd64 ]
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/eks-cleanup-app-signals.yml@python-eks-parallel-pipeline
+    secrets: inherit
+    with:
+      test-cluster-name: 'e2e-python-adot-test'
+      aws-region: us-east-1
+
   service-events-eks:
     if: ${{ always() }}
-    # Chain onto the tail of the eks-py* jobs: they all target e2e-python-adot-test and the
-    # sample-app Service binds cluster-wide NodePort 30100, which this SE test also uses. Running
-    # in parallel would collide on that port ("provided port is already allocated"), so serialize
-    # after the last eks-py* job, matching how eks-py311..314 chain via needs.
-    needs: eks-py314-amd64
+    # Runs LAST, after eks-cleanup. Service Events uses the UNCHANGED shared workflow, which installs
+    # and tears down App Signals itself — safe only with exclusive cluster access. eks-cleanup runs
+    # first so SE inherits a cold cluster and self-provisions, exactly as it does standalone. SE also
+    # binds cluster-wide NodePort 30100, so it must not overlap any parallel eks-py* job.
+    needs: eks-cleanup
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-service-events-test.yml@main
     secrets: inherit
     with:
@@ -337,3 +367,8 @@ jobs:
   #   (see: https://github.com/aws-observability/aws-application-signals-test-framework/blob/main/.github/workflows/validate-e2e-tests-are-accounted-for.yml)
   validate-all-tests-are-accounted-for:
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/validate-e2e-tests-are-accounted-for.yml@main
+    with:
+      # python-eks-test.yml is the SEQUENTIAL EKS workflow. This repo intentionally uses
+      # python-eks-parallel-test.yml instead (still validated, since it also matches python-*test.yml),
+      # so exclude the sequential one from the "expected but unused" check.
+      exclusions: 'python-eks-test.yml'

--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -125,75 +125,19 @@ jobs:
       staging-wheel-name: ${{ inputs.staging-wheel-name }}
 
 
-  # --- Parallel Python EKS pipeline -------------------------------------------------------------
-  # Shape: eks-setup -> [eks-py310..314 concurrently] -> eks-cleanup -> service-events-eks
-
-  eks-setup:
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/eks-setup-app-signals.yml@python-eks-parallel-pipeline
+  # --- Python EKS E2E (setup -> parallel versions -> cleanup) -----------------------------------
+  # The entire EKS flow lives in one reusable workflow (python-eks-e2e.yml) so it re-runs as a
+  # single unit. Re-running just this job (e.g. "Re-run failed jobs") re-executes setup -> eks-py* ->
+  # cleanup together, INCLUDING the shared-cluster setup the version tests depend on, WITHOUT
+  # re-running the rest of this suite. service-events-eks still runs after, on the cold cluster.
+  eks-e2e:
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-e2e.yml@python-eks-parallel-pipeline
     secrets: inherit
     with:
-      test-cluster-name: 'e2e-python-adot-test'
-      aws-region: us-east-1
-
-  eks-py310-amd64:
-    needs: eks-setup
-    if: ${{ always() && needs.eks-setup.result == 'success' }}
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@python-eks-parallel-pipeline
-    secrets: inherit
-    with:
-      aws-region: us-east-1
-      test-cluster-name: 'e2e-python-adot-test'
       adot-image-name: ${{ inputs.adot-image-name }}
-      caller-workflow-name: 'main-build'
-      python-version: '3.10'
-
-  eks-py311-amd64:
-    needs: eks-setup
-    if: ${{ always() && needs.eks-setup.result == 'success' }}
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@python-eks-parallel-pipeline
-    secrets: inherit
-    with:
       aws-region: us-east-1
       test-cluster-name: 'e2e-python-adot-test'
-      adot-image-name: ${{ inputs.adot-image-name }}
       caller-workflow-name: 'main-build'
-      python-version: '3.11'
-
-  eks-py312-amd64:
-    needs: eks-setup
-    if: ${{ always() && needs.eks-setup.result == 'success' }}
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@python-eks-parallel-pipeline
-    secrets: inherit
-    with:
-      aws-region: us-east-1
-      test-cluster-name: 'e2e-python-adot-test'
-      adot-image-name: ${{ inputs.adot-image-name }}
-      caller-workflow-name: 'main-build'
-      python-version: '3.12'
-
-  eks-py313-amd64:
-    needs: eks-setup
-    if: ${{ always() && needs.eks-setup.result == 'success' }}
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@python-eks-parallel-pipeline
-    secrets: inherit
-    with:
-      aws-region: us-east-1
-      test-cluster-name: 'e2e-python-adot-test'
-      adot-image-name: ${{ inputs.adot-image-name }}
-      caller-workflow-name: 'main-build'
-      python-version: '3.13'
-
-  eks-py314-amd64:
-    needs: eks-setup
-    if: ${{ always() && needs.eks-setup.result == 'success' }}
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@python-eks-parallel-pipeline
-    secrets: inherit
-    with:
-      aws-region: us-east-1
-      test-cluster-name: 'e2e-python-adot-test'
-      adot-image-name: ${{ inputs.adot-image-name }}
-      caller-workflow-name: 'main-build'
-      python-version: '3.14'
 
   #
   # PACKAGED DISTRIBUTION PLATFORM COVERAGE
@@ -313,25 +257,14 @@ jobs:
       caller-workflow-name: 'main-build'
       staging-wheel-name: ${{ inputs.staging-wheel-name }}
 
-  # Tear down cluster-wide App Signals state once, after ALL parallel eks-py* jobs finish.
-  # if: always() so a failed version job still triggers teardown; gated on every eks-py* so it never
-  # runs while a version job is still using the cluster.
-  eks-cleanup:
-    if: ${{ always() && needs.eks-setup.result == 'success' }}
-    needs: [ eks-setup, eks-py310-amd64, eks-py311-amd64, eks-py312-amd64, eks-py313-amd64, eks-py314-amd64 ]
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/eks-cleanup-app-signals.yml@python-eks-parallel-pipeline
-    secrets: inherit
-    with:
-      test-cluster-name: 'e2e-python-adot-test'
-      aws-region: us-east-1
-
   service-events-eks:
     if: ${{ always() }}
-    # Runs LAST, after eks-cleanup. Service Events uses the UNCHANGED shared workflow, which installs
-    # and tears down App Signals itself — safe only with exclusive cluster access. eks-cleanup runs
-    # first so SE inherits a cold cluster and self-provisions, exactly as it does standalone. SE also
-    # binds cluster-wide NodePort 30100, so it must not overlap any parallel eks-py* job.
-    needs: eks-cleanup
+    # Runs LAST, after the eks-e2e flow (which ends with its own cleanup). Service Events uses the
+    # UNCHANGED shared workflow, which installs and tears down App Signals itself — safe only with
+    # exclusive cluster access. eks-e2e's cleanup runs first so SE inherits a cold cluster and
+    # self-provisions, exactly as it does standalone. SE also binds cluster-wide NodePort 30100, so
+    # it must not overlap any parallel eks-py* job.
+    needs: eks-e2e
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-service-events-test.yml@main
     secrets: inherit
     with:
@@ -357,4 +290,8 @@ jobs:
   validate-all-tests-are-accounted-for:
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/validate-e2e-tests-are-accounted-for.yml@python-eks-parallel-pipeline
     with:
-      exclusions: 'python-eks-test.yml,eks-setup-app-signals.yml,eks-cleanup-app-signals.yml'
+      # python-eks-parallel-test.yml is now used INSIDE python-eks-e2e.yml (not referenced directly
+      # here), and python-eks-e2e.yml is an orchestrator, not a test file. The validation only scans
+      # direct `uses:` in this file, so both are excluded to keep it green. python-eks-test.yml is the
+      # sequential test this repo doesn't use; setup/cleanup are not test files.
+      exclusions: 'python-eks-test.yml,python-eks-parallel-test.yml,python-eks-e2e.yml,eks-setup-app-signals.yml,eks-cleanup-app-signals.yml'

--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -132,7 +132,6 @@ jobs:
   # SE failure can't block the version tests. Keeping SE UPSTREAM means re-running the eks-setup job
   # re-runs setup -> eks-py* -> cleanup WITHOUT dragging service-events along.
   service-events-eks:
-    if: ${{ always() }}
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-service-events-test.yml@main
     secrets: inherit
     with:
@@ -153,7 +152,7 @@ jobs:
 
   eks-py310-amd64:
     needs: eks-setup
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@python-eks-parallel-pipeline
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-shared-cluster-test.yml@python-eks-parallel-pipeline
     secrets: inherit
     with:
       aws-region: us-east-1
@@ -164,7 +163,7 @@ jobs:
 
   eks-py311-amd64:
     needs: eks-setup
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@python-eks-parallel-pipeline
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-shared-cluster-test.yml@python-eks-parallel-pipeline
     secrets: inherit
     with:
       aws-region: us-east-1
@@ -175,7 +174,7 @@ jobs:
 
   eks-py312-amd64:
     needs: eks-setup
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@python-eks-parallel-pipeline
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-shared-cluster-test.yml@python-eks-parallel-pipeline
     secrets: inherit
     with:
       aws-region: us-east-1
@@ -186,7 +185,7 @@ jobs:
 
   eks-py313-amd64:
     needs: eks-setup
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@python-eks-parallel-pipeline
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-shared-cluster-test.yml@python-eks-parallel-pipeline
     secrets: inherit
     with:
       aws-region: us-east-1
@@ -197,7 +196,7 @@ jobs:
 
   eks-py314-amd64:
     needs: eks-setup
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-parallel-test.yml@python-eks-parallel-pipeline
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-shared-cluster-test.yml@python-eks-parallel-pipeline
     secrets: inherit
     with:
       aws-region: us-east-1
@@ -210,7 +209,7 @@ jobs:
   # always() so a failed version job still triggers teardown; gated on eks-setup success so it never
   # tries to clean up state that was never installed.
   eks-cleanup:
-    if: ${{ always() && needs.eks-setup.result == 'success' }}
+    if: ${{ always() }}
     needs: [ eks-setup, eks-py310-amd64, eks-py311-amd64, eks-py312-amd64, eks-py313-amd64, eks-py314-amd64 ]
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/eks-cleanup-app-signals.yml@python-eks-parallel-pipeline
     secrets: inherit

--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -126,11 +126,7 @@ jobs:
 
 
   # --- Python EKS pipeline: service-events (first) -> setup -> parallel versions -> cleanup ------
-  # service-events-eks runs FIRST on a cold cluster: the UNCHANGED shared SE workflow self-installs
-  # and tears down App Signals and binds NodePort 30100, so it must not overlap the parallel eks-py*
-  # jobs. eks-setup waits for SE (needs) but runs regardless of SE's result (if: !cancelled()), so a
-  # SE failure can't block the version tests. Keeping SE UPSTREAM means re-running the eks-setup job
-  # re-runs setup -> eks-py* -> cleanup WITHOUT dragging service-events along.
+  # Service events has atomic setup and cleanup
   service-events-eks:
     uses: aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-service-events-test.yml@main
     secrets: inherit

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/crewai/requirements.latest.txt
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/crewai/requirements.latest.txt
@@ -1,6 +1,12 @@
 crewai[litellm,anthropic,bedrock,azure-ai-inference,google-genai]>=1.10.0,<2
-# litellm 1.98.0 (2026-08-22) imports `NotRequired` from `typing`, which only exists on Python 3.11+,
-# so litellm fails to import on the Python 3.10 crewai-latest env (crewai then reports the LiteLLM
-# fallback as "not installed"). Cap below 1.98.0 until litellm restores 3.10 support (importing
-# NotRequired from typing_extensions). Upstream: BerriAI/litellm.
-litellm<1.98.0
+# Python 3.10 ONLY: cap litellm below 1.97.0. Two separate upstream breakages force this, and both are
+# specific to 3.10 (litellm 1.97.0+ works on 3.11+, so those envs stay uncapped and test the latest):
+#   1. On 3.10, litellm 1.97.0's `litellm.types.utils.Message` references `ChatCompletionReasoningSummaryTextBlock`,
+#      which is not resolvable in that module's namespace on 3.10, so the pydantic model is never finalized and
+#      constructing `Message(...)` raises PydanticUserError ("`Message` is not fully defined"). Our tests build
+#      litellm's `Message` directly, so every crew-kickoff test fails. (Constructs fine on 3.11+.)
+#   2. litellm 1.98.0 (2026-08-22) imports `NotRequired` from `typing` (3.11+ only), so it fails to import
+#      on Python 3.10 entirely (crewai then reports the LiteLLM fallback as "not installed").
+# 1.96.2 is the newest release that imports on 3.10 AND has a constructible `Message`. Lift this cap once
+# litellm ships a release that both imports on 3.10 and defines `Message` fully. Upstream: BerriAI/litellm.
+litellm<1.97.0; python_version == "3.10"

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/crewai/requirements.latest.txt
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/crewai/requirements.latest.txt
@@ -1,1 +1,6 @@
 crewai[litellm,anthropic,bedrock,azure-ai-inference,google-genai]>=1.10.0,<2
+# litellm 1.98.0 (2026-08-22) imports `NotRequired` from `typing`, which only exists on Python 3.11+,
+# so litellm fails to import on the Python 3.10 crewai-latest env (crewai then reports the LiteLLM
+# fallback as "not installed"). Cap below 1.98.0 until litellm restores 3.10 support (importing
+# NotRequired from typing_extensions). Upstream: BerriAI/litellm.
+litellm<1.98.0


### PR DESCRIPTION
EKS tests for ADOT Python currently run sequentially, dedicating almost an hour to EKS testing on every build. This PR wires ADOT Python's main build up to the new parallel EKS test workflows (added in the companion aws-application-signals-test-framework PR), running all supported Python versions concurrently against one shared cluster and removing a major bottleneck in the build/release pipeline.

The existing sequential EKS test is untouched; this only changes how application-signals-e2e-test.yml invokes EKS testing.

Description of changes:

Rework the EKS portion of .github/workflows/application-signals-e2e-test.yml from a single sequential test into a parallel flow built on the framework's new reusable workflows. The flow is:

service-events-eks  ->  eks-setup  ->  eks-py3.10 … eks-py3.14 (parallel)  ->  eks-cleanup

- service-events-eks runs first. It uses the unchanged shared Service Events workflow, which installs and tears down App Signals itself and binds a fixed NodePort, so it must not overlap the parallel version tests. Placing it upstream (rather than after cleanup) means re-running eks-setup re-runs the whole version flow without dragging Service Events along.
- eks-setup installs App Signals on the shared cluster once, before the version tests. It runs regardless of whether Service Events passed or failed (so a Service Events failure can't block the version matrix) while still respecting run cancellation.
- eks-py310…eks-py314 each call the new python-eks-shared-cluster-test.yml for one Python version. They run in parallel against the shared cluster once setup succeeds.
- eks-cleanup tears down the shared App Signals state once, after every version test finishes. Teardown still runs even if a version test fails.

Update the validate-e2e-tests-are-accounted-for exclusions to python-eks-test.yml,eks-setup-app-signals.yml,eks-cleanup-app-signals.yml — this repo uses the new shared-cluster test instead of the sequential python-eks-test.yml, and setup/cleanup are lifecycle workflows, not tests.

Re-running a failed EKS run: because the version tests depend on eks-setup's shared cluster state (which eks-cleanup tears down), re-running a single failed version job on its own won't work. Instead, use "Re-run this job" on eks-setup, which cascades to re-run setup → version tests → cleanup. The shared-cluster test prints this guidance on failure.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
