### PR TITLE
add image_scan operation to release-build

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -160,6 +160,14 @@ jobs:
             ${{ env.RELEASE_PUBLIC_REPOSITORY }}:v${{ env.VERSION }}
             ${{ env.RELEASE_PRIVATE_REPOSITORY }}:v${{ env.VERSION }}
 
+      - name: Perform image scan
+        uses: ./.github/actions/image_scan
+        with:
+          image-ref: ${{ env.RELEASE_PUBLIC_REPOSITORY }}:v${{ env.VERSION }}
+          severity: 'CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN'
+          logout: 'false'
+          trivyignore-file: .github/trivy/daily-scan.trivyignore.yaml
+
       - name: Tag platform images in private ECR
         env:
           REPO_NAME: adot-autoinstrumentation-python


### PR DESCRIPTION
title

As part of adding trivy artifact verification to release builds.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

