### PR TITLE
Use API tokens for CloudWatch plugin publishing

### DIFF
--- a/.github/workflows/release-cloudwatch-plugin-otel.yml
+++ b/.github/workflows/release-cloudwatch-plugin-otel.yml
@@ -8,6 +8,7 @@ on:
         required: true
 
 env:
+  AWS_DEFAULT_REGION: us-east-1
   PACKAGE_DIR: cloudwatch-plugin-otel
   VERSION: ${{ github.event.inputs.version }}
   WHEEL_ARTIFACT_NAME: cloudwatch_plugin_otel-${{ github.event.inputs.version }}-py3-none-any.whl
@@ -66,6 +67,24 @@ jobs:
       - name: Checkout Repo @ SHA - ${{ github.sha }}
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
 
+      - name: Configure AWS credentials for PyPI secrets
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 #v5.0.0
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_SECRETS_MANAGER }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
+      - name: Get PyPI secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 #v2.0.10
+        id: pypi_secrets
+        with:
+          secret-ids: |
+            PROD_PYPI_TOKEN,${{ secrets.PYPI_PROD_TOKEN_SECRET_ARN }}
+            TEST_PYPI_TOKEN,${{ secrets.PYPI_TEST_TOKEN_SECRET_ARN }}
+          parse-json-secrets: true
+
+      - name: Install twine
+        run: pip install twine==5.1.1
+
       - name: Download wheel artifact
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
         with:
@@ -80,21 +99,21 @@ jobs:
 
       # The step below publishes to TestPyPI in order to catch any issues
       - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e #v1.13.0
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          attestations: false
-          skip-existing: true
-          verbose: true
-          packages-dir: dist-pypi
+        env:
+          TWINE_USERNAME: '__token__'
+          TWINE_PASSWORD: ${{ env.TEST_PYPI_TOKEN_API_TOKEN }}
+        run: |
+          twine upload --repository testpypi --skip-existing --verbose \
+            "dist-pypi/$WHEEL_ARTIFACT_NAME" "dist-pypi/$SOURCE_ARTIFACT_NAME"
 
       # Publish to prod PyPI
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e #v1.13.0
-        with:
-          skip-existing: true
-          verbose: true
-          packages-dir: dist-pypi
+        env:
+          TWINE_USERNAME: '__token__'
+          TWINE_PASSWORD: ${{ env.PROD_PYPI_TOKEN_API_TOKEN }}
+        run: |
+          twine upload --skip-existing --verbose \
+            "dist-pypi/$WHEEL_ARTIFACT_NAME" "dist-pypi/$SOURCE_ARTIFACT_NAME"
 
       - name: Prepare Python release notes
         uses: ./.github/actions/prepare_python_release_notes


### PR DESCRIPTION
## Description

Restore the repository's previous token-based PyPI publishing mechanism for the CloudWatch plugin release workflow.

The current workflow invokes `pypa/gh-action-pypi-publish` without a password, which selects Trusted Publishing. TestPyPI rejected the token in [run 31855125372](https://github.com/aws-observability/aws-otel-python-instrumentation/actions/runs/31855125372/job/94938739333) because no matching Trusted Publisher is configured.

This change follows the token flow previously used by `release-build.yml` before commit `0c60c73`:

- assume `AWS_ROLE_ARN_SECRETS_MANAGER`
- retrieve the TestPyPI and PyPI token secrets by ARN
- parse the existing `*_PYPI_TOKEN_API_TOKEN` environment variables
- install the previously pinned `twine==5.1.1`
- upload to TestPyPI and PyPI as `__token__`

The only adaptations are the CloudWatch plugin artifact names and their current `dist-pypi/` staging directory.

## Testing

- `actionlint -ignore SC2027 -ignore SC2086 -ignore SC2129 -ignore SC2162 -ignore SC2206 .github/workflows/release-cloudwatch-plugin-otel.yml`
- Parsed the workflow with Ruby YAML
- Ran the repository SHA-pinned action policy check
- `git diff --check`
- Compared the credential retrieval and Twine upload steps line-by-line with the pre-`0c60c73` release workflow