### PR TITLE
Extract shared Python release actions

### DIFF
--- a/.github/actions/get_main_build_run/action.yml
+++ b/.github/actions/get_main_build_run/action.yml
@@ -27,30 +27,20 @@ runs:
       id: main_build
       shell: bash
       env:
-        GH_TOKEN: ${{ inputs.github-token }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
         TARGET_BRANCH: ${{ inputs.branch }}
         WORKFLOW_NAME: ${{ inputs.workflow-name }}
       run: |
-        set -euo pipefail
-
         WORKFLOW_ID=$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows" |
-          jq -r --arg name "$WORKFLOW_NAME" 'first(.workflows[] | select(.name == $name) | .id) // empty')
-        if [ -z "$WORKFLOW_ID" ]; then
-          echo "Workflow '$WORKFLOW_NAME' was not found."
-          exit 1
-        fi
+          jq -r --arg name "$WORKFLOW_NAME" '.workflows[] | select(.name == $name) | .id')
+        LATEST_RUN=$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/$WORKFLOW_ID/runs" |
+          jq -c --arg branch "$TARGET_BRANCH" \
+            '[.workflow_runs[] | select(.head_branch == $branch)] | sort_by(.created_at) | .[-1]')
+        STATUS=$(echo "$LATEST_RUN" | jq -r '.status')
+        CONCLUSION=$(echo "$LATEST_RUN" | jq -r '.conclusion')
+        RUN_ID=$(echo "$LATEST_RUN" | jq -r '.id')
 
-        LATEST_RUN=$(gh api --method GET "repos/$GITHUB_REPOSITORY/actions/workflows/$WORKFLOW_ID/runs" \
-          -f branch="$TARGET_BRANCH" \
-          -f per_page=1)
-        RUN_ID=$(echo "$LATEST_RUN" | jq -r '.workflow_runs[0].id // empty')
-        STATUS=$(echo "$LATEST_RUN" | jq -r '.workflow_runs[0].status // empty')
-        CONCLUSION=$(echo "$LATEST_RUN" | jq -r '.workflow_runs[0].conclusion // empty')
-
-        if [ -z "$RUN_ID" ]; then
-          echo "No main build was found on branch $TARGET_BRANCH."
-          exit 1
-        elif [ "$STATUS" != "completed" ]; then
+        if [ "$STATUS" = "in_progress" ] || [ "$STATUS" = "queued" ]; then
           echo "Main build is still running (status: $STATUS). Cannot proceed with release."
           exit 1
         elif [ "$CONCLUSION" != "success" ]; then

--- a/.github/actions/get_main_build_run/action.yml
+++ b/.github/actions/get_main_build_run/action.yml
@@ -1,0 +1,62 @@
+## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+## SPDX-License-Identifier: Apache-2.0
+name: Get successful main build run
+description: Find the latest successful run of a workflow on a branch.
+
+inputs:
+  github-token:
+    required: true
+    description: GitHub token used to query workflow runs.
+  branch:
+    required: true
+    description: Branch whose latest workflow run should be used.
+  workflow-name:
+    required: false
+    default: Python Instrumentation Main Build
+    description: Name of the workflow to query.
+
+outputs:
+  run_id:
+    description: ID of the latest successful workflow run.
+    value: ${{ steps.main_build.outputs.run_id }}
+
+runs:
+  using: composite
+  steps:
+    - name: Get successful main build run
+      id: main_build
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        TARGET_BRANCH: ${{ inputs.branch }}
+        WORKFLOW_NAME: ${{ inputs.workflow-name }}
+      run: |
+        set -euo pipefail
+
+        WORKFLOW_ID=$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows" |
+          jq -r --arg name "$WORKFLOW_NAME" 'first(.workflows[] | select(.name == $name) | .id) // empty')
+        if [ -z "$WORKFLOW_ID" ]; then
+          echo "Workflow '$WORKFLOW_NAME' was not found."
+          exit 1
+        fi
+
+        LATEST_RUN=$(gh api --method GET "repos/$GITHUB_REPOSITORY/actions/workflows/$WORKFLOW_ID/runs" \
+          -f branch="$TARGET_BRANCH" \
+          -f per_page=1)
+        RUN_ID=$(echo "$LATEST_RUN" | jq -r '.workflow_runs[0].id // empty')
+        STATUS=$(echo "$LATEST_RUN" | jq -r '.workflow_runs[0].status // empty')
+        CONCLUSION=$(echo "$LATEST_RUN" | jq -r '.workflow_runs[0].conclusion // empty')
+
+        if [ -z "$RUN_ID" ]; then
+          echo "No main build was found on branch $TARGET_BRANCH."
+          exit 1
+        elif [ "$STATUS" != "completed" ]; then
+          echo "Main build is still running (status: $STATUS). Cannot proceed with release."
+          exit 1
+        elif [ "$CONCLUSION" != "success" ]; then
+          echo "Latest main build on branch $TARGET_BRANCH conclusion: $CONCLUSION"
+          exit 1
+        fi
+
+        echo "Main build succeeded (run ID: $RUN_ID)."
+        echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"

