### PR TITLE
feat: update OpenAI GenAI instrumentations

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -24,7 +24,8 @@ jobs:
       otel_contrib_version: ${{ steps.get_versions.outputs.otel_contrib_version }}
       aws_sdk_ext_version: ${{ steps.get_versions.outputs.opentelemetry_sdk_extension_aws_version }}
       aws_xray_prop_version: ${{ steps.get_versions.outputs.opentelemetry_propagator_aws_xray_version }}
-      openai_agents_v2_version: ${{ steps.get_versions.outputs.opentelemetry_instrumentation_openai_agents_v2_version }}
+      openai_agents_version: ${{ steps.get_versions.outputs.opentelemetry_instrumentation_genai_openai_agents_version }}
+      openai_client_version: ${{ steps.get_versions.outputs.opentelemetry_instrumentation_genai_openai_version }}
       breaking_changes_info: ${{ steps.breaking_changes.outputs.breaking_changes_info }}
     
     steps:
@@ -76,7 +77,8 @@ jobs:
         OTEL_CONTRIB_VERSION: ${{ steps.get_versions.outputs.otel_contrib_version }}
         OPENTELEMETRY_SDK_EXTENSION_AWS_VERSION: ${{ steps.get_versions.outputs.opentelemetry_sdk_extension_aws_version }}
         OPENTELEMETRY_PROPAGATOR_AWS_XRAY_VERSION: ${{ steps.get_versions.outputs.opentelemetry_propagator_aws_xray_version }}
-        OPENTELEMETRY_INSTRUMENTATION_OPENAI_AGENTS_V2_VERSION: ${{ steps.get_versions.outputs.opentelemetry_instrumentation_openai_agents_v2_version }}
+        OPENTELEMETRY_INSTRUMENTATION_GENAI_OPENAI_AGENTS_VERSION: ${{ steps.get_versions.outputs.opentelemetry_instrumentation_genai_openai_agents_version }}
+        OPENTELEMETRY_INSTRUMENTATION_GENAI_OPENAI_VERSION: ${{ steps.get_versions.outputs.opentelemetry_instrumentation_genai_openai_version }}
       run: python scripts/update_dependencies.py
     
     - name: Check for changes and commit
