### PR TITLE
Drop service.name from span-metric datapoint attributes; emit calls with {call} unit

### DIFF
--- a/cloudwatch-plugin-otel/CHANGELOG.md
+++ b/cloudwatch-plugin-otel/CHANGELOG.md
@@ -10,6 +10,12 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- `service.name` is no longer emitted as a metric datapoint attribute; it is carried by the
+  metric's resource (the host SDK's resource). Consumers reading `service.name` from datapoint
+  dimensions must read it from the resource instead.
+- The `traces.span.metrics.calls` counter now uses the `{call}` unit (UCUM annotation) instead of
+  an unset unit.
+
 ## v0.1.0 - 2026-08-14
 
 - Initial span metrics release

--- a/cloudwatch-plugin-otel/README.md
+++ b/cloudwatch-plugin-otel/README.md
@@ -6,13 +6,14 @@ Amazon CloudWatch plugin for OpenTelemetry.
 
 The span metrics instrumentor registers a span processor that emits:
 
-- `traces.span.metrics.calls`, a counter incremented once per ended span.
+- `traces.span.metrics.calls`, a counter (unit `{call}`) incremented once per ended span.
 - `traces.span.metrics.duration`, a histogram of span duration in seconds.
 
 Both metrics use the `cloudwatch.plugin.otel.span_metrics` instrumentation
-scope. They include `service.name`, `span.name`, `span.kind`, `status.code`, and
-supported HTTP, RPC, database, messaging, and error semantic-convention
-attributes when those attributes are present on the span.
+scope. They include `span.name`, `span.kind`, `status.code`, and supported
+HTTP, RPC, database, messaging, and error semantic-convention attributes when
+those attributes are present on the span. `service.name` is carried by the
+metric's resource (the host SDK's resource), not duplicated on each datapoint.
 
 The instrumentor also wraps the active root sampler. A `DROP` decision becomes
 `RECORD_ONLY`, allowing the span processor to derive metrics without changing

--- a/cloudwatch-plugin-otel/src/plugins/opentelemetry/cloudwatch/span_metrics/_constants.py
+++ b/cloudwatch-plugin-otel/src/plugins/opentelemetry/cloudwatch/span_metrics/_constants.py
@@ -14,9 +14,6 @@ def _semconv(module_path: str, name: str, literal: str) -> str:
         return literal
 
 
-_SERVICE = "opentelemetry.semconv.attributes.service_attributes"
-SERVICE_NAME = _semconv(_SERVICE, "SERVICE_NAME", "service.name")
-
 _HTTP = "opentelemetry.semconv.attributes.http_attributes"
 HTTP_REQUEST_METHOD = _semconv(_HTTP, "HTTP_REQUEST_METHOD", "http.request.method")
 HTTP_RESPONSE_STATUS_CODE = _semconv(_HTTP, "HTTP_RESPONSE_STATUS_CODE", "http.response.status_code")
@@ -63,6 +60,10 @@ class _SpanMetrics:
     SCOPE_NAME: Final = "cloudwatch.plugin.otel.span_metrics"
 
     CALLS_NAME: Final = "traces.span.metrics.calls"