--- a/.github/actions/prepare_python_release_notes/action.yml
+++ b/.github/actions/prepare_python_release_notes/action.yml
@@ -1,0 +1,69 @@
+## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+## SPDX-License-Identifier: Apache-2.0
+name: Prepare Python release notes
+description: Write changelog entries and Python dependencies to a release notes file.
+
+inputs:
+  pyproject-file:
+    required: true
+    description: Path to the package pyproject.toml.
+  changelog-file:
+    required: true
+    description: Path to the package CHANGELOG.md.
+  version:
+    required: true
+    description: Package version whose changelog entries should be extracted.
+
+runs:
+  using: composite
+  steps:
+    - name: Prepare Python release notes
+      shell: bash
+      env:
+        CHANGELOG_FILE: ${{ inputs.changelog-file }}
+        PYPROJECT_FILE: ${{ inputs.pyproject-file }}
+        VERSION: ${{ inputs.version }}
+      run: |
+        # Extract all dependencies from pyproject.toml
+        DEPS=$(python3 -c "
+        import os, re
+        with open(os.environ['PYPROJECT_FILE'], 'r') as f:
+            content = f.read()
+        deps_match = re.search(r'dependencies\s*=\s*\[(.*?)\]', content, re.DOTALL)
+        if deps_match:
+            deps_content = deps_match.group(1)
+            dep_lines = re.findall(r'\"([^\"]+)\"', deps_content)
+            formatted_deps = []
+            for dep_line in dep_lines:
+                if ' == ' in dep_line:
+                    package, version = dep_line.split(' == ', 1)
+                    formatted_deps.append(f'- \`{package}\` - {version}')
+                else:
+                    formatted_deps.append(f'- \`{dep_line}\`')
+            print('\n'.join(formatted_deps))
+        ")
+
+        # Extract CHANGELOG entries for this version
+        CHANGELOG_ENTRIES=$(python3 -c "
+        import os, re
+        version = os.environ['VERSION']
+        with open(os.environ['CHANGELOG_FILE'], 'r') as f:
+            content = f.read()
+        version_pattern = rf'## v{re.escape(version)}.*?\n(.*?)(?=\n## |\Z)'
+        version_match = re.search(version_pattern, content, re.DOTALL)
+        if version_match:
+            entries = version_match.group(1).strip()
+            if entries:
+                # Join continuation lines (indented lines) with the previous line
+                joined = re.sub(r'\n  +', ' ', entries)
+                print(joined)
+        ")
+
+        # Create release notes
+        cat > release_notes.md << EOF
+        $(if [ -n "$CHANGELOG_ENTRIES" ]; then echo "## What's Changed"; echo "$CHANGELOG_ENTRIES"; echo ""; fi)
+
+        ## Upstream Components
+
+        $DEPS
+        EOF

--- a/.github/actions/publish_pypi/action.yml
+++ b/.github/actions/publish_pypi/action.yml
@@ -30,6 +30,7 @@ runs:
         name: ${{ inputs.source-artifact-name }}
         path: ${{ inputs.packages-dir }}
 
+    # The step below publishes to TestPyPI in order to catch any issues
     - name: Publish to TestPyPI
       uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e #v1.13.0
       with:
@@ -39,6 +40,7 @@ runs:
         verbose: true
         packages-dir: ${{ inputs.packages-dir }}
 
+    # Publish to prod PyPI
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e #v1.13.0
       with:

--- a/.github/actions/publish_pypi/action.yml
+++ b/.github/actions/publish_pypi/action.yml
@@ -1,0 +1,47 @@
+## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+## SPDX-License-Identifier: Apache-2.0
+name: Publish Python package
+description: Download wheel and source artifacts and publish them to TestPyPI and PyPI.
+
+inputs:
+  wheel-artifact-name:
+    required: true
+    description: Name of the GitHub Actions wheel artifact.
+  source-artifact-name:
+    required: true
+    description: Name of the GitHub Actions source artifact.
+  packages-dir:
+    required: false
+    default: dist-pypi
+    description: Directory used to stage distributions for publication.
+
+runs:
+  using: composite
+  steps:
+    - name: Download wheel artifact
+      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
+      with:
+        name: ${{ inputs.wheel-artifact-name }}
+        path: ${{ inputs.packages-dir }}
+
+    - name: Download source artifact
+      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
+      with:
+        name: ${{ inputs.source-artifact-name }}
+        path: ${{ inputs.packages-dir }}
+
+    - name: Publish to TestPyPI
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e #v1.13.0
+      with:
+        repository-url: https://test.pypi.org/legacy/
+        attestations: false
+        skip-existing: true
+        verbose: true
+        packages-dir: ${{ inputs.packages-dir }}
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e #v1.13.0
+      with:
+        skip-existing: true
+        verbose: true
+        packages-dir: ${{ inputs.packages-dir }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -411,54 +411,20 @@ jobs:
         run: |
           cp ${{ env.LAYER_ARTIFACT_NAME }} layer.zip
 
+      - name: Prepare Python release notes
+        uses: ./.github/actions/prepare_python_release_notes
+        with:
+          pyproject-file: aws-opentelemetry-distro/pyproject.toml
+          changelog-file: CHANGELOG.md
+          version: ${{ env.VERSION }}
+
       # Publish to GitHub releases
       - name: Create GH release
         id: create_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Extract all dependencies from pyproject.toml
-          DEPS=$(python3 -c "
-          import re
-          with open('aws-opentelemetry-distro/pyproject.toml', 'r') as f:
-              content = f.read()
-          deps_match = re.search(r'dependencies\s*=\s*\[(.*?)\]', content, re.DOTALL)
-          if deps_match:
-              deps_content = deps_match.group(1)
-              dep_lines = re.findall(r'\"([^\"]+)\"', deps_content)
-              formatted_deps = []
-              for dep_line in dep_lines:
-                  if ' == ' in dep_line:
-                      package, version = dep_line.split(' == ', 1)
-                      formatted_deps.append(f'- \`{package}\` - {version}')
-                  else:
-                      formatted_deps.append(f'- \`{dep_line}\`')
-              print('\n'.join(formatted_deps))
-          ")
-
-          # Extract CHANGELOG entries for this version
-          CHANGELOG_ENTRIES=$(python3 -c "
-          import re, os
-          version = os.environ['VERSION']
-          with open('CHANGELOG.md', 'r') as f:
-              content = f.read()
-          version_pattern = rf'## v{re.escape(version)}.*?\n(.*?)(?=\n## |\Z)'
-          version_match = re.search(version_pattern, content, re.DOTALL)
-          if version_match:
-              entries = version_match.group(1).strip()
-              if entries:
-                  # Join continuation lines (indented lines) with the previous line
-                  joined = re.sub(r'\n  +', ' ', entries)
-                  print(joined)
-          ")
-
-          # Create release notes
-          cat > release_notes.md << EOF
-          $(if [ -n "$CHANGELOG_ENTRIES" ]; then echo "## What's Changed"; echo "$CHANGELOG_ENTRIES"; echo ""; fi)
-
-          ## Upstream Components
-
-          $DEPS
+          cat >> release_notes.md << EOF
 
           ## Release Artifacts
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Download main build artifacts
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_ID: ${{ steps.main_build.outputs.run_id }}
         run: |
           gh run download "$RUN_ID" -n release-artifacts -D dist

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -41,27 +41,20 @@ jobs:
       - name: Checkout Repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
 
-      - name: Get main build run ID and download artifacts
+      - name: Get successful main build run
+        id: main_build
+        uses: ./.github/actions/get_main_build_run
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref_name }}
+
+      - name: Download main build artifacts
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ steps.main_build.outputs.run_id }}
         run: |
-          WORKFLOW_ID=$(gh api repos/${{ github.repository }}/actions/workflows --jq '.workflows[] | select(.name=="Python Instrumentation Main Build") | .id')
-          LATEST_RUN=$(gh api repos/${{ github.repository }}/actions/workflows/$WORKFLOW_ID/runs --jq '[.workflow_runs[] | select(.head_branch=="${{ github.ref_name }}")] | sort_by(.created_at) | .[-1]')
-          STATUS=$(echo "$LATEST_RUN" | jq -r '.status')
-          CONCLUSION=$(echo "$LATEST_RUN" | jq -r '.conclusion')
-          RUN_ID=$(echo "$LATEST_RUN" | jq -r '.id')
-          
-          if [ "$STATUS" = "in_progress" ] || [ "$STATUS" = "queued" ]; then
-            echo "Main build is still running (status: $STATUS). Cannot proceed with release."
-            exit 1
-          elif [ "$CONCLUSION" != "success" ]; then
-            echo "Latest main build on branch ${{ github.ref_name }} conclusion: $CONCLUSION"
-            exit 1
-          fi
-          echo "Main build succeeded (run ID: $RUN_ID), downloading artifacts..."
-          
-          gh run download $RUN_ID -n release-artifacts -D dist
-          gh run download $RUN_ID -n layer.zip -D layer
+          gh run download "$RUN_ID" -n release-artifacts -D dist
+          gh run download "$RUN_ID" -n layer.zip -D layer
 
       - name: Upload SDK wheel artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
@@ -126,35 +119,11 @@ jobs:
         with:
           registry: public.ecr.aws
      
-      - name: Download SDK wheel artifact
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
+      - name: Publish Python package
+        uses: ./.github/actions/publish_pypi
         with:
-          name: ${{ env.WHEEL_ARTIFACT_NAME }}
-          path: dist-pypi
-
-      - name: Download SDK source artifact
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
-        with:
-          name: ${{ env.SOURCE_ARTIFACT_NAME }}
-          path: dist-pypi
-      
-      # The step below publishes to testpypi in order to catch any issues 
-      - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          attestations: false
-          skip-existing: true
-          verbose: true
-          packages-dir: dist-pypi
-
-      # Publish to prod PyPI
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
-        with:
-          skip-existing: true
-          verbose: true
-          packages-dir: dist-pypi
+          wheel-artifact-name: ${{ env.WHEEL_ARTIFACT_NAME }}
+          source-artifact-name: ${{ env.SOURCE_ARTIFACT_NAME }}
 
       - name: Build and push image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0


### PR DESCRIPTION
Extracts the existing main-build gate, PyPI publishing steps, and common Python release-note preparation into reusable composite actions. The bodies are moved from the current release workflow with only path/input/output plumbing; package-specific downloads, release text, checksums, and assets remain in the callers. Equivalence commands and results are in the verification comment.