### PR TITLE
Only demote duplicate nested GenAI client spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- Only demote duplicate nested GenAI client spans
+  ([#872](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/872))
 - (fix): Align and capture missing GenAI request attributes from framework LLM calls
   ([#871](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/871))
 - fix: align LlamaIndex tools with the OTel GenAI schema and expand GenAI contract coverage

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
@@ -31,7 +31,7 @@ from amazon.opentelemetry.distro.aws_span_metrics_processor_builder import AwsSp
 from amazon.opentelemetry.distro.exporter.console.logs.compact_console_log_exporter import (
     CompactConsoleLogRecordExporter,
 )
-from amazon.opentelemetry.distro.gen_ai_nested_client_span_processor import GenAiNestedClientSpanProcessor
+from amazon.opentelemetry.distro.gen_ai_nested_client_span_processor import GenAINestedClientSpanProcessor
 from amazon.opentelemetry.distro.otlp_udp_exporter import OTLPUdpSpanExporter
 from amazon.opentelemetry.distro.sampler._aws_xray_adaptive_sampling_config import (
     _AnomalyCaptureLimit,
@@ -340,7 +340,7 @@ def _init_tracing(
     )
 
     if is_agent_observability_enabled():
-        trace_provider.add_span_processor(GenAiNestedClientSpanProcessor())
+        trace_provider.add_span_processor(GenAINestedClientSpanProcessor())
 
     for _, exporter_class in exporters.items():
         exporter_args: Dict[str, any] = {}

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
@@ -339,6 +339,9 @@ def _init_tracing(
         resource=resource,
     )
 
+    if is_agent_observability_enabled():
+        trace_provider.add_span_processor(GenAiNestedClientSpanProcessor())
+
     for _, exporter_class in exporters.items():
         exporter_args: Dict[str, any] = {}
         span_exporter: SpanExporter = exporter_class(**exporter_args)
@@ -606,7 +609,6 @@ def _customize_span_processors(provider: TracerProvider, resource: Resource, sam
     # and quality degradation that sampling could miss.
     if is_agent_observability_enabled():
         _export_unsampled_span_for_agent_observability(provider, resource)
-        provider.add_span_processor(GenAiNestedClientSpanProcessor())
         baggage_keys.add("session.id")
 
     provider.add_span_processor(BaggageSpanProcessor(lambda key: key in baggage_keys))

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
@@ -339,6 +339,8 @@ def _init_tracing(
         resource=resource,
     )
 
+    # This processor modifies span kind in on_end, so it must run before batch
+    # processors to ensure exporters observe the updated kind.
     if is_agent_observability_enabled():
         trace_provider.add_span_processor(GenAINestedClientSpanProcessor())
 

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/gen_ai_nested_client_span_processor.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/gen_ai_nested_client_span_processor.py
@@ -24,12 +24,11 @@ class GenAiNestedClientSpanProcessor(SpanProcessor):
         pass
 
     def on_end(self, span: ReadableSpan) -> None:
+        span_id = span.context.span_id if span.context else None
+        has_gen_ai_client_child = bool(span_id and self._has_gen_ai_client_child.pop(span_id))
+
         if span.kind != SpanKind.CLIENT:
             return
-
-        parent_span_id = span.parent.span_id if span.parent else None
-        if parent_span_id:
-            self._has_gen_ai_client_child.put(parent_span_id, True)
 
         is_llm_span = (span.attributes or {}).get(GEN_AI_OPERATION_NAME) in (
             GenAiOperationNameValues.CHAT.value,
@@ -37,7 +36,14 @@ class GenAiNestedClientSpanProcessor(SpanProcessor):
             GenAiOperationNameValues.GENERATE_CONTENT.value,
             GenAiOperationNameValues.EMBEDDINGS.value,
         )
-        if is_llm_span and span.context and self._has_gen_ai_client_child.pop(span.context.span_id):
+        if not is_llm_span:
+            return
+
+        parent_span_id = span.parent.span_id if span.parent else None
+        if parent_span_id:
+            self._has_gen_ai_client_child.put(parent_span_id, True)
+
+        if has_gen_ai_client_child:
             span._kind = SpanKind.INTERNAL  # noqa: SLF001
 
     def shutdown(self) -> None:

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/gen_ai_nested_client_span_processor.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/gen_ai_nested_client_span_processor.py
@@ -9,13 +9,6 @@ from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
 )
 from opentelemetry.trace import SpanKind
 
-_GEN_AI_INFERENCE_OPERATIONS = (
-    GenAiOperationNameValues.CHAT.value,
-    GenAiOperationNameValues.TEXT_COMPLETION.value,
-    GenAiOperationNameValues.GENERATE_CONTENT.value,
-    GenAiOperationNameValues.EMBEDDINGS.value,
-)
-
 
 class GenAiNestedClientSpanProcessor(SpanProcessor):
     # OTel GenAI semantic conventions require outgoing LLM calls to be CLIENT spans.
@@ -31,10 +24,16 @@ class GenAiNestedClientSpanProcessor(SpanProcessor):
         pass
 
     def on_end(self, span: ReadableSpan) -> None:
+        gen_ai_inference_operations = (
+            GenAiOperationNameValues.CHAT.value,
+            GenAiOperationNameValues.TEXT_COMPLETION.value,
+            GenAiOperationNameValues.GENERATE_CONTENT.value,
+            GenAiOperationNameValues.EMBEDDINGS.value,
+        )
         span_id = span.context.span_id if span.context else None
         child_operations = {
             operation
-            for operation in _GEN_AI_INFERENCE_OPERATIONS
+            for operation in gen_ai_inference_operations
             if span_id and self._has_gen_ai_client_child.pop((span_id, operation))
         }
 
@@ -42,7 +41,7 @@ class GenAiNestedClientSpanProcessor(SpanProcessor):
             return
 
         operation = (span.attributes or {}).get(GEN_AI_OPERATION_NAME)
-        if operation not in _GEN_AI_INFERENCE_OPERATIONS:
+        if operation not in gen_ai_inference_operations:
             return
 
         parent_span_id = span.parent.span_id if span.parent else None

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/gen_ai_nested_client_span_processor.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/gen_ai_nested_client_span_processor.py
@@ -10,14 +10,14 @@ from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
 from opentelemetry.trace import SpanKind
 
 
-class GenAiNestedClientSpanProcessor(SpanProcessor):
+class GenAINestedClientSpanProcessor(SpanProcessor):
     # OTel GenAI semantic conventions require outgoing LLM calls to be CLIENT spans.
-    # However, the same call can be instrumented by both the agentic framework
-    # and the underlying LLM client SDK, producing nested CLIENT spans for a single request.
-    # This processor converts the outer span to INTERNAL so only the innermost
-    # SDK spans remains CLIENT, avoiding the nested CLIENT anti-pattern.
+    # Framework and SDK instrumentation can produce nested CLIENT spans for the same call.
+    # Demote the outer span to INTERNAL only when the child has the same GenAI
+    # inference operation; HTTP and different-operation children leave it CLIENT.
 
     def __init__(self):
+        # Maps (parent span ID, operation) to whether a matching GenAI CLIENT child ended.
         self._has_gen_ai_client_child: DictWithLock = DictWithLock()
 
     def on_start(self, span: Span, parent_context=None) -> None:
@@ -30,6 +30,7 @@ class GenAiNestedClientSpanProcessor(SpanProcessor):
             GenAiOperationNameValues.GENERATE_CONTENT.value,
             GenAiOperationNameValues.EMBEDDINGS.value,
         )
+        # Clean up before early returns so child state cannot leak for non-GenAI parents.
         span_id = span.context.span_id if span.context else None
         child_operations = {
             operation

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/gen_ai_nested_client_span_processor.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/gen_ai_nested_client_span_processor.py
@@ -12,13 +12,14 @@ from opentelemetry.trace import SpanKind
 
 class GenAINestedClientSpanProcessor(SpanProcessor):
     # OTel GenAI semantic conventions require outgoing LLM calls to be CLIENT spans.
-    # Framework and SDK instrumentation can produce nested CLIENT spans for the same call.
-    # Demote the outer span to INTERNAL only when the child has the same GenAI
-    # inference operation; HTTP and different-operation children leave it CLIENT.
+    # However, the same call can be instrumented by both the agentic framework
+    # and the underlying LLM client SDK, producing nested CLIENT spans for a single request.
+    # This processor converts the outer span to INTERNAL only when its child has
+    # the same GenAI inference operation.
 
     def __init__(self):
-        # Maps (parent span ID, operation) to whether a matching GenAI CLIENT child ended.
-        self._has_gen_ai_client_child: DictWithLock = DictWithLock()
+        # Tracks which parent spans have a GenAI CLIENT child for each operation.
+        self._parent_span_id_and_operation_to_gen_ai_client_child: DictWithLock = DictWithLock()
 
     def on_start(self, span: Span, parent_context=None) -> None:
         pass
@@ -35,7 +36,7 @@ class GenAINestedClientSpanProcessor(SpanProcessor):
         child_operations = {
             operation
             for operation in gen_ai_inference_operations
-            if span_id and self._has_gen_ai_client_child.pop((span_id, operation))
+            if span_id and self._parent_span_id_and_operation_to_gen_ai_client_child.pop((span_id, operation))
         }
 
         if span.kind != SpanKind.CLIENT:
@@ -47,13 +48,13 @@ class GenAINestedClientSpanProcessor(SpanProcessor):
 
         parent_span_id = span.parent.span_id if span.parent else None
         if parent_span_id:
-            self._has_gen_ai_client_child.put((parent_span_id, operation), True)
+            self._parent_span_id_and_operation_to_gen_ai_client_child.put((parent_span_id, operation), True)
 
         if operation in child_operations:
             span._kind = SpanKind.INTERNAL  # noqa: SLF001
 
     def shutdown(self) -> None:
-        self._has_gen_ai_client_child.clear()
+        self._parent_span_id_and_operation_to_gen_ai_client_child.clear()
 
     def force_flush(self, timeout_millis: int = 30000) -> bool:  # pylint: disable=no-self-use
         return True

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/gen_ai_nested_client_span_processor.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/gen_ai_nested_client_span_processor.py
@@ -9,6 +9,13 @@ from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
 )
 from opentelemetry.trace import SpanKind
 
+_GEN_AI_INFERENCE_OPERATIONS = (
+    GenAiOperationNameValues.CHAT.value,
+    GenAiOperationNameValues.TEXT_COMPLETION.value,
+    GenAiOperationNameValues.GENERATE_CONTENT.value,
+    GenAiOperationNameValues.EMBEDDINGS.value,
+)
+
 
 class GenAiNestedClientSpanProcessor(SpanProcessor):
     # OTel GenAI semantic conventions require outgoing LLM calls to be CLIENT spans.
@@ -25,25 +32,24 @@ class GenAiNestedClientSpanProcessor(SpanProcessor):
 
     def on_end(self, span: ReadableSpan) -> None:
         span_id = span.context.span_id if span.context else None
-        has_gen_ai_client_child = bool(span_id and self._has_gen_ai_client_child.pop(span_id))
+        child_operations = {
+            operation
+            for operation in _GEN_AI_INFERENCE_OPERATIONS
+            if span_id and self._has_gen_ai_client_child.pop((span_id, operation))
+        }
 
         if span.kind != SpanKind.CLIENT:
             return
 
-        is_llm_span = (span.attributes or {}).get(GEN_AI_OPERATION_NAME) in (
-            GenAiOperationNameValues.CHAT.value,
-            GenAiOperationNameValues.TEXT_COMPLETION.value,
-            GenAiOperationNameValues.GENERATE_CONTENT.value,
-            GenAiOperationNameValues.EMBEDDINGS.value,
-        )
-        if not is_llm_span:
+        operation = (span.attributes or {}).get(GEN_AI_OPERATION_NAME)
+        if operation not in _GEN_AI_INFERENCE_OPERATIONS:
             return
 
         parent_span_id = span.parent.span_id if span.parent else None
         if parent_span_id:
-            self._has_gen_ai_client_child.put(parent_span_id, True)
+            self._has_gen_ai_client_child.put((parent_span_id, operation), True)
 
-        if has_gen_ai_client_child:
+        if operation in child_operations:
             span._kind = SpanKind.INTERNAL  # noqa: SLF001
 
     def shutdown(self) -> None:

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py
@@ -42,6 +42,7 @@ from amazon.opentelemetry.distro.aws_opentelemetry_configurator import (
     _fetch_logs_header,
     _init_logging,
     _init_serviceevents,
+    _init_tracing,
     _is_application_signals_enabled,
     _is_application_signals_runtime_enabled,
     _is_defer_to_workers_enabled,
@@ -606,14 +607,28 @@ class TestAwsOpenTelemetryConfigurator(TestCase):
         os.environ["AGENT_OBSERVABILITY_ENABLED"] = "true"
         os.environ["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] = "https://xray.us-east-1.amazonaws.com/v1/traces"
         _customize_span_processors(mock_tracer_provider, Resource.get_empty(), mock_sampler)
-        self.assertEqual(mock_tracer_provider.add_span_processor.call_count, 3)
+        self.assertEqual(mock_tracer_provider.add_span_processor.call_count, 2)
+        self.assertIsInstance(
+            mock_tracer_provider.add_span_processor.call_args_list[0].args[0], BatchUnsampledSpanProcessor
+        )
+        self.assertIsInstance(mock_tracer_provider.add_span_processor.call_args_list[1].args[0], BaggageSpanProcessor)
 
-        first_processor = mock_tracer_provider.add_span_processor.call_args_list[0].args[0]
-        self.assertIsInstance(first_processor, BatchUnsampledSpanProcessor)
-        second_processor = mock_tracer_provider.add_span_processor.call_args_list[1].args[0]
-        self.assertIsInstance(second_processor, GenAiNestedClientSpanProcessor)
-        third_processor = mock_tracer_provider.add_span_processor.call_args_list[2].args[0]
-        self.assertIsInstance(third_processor, BaggageSpanProcessor)
+        trace_provider = MagicMock()
+        batch_processor = MagicMock()
+        exporter = MagicMock()
+        with patch.multiple(
+            "amazon.opentelemetry.distro.aws_opentelemetry_configurator",
+            TracerProvider=MagicMock(return_value=trace_provider),
+            BatchSpanProcessor=MagicMock(return_value=batch_processor),
+            _customize_span_exporter=MagicMock(return_value=exporter),
+            _customize_span_processors=MagicMock(),
+            set_tracer_provider=MagicMock(),
+        ):
+            _init_tracing({"otlp": MagicMock(return_value=exporter)})
+
+        processors = [call.args[0] for call in trace_provider.add_span_processor.call_args_list]
+        self.assertIsInstance(processors[0], GenAiNestedClientSpanProcessor)
+        self.assertIs(processors[1], batch_processor)
 
         os.environ.pop("AGENT_OBSERVABILITY_ENABLED", None)
         os.environ.pop("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", None)
@@ -1016,14 +1031,13 @@ class TestAwsOpenTelemetryConfigurator(TestCase):
         os.environ.setdefault("AGENT_OBSERVABILITY_ENABLED", "true")
         os.environ.setdefault("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "https://xray.us-east-1.amazonaws.com/v1/traces")
         _customize_span_processors(mock_tracer_provider, Resource.get_empty(), mock_sampler)
-        self.assertEqual(mock_tracer_provider.add_span_processor.call_count, 5)
+        self.assertEqual(mock_tracer_provider.add_span_processor.call_count, 4)
 
         processors = [call.args[0] for call in mock_tracer_provider.add_span_processor.call_args_list]
         self.assertIsInstance(processors[0], BatchUnsampledSpanProcessor)
-        self.assertIsInstance(processors[1], GenAiNestedClientSpanProcessor)
-        self.assertIsInstance(processors[2], BaggageSpanProcessor)
-        self.assertIsInstance(processors[3], AttributePropagatingSpanProcessor)
-        self.assertIsInstance(processors[4], AwsSpanMetricsProcessor)
+        self.assertIsInstance(processors[1], BaggageSpanProcessor)
+        self.assertIsInstance(processors[2], AttributePropagatingSpanProcessor)
+        self.assertIsInstance(processors[3], AwsSpanMetricsProcessor)
 
         os.environ.pop("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
 

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py
@@ -64,7 +64,7 @@ from amazon.opentelemetry.distro.exporter.otlp.aws.logs._aws_cw_otlp_batch_log_r
 )
 from amazon.opentelemetry.distro.exporter.otlp.aws.logs.otlp_aws_log_record_exporter import OTLPAwsLogRecordExporter
 from amazon.opentelemetry.distro.exporter.otlp.aws.traces.otlp_aws_span_exporter import OTLPAwsSpanExporter
-from amazon.opentelemetry.distro.gen_ai_nested_client_span_processor import GenAiNestedClientSpanProcessor
+from amazon.opentelemetry.distro.gen_ai_nested_client_span_processor import GenAINestedClientSpanProcessor
 from amazon.opentelemetry.distro.otlp_udp_exporter import OTLPUdpSpanExporter
 from amazon.opentelemetry.distro.sampler._aws_xray_sampling_client import _AwsXRaySamplingClient
 from amazon.opentelemetry.distro.sampler.aws_xray_remote_sampler import AwsXRayRemoteSampler
@@ -627,7 +627,7 @@ class TestAwsOpenTelemetryConfigurator(TestCase):
             _init_tracing({"otlp": MagicMock(return_value=exporter)})
 
         processors = [call.args[0] for call in trace_provider.add_span_processor.call_args_list]
-        self.assertIsInstance(processors[0], GenAiNestedClientSpanProcessor)
+        self.assertIsInstance(processors[0], GenAINestedClientSpanProcessor)
         self.assertIs(processors[1], batch_processor)
 
         os.environ.pop("AGENT_OBSERVABILITY_ENABLED", None)

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_gen_ai_nested_client_span_processor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_gen_ai_nested_client_span_processor.py
@@ -93,6 +93,19 @@ class TestGenAiNestedClientSpanProcessor(unittest.TestCase):
         self.assertEqual(spans[0].kind, SpanKind.CLIENT)
         self.assertEqual(spans[1].kind, SpanKind.INTERNAL)
 
+    def test_different_llm_operation_child_leaves_parent_client(self):
+        parent = self._make_llm_span()
+        child = self._make_llm_span(
+            op=GenAiOperationNameValues.EMBEDDINGS.value,
+            ctx=trace.set_span_in_context(parent),
+        )
+        child.end()
+        parent.end()
+
+        spans = self.exporter.get_finished_spans()
+        self.assertEqual(spans[0].kind, SpanKind.CLIENT)
+        self.assertEqual(spans[1].kind, SpanKind.CLIENT)
+
     def test_non_llm_operation_ignored(self):
         span = self.tracer.start_span("invoke_agent MyAgent", kind=SpanKind.CLIENT)
         span.set_attribute(GEN_AI_OPERATION_NAME, GenAiOperationNameValues.INVOKE_AGENT.value)

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_gen_ai_nested_client_span_processor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_gen_ai_nested_client_span_processor.py
@@ -41,7 +41,7 @@ class TestGenAiNestedClientSpanProcessor(unittest.TestCase):
         self.assertEqual(child_span.kind, SpanKind.CLIENT)
         self.assertEqual(parent_span.kind, SpanKind.INTERNAL)
 
-    def test_http_child_converts_parent(self):
+    def test_http_child_leaves_parent_client(self):
         parent = self._make_llm_span()
         ctx = trace.set_span_in_context(parent)
         child = self.tracer.start_span("POST", kind=SpanKind.CLIENT, context=ctx)
@@ -50,7 +50,7 @@ class TestGenAiNestedClientSpanProcessor(unittest.TestCase):
 
         spans = self.exporter.get_finished_spans()
         parent_span = next(s for s in spans if s.name == "chat model")
-        self.assertEqual(parent_span.kind, SpanKind.INTERNAL)
+        self.assertEqual(parent_span.kind, SpanKind.CLIENT)
 
     def test_no_child_stays_client(self):
         span = self._make_llm_span()
@@ -100,6 +100,17 @@ class TestGenAiNestedClientSpanProcessor(unittest.TestCase):
 
         spans = self.exporter.get_finished_spans()
         self.assertEqual(spans[0].kind, SpanKind.CLIENT)
+
+    def test_llm_child_leaves_non_llm_parent_client(self):
+        parent = self.tracer.start_span("invoke_agent MyAgent", kind=SpanKind.CLIENT)
+        parent.set_attribute(GEN_AI_OPERATION_NAME, GenAiOperationNameValues.INVOKE_AGENT.value)
+        child = self._make_llm_span(ctx=trace.set_span_in_context(parent))
+        child.end()
+        parent.end()
+
+        spans = self.exporter.get_finished_spans()
+        self.assertEqual(spans[0].kind, SpanKind.CLIENT)
+        self.assertEqual(spans[1].kind, SpanKind.CLIENT)
 
     def test_internal_span_ignored(self):
         span = self.tracer.start_span("chat model", kind=SpanKind.INTERNAL)

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_gen_ai_nested_client_span_processor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_gen_ai_nested_client_span_processor.py
@@ -149,10 +149,10 @@ class TestGenAINestedClientSpanProcessor(unittest.TestCase):
 
     def test_shutdown_clears_state(self):
         processor = GenAINestedClientSpanProcessor()
-        processor._has_gen_ai_client_child.put(123, True)
-        self.assertEqual(len(processor._has_gen_ai_client_child), 1)
+        processor._parent_span_id_and_operation_to_gen_ai_client_child.put(123, True)
+        self.assertEqual(len(processor._parent_span_id_and_operation_to_gen_ai_client_child), 1)
         processor.shutdown()
-        self.assertEqual(len(processor._has_gen_ai_client_child), 0)
+        self.assertEqual(len(processor._parent_span_id_and_operation_to_gen_ai_client_child), 0)
 
     def test_force_flush_returns_true(self):
         processor = GenAINestedClientSpanProcessor()

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_gen_ai_nested_client_span_processor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_gen_ai_nested_client_span_processor.py
@@ -3,7 +3,7 @@
 
 import unittest
 
-from amazon.opentelemetry.distro.gen_ai_nested_client_span_processor import GenAiNestedClientSpanProcessor
+from amazon.opentelemetry.distro.gen_ai_nested_client_span_processor import GenAINestedClientSpanProcessor
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -15,11 +15,11 @@ from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
 from opentelemetry.trace import SpanKind
 
 
-class TestGenAiNestedClientSpanProcessor(unittest.TestCase):
+class TestGenAINestedClientSpanProcessor(unittest.TestCase):
     def setUp(self):
         self.exporter = InMemorySpanExporter()
         self.provider = TracerProvider()
-        self.provider.add_span_processor(GenAiNestedClientSpanProcessor())
+        self.provider.add_span_processor(GenAINestedClientSpanProcessor())
         self.provider.add_span_processor(SimpleSpanProcessor(self.exporter))
         self.tracer = self.provider.get_tracer("test")
 
@@ -148,14 +148,14 @@ class TestGenAiNestedClientSpanProcessor(unittest.TestCase):
         self.assertEqual(spans[0].kind, SpanKind.CLIENT)
 
     def test_shutdown_clears_state(self):
-        processor = GenAiNestedClientSpanProcessor()
+        processor = GenAINestedClientSpanProcessor()
         processor._has_gen_ai_client_child.put(123, True)
         self.assertEqual(len(processor._has_gen_ai_client_child), 1)
         processor.shutdown()
         self.assertEqual(len(processor._has_gen_ai_client_child), 0)
 
     def test_force_flush_returns_true(self):
-        processor = GenAiNestedClientSpanProcessor()
+        processor = GenAINestedClientSpanProcessor()
         self.assertTrue(processor.force_flush())
 
 


### PR DESCRIPTION
## Summary

Demote an outer GenAI `CLIENT` span only when it has a nested `CLIENT` span with the same supported GenAI operation. Register the processor before batch exporters so they observe the final span kind.

## Behavioral differences

- `CHAT -> CHAT`: outer span becomes `INTERNAL`
- `CHAT -> POST`: outer span remains `CLIENT`
- `CHAT -> EMBEDDINGS`: outer span remains `CLIENT`
- Standalone GenAI spans remain `CLIENT`
- The same matching behavior applies to `GENERATE_CONTENT`, `TEXT_COMPLETION`, and `EMBEDDINGS`

Includes focused processor tests for matching operations, HTTP children, differing operations, non-GenAI spans, and processor registration order.