+    # {call} is the UCUM annotation for counted things, matching OTel semconv counter conventions
+    # (cf. {request}, {operation}). The collector spanmetrics connector leaves the unit unset; the
+    # annotation is preferred because it states what is being counted.
+    CALLS_UNIT: Final = "{call}"
     DURATION_NAME: Final = "traces.span.metrics.duration"
     DURATION_UNIT: Final = "s"
     DURATION_BUCKET_BOUNDARIES: Final = [

--- a/cloudwatch-plugin-otel/src/plugins/opentelemetry/cloudwatch/span_metrics/connector.py
+++ b/cloudwatch-plugin-otel/src/plugins/opentelemetry/cloudwatch/span_metrics/connector.py
@@ -30,7 +30,6 @@ from plugins.opentelemetry.cloudwatch.span_metrics._constants import (
     RPC_SERVICE,
     RPC_SYSTEM,
     RPC_SYSTEM_NAME,
-    SERVICE_NAME,
     _SpanMetrics,
 )
 from plugins.opentelemetry.cloudwatch.version import __version__
@@ -50,9 +49,10 @@ class SpanMetricsConnector(SpanProcessor):
     """Span metrics processor implementation.
 
     `SpanMetricsConnector` is an implementation of `SpanProcessor` that derives
-    metrics from ended spans, dimensioned by `service.name`, `span.name`,
-    `span.kind`, and `status.code` (plus copied low-cardinality HTTP, RPC,
-    database, and messaging semantic-convention attributes):
+    metrics from ended spans, dimensioned by `span.name`, `span.kind`, and
+    `status.code` (plus copied low-cardinality HTTP, RPC, database, and
+    messaging semantic-convention attributes); `service.name` is carried by
+    the metric's resource, not duplicated on each datapoint:
 
     - `traces.span.metrics.calls`: a counter incremented once per span.
     - `traces.span.metrics.duration`: a histogram of span durations, in seconds.
@@ -65,7 +65,7 @@ class SpanMetricsConnector(SpanProcessor):
     def __init__(self, meter_provider: Optional[MeterProvider] = None) -> None:
         self.enabled = True
         meter: Meter = get_meter(_SpanMetrics.SCOPE_NAME, __version__, meter_provider)
-        self._calls_counter = meter.create_counter(_SpanMetrics.CALLS_NAME)
+        self._calls_counter = meter.create_counter(_SpanMetrics.CALLS_NAME, unit=_SpanMetrics.CALLS_UNIT)
         self._duration_histogram = meter.create_histogram(
             _SpanMetrics.DURATION_NAME,
             unit=_SpanMetrics.DURATION_UNIT,
@@ -130,10 +130,11 @@ class SpanMetricsConnector(SpanProcessor):
             _SpanMetrics.LIB_VERSION: __version__,
         }
 
-        if span.resource is not None:
-            service_name = span.resource.attributes.get(SERVICE_NAME)
-            if service_name is not None:
-                attributes[SERVICE_NAME] = service_name
+        # service.name is deliberately NOT a datapoint attribute: the metrics are recorded into the
+        # host SDK's MeterProvider, whose resource already carries service.name, so duplicating it
+        # on every datapoint would add a redundant dimension. Consumers read it from the metric
+        # resource. (Intentional divergence from the collector spanmetrics connector, which flattens
+        # it into datapoint attributes because collector-side consumers may drop the resource.)
 
         self._copy(attributes, span_attributes, HTTP_REQUEST_METHOD, HTTP_METHOD)
         self._copy(attributes, span_attributes, HTTP_RESPONSE_STATUS_CODE, HTTP_STATUS_CODE)

--- a/cloudwatch-plugin-otel/tests/span_metrics/test_connector.py
+++ b/cloudwatch-plugin-otel/tests/span_metrics/test_connector.py
@@ -83,10 +83,11 @@ class SpanMetricsConnectorTestBase(TestBase):
         self.assertIsNotNone(data_point, f"found no {metric_name} point for span {span_name!r}")
         return data_point
 
-    def assert_span_metrics(self, span_name, *, span_kind, status_code, service_name="unknown_service"):
+    def assert_span_metrics(self, span_name, *, span_kind, status_code):
         calls = self.get_metric_data_point(_SpanMetrics.CALLS_NAME, span_name)
         self.assertEqual(calls.value, 1)
-        self.assertEqual(calls.attributes[SERVICE_NAME], service_name)
+        # service.name lives on the metric resource, never on the datapoint.
+        self.assertNotIn(SERVICE_NAME, calls.attributes)
         self.assertEqual(calls.attributes[_SpanMetrics.SPAN_NAME], span_name)
         self.assertEqual(calls.attributes[_SpanMetrics.SPAN_KIND], span_kind)
         self.assertEqual(calls.attributes[_SpanMetrics.STATUS_CODE], status_code)
@@ -288,7 +289,6 @@ class TestSpanMetricsConnector(SpanMetricsConnectorTestBase):
         self.assertEqual(
             set(calls.attributes),
             {
-                SERVICE_NAME,
                 _SpanMetrics.SPAN_NAME,
                 _SpanMetrics.SPAN_KIND,
                 _SpanMetrics.STATUS_CODE,
@@ -321,13 +321,32 @@ class TestSpanMetricsConnector(SpanMetricsConnectorTestBase):
         duration = self.get_metric_data_point(_SpanMetrics.DURATION_NAME, "repeat")
         self.assertEqual(duration.count, 2)
 
-    def test_resource_service_name_used(self):
+    def test_service_name_never_on_datapoint_even_with_resource(self):
+        # service.name lives on the metric's resource (the host MeterProvider's resource); the
+        # datapoint must not duplicate it, even when the span's resource carries it.
         tracer_provider, _ = self.create_tracer_provider(resource=Resource.create({SERVICE_NAME: "orders-service"}))
         tracer_provider.add_span_processor(self.processor)
         with tracer_provider.get_tracer(__name__).start_as_current_span("resource-span", kind=SpanKind.CLIENT):
             pass
         calls = self.get_metric_data_point(_SpanMetrics.CALLS_NAME, "resource-span")
-        self.assertEqual(calls.attributes[SERVICE_NAME], "orders-service")
+        self.assertNotIn(SERVICE_NAME, calls.attributes)
+
+    def test_calls_counter_uses_call_annotation_unit_and_resource_carries_service_name(self):
+        self.record_span("unit-span")
+        for resource_metric in self.memory_metrics_reader.get_metrics_data().resource_metrics:
+            for scope_metric in resource_metric.scope_metrics:
+                for metric in scope_metric.metrics:
+                    if metric.name == _SpanMetrics.CALLS_NAME:
+                        # Assert the literal, not _SpanMetrics.CALLS_UNIT — comparing the exported
+                        # unit against the same constant the connector passes would be circular and
+                        # let a typo in the constant slip through.
+                        self.assertEqual(metric.unit, "{call}")
+                        # The positive half of the service.name contract: the metric RESOURCE
+                        # carries it (datapoint absence alone would also pass if it were dropped
+                        # everywhere).
+                        self.assertIn(SERVICE_NAME, resource_metric.resource.attributes)
+                        return
+        self.fail("calls metric not found")
 
     def test_default_meter_uses_global_provider_with_package_scope(self):
         self.tracer_provider.add_span_processor(SpanMetricsConnector())

--- a/contract-tests/tests/test/amazon/cloudwatch_plugin_otel/span_metrics/contract_test_base.py
+++ b/contract-tests/tests/test/amazon/cloudwatch_plugin_otel/span_metrics/contract_test_base.py
@@ -291,13 +291,28 @@ class SpanMetricsContractTestBase(TestCase):
         calls = self._get_latest_data_point(metrics, "traces.span.metrics.calls", expected)
         calls_attributes = self._attributes(calls.attributes)
         self.assertGreaterEqual(getattr(calls, calls.WhichOneof("value")), 1)
-        self.assertEqual(calls_attributes[SERVICE_NAME], "cloudwatch-plugin-otel-contract-test")
+        # service.name lives on the metric RESOURCE, never on the datapoint.
+        self.assertNotIn(SERVICE_NAME, calls_attributes)
+        self._assert_calls_metric_resource_service_name(metrics)
         self.assertEqual(calls_attributes["aws.otel.span.metrics.schema"], "v1")
         self.assertTrue(calls_attributes["aws.otel.extension.lib.version"])
 
         duration = self._get_latest_data_point(metrics, "traces.span.metrics.duration", calls_attributes)
         self.assertGreaterEqual(duration.count, 1)
         self.assertGreaterEqual(duration.sum, 0)
+
+    def _assert_calls_metric_resource_service_name(self, metrics: List[ResourceScopeMetric]) -> None:
+        """The metric's resource must carry the app's configured service.name (with its exact value —
+        the SDK unconditionally provides an unknown_service default, so key presence alone proves
+        nothing) and the calls counter must use the {call} unit."""
+        for resource_scope_metric in metrics:
+            if resource_scope_metric.metric.name != "traces.span.metrics.calls":
+                continue
+            resource_attributes = self._attributes(resource_scope_metric.resource_metrics.resource.attributes)
+            self.assertEqual(resource_attributes.get(SERVICE_NAME), "cloudwatch-plugin-otel-contract-test")
+            self.assertEqual(resource_scope_metric.metric.unit, "{call}")
+            return
+        self.fail("no traces.span.metrics.calls metric found")
 
     def _get_latest_data_point(
         self,


### PR DESCRIPTION
## Description

Two changes to the span-metrics schema emitted by the CloudWatch plugin:

1. **`service.name` is no longer a datapoint attribute.** The metrics are recorded into the host SDK's `MeterProvider`, whose resource already carries `service.name`, so duplicating it on every datapoint adds a redundant dimension with no extra information. Consumers read it from the metric resource. This intentionally diverges from the collector spanmetrics connector, which flattens `service.name` into datapoint attributes because collector-side consumers may drop the resource; here the resource is preserved end to end.

2. **`traces.span.metrics.calls` now uses the `{call}` unit** (UCUM annotation) instead of an unset unit, matching OTel semantic-convention counter conventions (cf. `{request}`, `{operation}`).

## Testing

- Unit tests updated: the connector suite asserts `service.name` is never emitted as a datapoint attribute (including when the span's resource carries it), that the metric **resource** carries `service.name`, and that the calls counter uses the literal `{call}` unit. 83 tests pass against both the oldest and latest supported OpenTelemetry requirement sets.
- Contract tests updated: the span-metrics harness now asserts `service.name` is absent from datapoints, present on the metric resource **with the configured value** (key presence alone can never fail — the SDK defaults `service.name` unconditionally), and the `{call}` unit. All 6 span-metrics contract tests (auto / manual / global instrumentation) pass locally against the built wheel and images.

CHANGELOG and README updated accordingly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.