### PR TITLE
Pre-release cloudwatch-plugin-otel: Update version to 0.1.0

### DIFF
--- a/cloudwatch-plugin-otel/CHANGELOG.md
+++ b/cloudwatch-plugin-otel/CHANGELOG.md
@@ -10,5 +10,6 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
-- Initial package scaffold
-  ([#850](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/850))
+## v0.1.0 - 2026-08-14
+
+- Initial span metrics release

--- a/cloudwatch-plugin-otel/CHANGELOG.md
+++ b/cloudwatch-plugin-otel/CHANGELOG.md
@@ -13,3 +13,4 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 ## v0.1.0 - 2026-08-14
 
 - Initial span metrics release
+  ([#857](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/857))

--- a/cloudwatch-plugin-otel/src/plugins/opentelemetry/cloudwatch/version.py
+++ b/cloudwatch-plugin-otel/src/plugins/opentelemetry/cloudwatch/version.py
@@ -1,4 +1,4 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "0.1.0.dev0"
+__version__ = "0.1.0"


### PR DESCRIPTION
This PR updates cloudwatch-plugin-otel to version 0.1.0.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.