@@ -147,7 +149,8 @@ jobs:
         - [OpenTelemetry Contrib](https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/v${{ needs.update-dependencies.outputs.otel_contrib_version }}): ${{ needs.update-dependencies.outputs.otel_contrib_version }}
         - [opentelemetry-sdk-extension-aws](https://pypi.org/project/opentelemetry-sdk-extension-aws/${{ needs.update-dependencies.outputs.aws_sdk_ext_version }}/): ${{ needs.update-dependencies.outputs.aws_sdk_ext_version }}
         - [opentelemetry-propagator-aws-xray](https://pypi.org/project/opentelemetry-propagator-aws-xray/${{ needs.update-dependencies.outputs.aws_xray_prop_version }}/): ${{ needs.update-dependencies.outputs.aws_xray_prop_version }}
-        - [opentelemetry-instrumentation-openai-agents-v2](https://pypi.org/project/opentelemetry-instrumentation-openai-agents-v2/${{ needs.update-dependencies.outputs.openai_agents_v2_version }}/): ${{ needs.update-dependencies.outputs.openai_agents_v2_version }}
+        - [opentelemetry-instrumentation-genai-openai-agents](https://pypi.org/project/opentelemetry-instrumentation-genai-openai-agents/${{ needs.update-dependencies.outputs.openai_agents_version }}/): ${{ needs.update-dependencies.outputs.openai_agents_version }}
+        - [opentelemetry-instrumentation-genai-openai](https://pypi.org/project/opentelemetry-instrumentation-genai-openai/${{ needs.update-dependencies.outputs.openai_client_version }}/): ${{ needs.update-dependencies.outputs.openai_client_version }}
 
         **Upstream releases with breaking changes:**
         Note: the mechanism to detect upstream breaking changes is not perfect. Be sure to check all new releases and understand if any additional changes need to be addressed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- feat: migrate to the official OpenTelemetry GenAI OpenAI Agents and OpenAI client instrumentors
+  ([#862](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/862))
 - feat: attribute presigned S3 URLs as `AWS::S3` dependencies in Application Signals, opt-in via
   `OTEL_AWS_APPLICATION_SIGNALS_PRESIGNED_URL_ATTRIBUTION_ENABLED`
   ([#841](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/841))

--- a/aws-opentelemetry-distro/pyproject.toml
+++ b/aws-opentelemetry-distro/pyproject.toml
@@ -82,7 +82,8 @@ dependencies = [
   "opentelemetry-instrumentation-urllib3 == 0.65b0",
   "opentelemetry-instrumentation-wsgi == 0.65b0",
   "opentelemetry-instrumentation-cassandra == 0.65b0",
-  "opentelemetry-instrumentation-openai-agents-v2 == 0.1.0",
+  "opentelemetry-instrumentation-genai-openai-agents == 1.1b0",
+  "opentelemetry-instrumentation-genai-openai == 1.1b0",
   "cachetools == 6.2.4",
   "urllib3 >= 2.7.0; python_version >= '3.10'",
   "protobuf == 6.33.5",
@@ -126,7 +127,7 @@ aws_mcp = "amazon.opentelemetry.distro.instrumentation.mcp:McpInstrumentor"
 # Wraps the upstream OTel OpenAI Agents instrumentor under a unique entry point name.
 # This allows us to disable 3rd party "openai_agents" entry points in the opt-in path
 # while keeping OpenAI Agents instrumentation active via this alias.
-aws_openai_agents = "opentelemetry.instrumentation.openai_agents:OpenAIAgentsInstrumentor"
+aws_openai_agents = "opentelemetry.instrumentation.genai.openai_agents:OpenAIAgentsInstrumentor"
 
 [project.urls]
 Homepage = "https://github.com/aws-observability/aws-otel-python-instrumentation/tree/main/aws-opentelemetry-distro"

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
@@ -131,7 +131,7 @@ _THIRDPARTY_TO_AWS_NATIVE = {
 
 # Dist names owned by ADOT that register entry points with the same names as third-party ones.
 # These are excluded from third-party detection to avoid false positives.
-_ADOT_OWNED_DISTS = {"opentelemetry-instrumentation-openai-agents-v2"}
+_ADOT_OWNED_DISTS = {"opentelemetry-instrumentation-genai-openai-agents"}
 
 
 class AwsOpenTelemetryDistro(OpenTelemetryDistro):
@@ -261,7 +261,7 @@ class AwsOpenTelemetryDistro(OpenTelemetryDistro):
         """Skip AWS native agentic instrumentors that should not load.
 
         When agent observability is enabled:
-        - Skip ADOT-owned dists that duplicate an aws_* entry point (e.g. openai-agents-v2).
+        - Skip ADOT-owned dists that duplicate an aws_* entry point (e.g. genai-openai-agents).
         - AWS_AGENTIC_INSTRUMENTATION (auto/enabled/disabled) governs the aws_* side only.
           See the constant docstring for semantics. Third-party instrumentors are never
           touched here.

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/code_correlation/internal/3rd.txt
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/code_correlation/internal/3rd.txt
@@ -4671,6 +4671,8 @@ ocspbuilder
 apache-airflow-providers-apache-livy
 opentelemetry-instrumentation-openai-agents
 opentelemetry-instrumentation-openai-agents-v2
+opentelemetry-instrumentation-genai-openai
+opentelemetry-instrumentation-genai-openai-agents
 pyserde
 mypy-boto3-ssm-guiconnect
 evergreen-lint

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/openai_agents/test_openai_agents_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/openai_agents/test_openai_agents_instrumentor.py
@@ -5,14 +5,15 @@ import unittest
 from importlib.metadata import entry_points
 
 try:
-    from opentelemetry.instrumentation.openai_agents import OpenAIAgentsInstrumentor
+    from opentelemetry.instrumentation.genai.openai import OpenAIInstrumentor
+    from opentelemetry.instrumentation.genai.openai_agents import OpenAIAgentsInstrumentor
 
     _AVAILABLE = True
 except ImportError:
     _AVAILABLE = False
 
 
-@unittest.skipUnless(_AVAILABLE, "opentelemetry-instrumentation-openai-agents-v2 not available")
+@unittest.skipUnless(_AVAILABLE, "OpenTelemetry OpenAI instrumentors not available")
 class TestOpenAIAgentsInstrumentation(unittest.TestCase):
 
     def test_aws_openai_agents_entry_point_resolves(self):
@@ -22,6 +23,14 @@ class TestOpenAIAgentsInstrumentation(unittest.TestCase):
         ep = list(eps)[0]
         instrumentor_class = ep.load()
         self.assertIs(instrumentor_class, OpenAIAgentsInstrumentor)
+
+    def test_openai_client_entry_point_resolves(self):
+        eps = entry_points(group="opentelemetry_instrumentor", name="openai")
+        self.assertEqual(len(list(eps)), 1)
+
+        ep = list(eps)[0]
+        instrumentor_class = ep.load()
+        self.assertIs(instrumentor_class, OpenAIInstrumentor)
 
     def test_aws_entry_point_survives_when_openai_agents_disabled(self):
         disabled = {"openai_agents"}

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelemetry_distro.py
@@ -529,15 +529,15 @@ class TestAwsOpenTelemetryDistro(TestCase):
             return mock_super
 
     def test_skip_adot_owned_dist(self):
-        """ADOT-owned v2 package should be skipped when agent observability is enabled."""
-        ep = self._make_ep("openai_agents", "opentelemetry-instrumentation-openai-agents-v2")
+        """ADOT-owned Agents package should be skipped when agent observability is enabled."""
+        ep = self._make_ep("openai_agents", "opentelemetry-instrumentation-genai-openai-agents")
         mock_super = self._load_instrumentor_with_agent(ep)
         mock_super.assert_not_called()
 
     def test_load_adot_owned_dist_when_agent_disabled(self):
-        """ADOT-owned v2 package should load when agent observability is disabled."""
+        """ADOT-owned Agents package should load when agent observability is disabled."""
         distro = AwsOpenTelemetryDistro()
-        ep = self._make_ep("openai_agents", "opentelemetry-instrumentation-openai-agents-v2")
+        ep = self._make_ep("openai_agents", "opentelemetry-instrumentation-genai-openai-agents")
         with patch(
             "amazon.opentelemetry.distro.aws_opentelemetry_distro.is_agent_observability_enabled", return_value=False
         ), patch.object(OpenTelemetryDistro, "load_instrumentor") as mock_super:
@@ -630,10 +630,10 @@ class TestAwsOpenTelemetryDistro(TestCase):
         mock_super = self._load_instrumentor_with_agent(ep, third_party_eps=third_party)
         mock_super.assert_not_called()
 
-    def test_adot_v2_openai_agents_not_treated_as_third_party(self):
-        """ADOT v2 openai_agents should not cause aws_openai_agents to be skipped."""
+    def test_adot_openai_agents_not_treated_as_third_party(self):
+        """ADOT openai_agents should not cause aws_openai_agents to be skipped."""
         ep = self._make_ep("aws_openai_agents", "aws-opentelemetry-distro")
-        third_party = [self._make_ep("openai_agents", "opentelemetry-instrumentation-openai-agents-v2")]
+        third_party = [self._make_ep("openai_agents", "opentelemetry-instrumentation-genai-openai-agents")]
         mock_super = self._load_instrumentor_with_agent(ep, third_party_eps=third_party)
         mock_super.assert_called_once_with(ep)
 

--- a/scripts/get_upstream_versions.py
+++ b/scripts/get_upstream_versions.py
@@ -13,7 +13,8 @@ import requests
 INDEPENDENT_DEPS = [
     "opentelemetry-sdk-extension-aws",
     "opentelemetry-propagator-aws-xray",
-    "opentelemetry-instrumentation-openai-agents-v2",
+    "opentelemetry-instrumentation-genai-openai-agents",
+    "opentelemetry-instrumentation-genai-openai",
 ]
 
 
@@ -50,7 +51,11 @@ def get_latest_independent_versions():
     versions = {}
     for dep in INDEPENDENT_DEPS:
         try:
-            result = subprocess.run(["pip", "index", "versions", dep], capture_output=True, text=True, check=True)
+            command = ["pip", "index", "versions"]
+            if dep.startswith("opentelemetry-instrumentation-genai-"):
+                command.append("--pre")
+            command.append(dep)
+            result = subprocess.run(command, capture_output=True, text=True, check=True)
             # Parse output like "package (1.2.3)" from first line
             first_line = result.stdout.strip().split("\n")[0]
             match = re.search(r"\(([^)]+)\)", first_line)

--- a/scripts/update_dependencies.py
+++ b/scripts/update_dependencies.py
@@ -74,7 +74,8 @@ CONTRIB_DEPS = [
 INDEPENDENT_DEPS = [
     "opentelemetry-sdk-extension-aws",
     "opentelemetry-propagator-aws-xray",
-    "opentelemetry-instrumentation-openai-agents-v2",
+    "opentelemetry-instrumentation-genai-openai-agents",
+    "opentelemetry-instrumentation-genai-openai",
 ]
 
 
@@ -143,20 +144,22 @@ def main():
     otel_contrib_version = os.environ.get("OTEL_CONTRIB_VERSION")
     aws_sdk_ext_version = os.environ.get("OPENTELEMETRY_SDK_EXTENSION_AWS_VERSION")
     aws_xray_prop_version = os.environ.get("OPENTELEMETRY_PROPAGATOR_AWS_XRAY_VERSION")
-    openai_agents_v2_version = os.environ.get("OPENTELEMETRY_INSTRUMENTATION_OPENAI_AGENTS_V2_VERSION")
+    openai_agents_version = os.environ.get("OPENTELEMETRY_INSTRUMENTATION_GENAI_OPENAI_AGENTS_VERSION")
+    openai_version = os.environ.get("OPENTELEMETRY_INSTRUMENTATION_GENAI_OPENAI_VERSION")
 
     if not otel_python_version or not otel_contrib_version:
         print("Error: OTEL_PYTHON_VERSION and OTEL_CONTRIB_VERSION environment variables required")
         sys.exit(1)
 
-    if not aws_sdk_ext_version or not aws_xray_prop_version or not openai_agents_v2_version:
+    if not aws_sdk_ext_version or not aws_xray_prop_version or not openai_agents_version or not openai_version:
         print("Error: independent dependency versions required")
         sys.exit(1)
 
     independent_versions = {
         "opentelemetry-sdk-extension-aws": aws_sdk_ext_version,
         "opentelemetry-propagator-aws-xray": aws_xray_prop_version,
-        "opentelemetry-instrumentation-openai-agents-v2": openai_agents_v2_version,
+        "opentelemetry-instrumentation-genai-openai-agents": openai_agents_version,
+        "opentelemetry-instrumentation-genai-openai": openai_version,
     }
 
     # All files to update


### PR DESCRIPTION
## Description

- Replace the deprecated `opentelemetry-instrumentation-openai-agents-v2`
  dependency with `opentelemetry-instrumentation-genai-openai-agents==1.1b0`.
- Add `opentelemetry-instrumentation-genai-openai==1.1b0` so OpenAI client
  calls continue to emit chat, Responses API, embedding, speech, and
  transcription telemetry.
- Update the ADOT alias, ownership detection, tests, code-correlation package
  list, and nightly dependency automation for the renamed packages.

The upstream Agents release notes state that the Agents instrumentor no longer
captures OpenAI client spans because those are covered by the separate OpenAI
instrumentor. The `1.1b0` OpenAI client release also adds support for OpenAI
Python SDK v3.

## Testing

- Built `aws_opentelemetry_distro-0.19.0.dev0-py3-none-any.whl`.
- Ran the focused OpenAI instrumentation tests: 4 passed.
- Ran `test_aws_opentelemetry_distro.py`: 42 passed.
- Loaded the `aws_openai_agents`, `openai_agents`, and `openai` entry points.
- Instrumented and uninstrumented both OpenAI instrumentors with
  `openai-agents==0.22.0` and `openai==3.3.1`.
- Ran Black and Flake8 checks on changed Python files.
- Verified the nightly version-discovery script returns both `1.1b0` releases.

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
