### PR TITLE
pin litellm to sub 1.97 for 3.10 to resolve dependency issue with crewAI tests in 3.10 unit tests

### DIFF
--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/crewai/requirements.latest.txt
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/crewai/requirements.latest.txt
@@ -1,1 +1,12 @@
 crewai[litellm,anthropic,bedrock,azure-ai-inference,google-genai]>=1.10.0,<2
+# Python 3.10 ONLY: cap litellm below 1.97.0. Two separate upstream breakages force this, and both are
+# specific to 3.10 (litellm 1.97.0+ works on 3.11+, so those envs stay uncapped and test the latest):
+#   1. On 3.10, litellm 1.97.0's `litellm.types.utils.Message` references `ChatCompletionReasoningSummaryTextBlock`,
+#      which is not resolvable in that module's namespace on 3.10, so the pydantic model is never finalized and
+#      constructing `Message(...)` raises PydanticUserError ("`Message` is not fully defined"). Our tests build
+#      litellm's `Message` directly, so every crew-kickoff test fails. (Constructs fine on 3.11+.)
+#   2. litellm 1.98.0 (2026-08-22) imports `NotRequired` from `typing` (3.11+ only), so it fails to import
+#      on Python 3.10 entirely (crewai then reports the LiteLLM fallback as "not installed").
+# 1.96.2 is the newest release that imports on 3.10 AND has a constructible `Message`. Lift this cap once
+# litellm ships a release that both imports on 3.10 and defines `Message` fully. Upstream: BerriAI/litellm.
+litellm<1.97.0; python_version == "3.10"


### PR DESCRIPTION
CrewAI had a chage in dependencies which means it no longer interfaces with the most recent version of litellm. The next working version of litellm that interfaces with the most current version of CrewAI is 1.96.x so we temporarily pin the version of litellm to be that. 





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

