### PR TITLE
fix(openai-agents): isolate telemetry capture context and fail open

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/openai_agents/__init__.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/openai_agents/__init__.py
@@ -34,7 +34,7 @@ class OpenAIAgentsInstrumentor(BaseInstrumentor):  # type: ignore
             set_trace_processors,
         )
 
-        from ._gen_ai_context_capture import GenAIContextCapture  # pylint: disable=import-outside-toplevel
+        from ._gen_ai_context_capture import GenAICapturingContext  # pylint: disable=import-outside-toplevel
         from ._processor import OpenTelemetryTracingProcessor  # pylint: disable=import-outside-toplevel
 
         tracer_provider = kwargs.get("tracer_provider") or trace.get_tracer_provider()
@@ -44,28 +44,34 @@ class OpenAIAgentsInstrumentor(BaseInstrumentor):  # type: ignore
         try_wrap(
             "openai.resources.responses.responses",
             "Responses.create",
-            GenAIContextCapture.capture_openai_request_attributes,
+            GenAICapturingContext.capture_openai_request_attributes,
         )
         try_wrap(
             "openai.resources.responses.responses",
             "AsyncResponses.create",
-            GenAIContextCapture.capture_openai_request_attributes,
+            GenAICapturingContext.capture_openai_request_attributes,
         )
         try_wrap(
             "openai.resources.chat.completions.completions",
             "Completions.create",
-            GenAIContextCapture.capture_openai_completion_attributes,
+            GenAICapturingContext.capture_openai_completion_attributes,
         )
         try_wrap(
             "openai.resources.chat.completions.completions",
             "AsyncCompletions.create",
-            GenAIContextCapture.capture_openai_completion_attributes,
+            GenAICapturingContext.capture_openai_completion_attributes,
         )
-        try_wrap("litellm", "completion", GenAIContextCapture.capture_litellm_completion_attributes)
-        try_wrap("litellm", "acompletion", GenAIContextCapture.capture_litellm_completion_attributes)
-        try_wrap("agents.items", "ItemHelpers.tool_call_output_item", GenAIContextCapture.capture_tool_call_attributes)
+        try_wrap("litellm", "completion", GenAICapturingContext.capture_litellm_completion_attributes)
+        try_wrap("litellm", "acompletion", GenAICapturingContext.capture_litellm_completion_attributes)
         try_wrap(
-            "agents.tool_context", "ToolContext.from_agent_context", GenAIContextCapture.capture_tool_call_attributes
+            "agents.items",
+            "ItemHelpers.tool_call_output_item",
+            GenAICapturingContext.capture_tool_call_attributes,
+        )
+        try_wrap(
+            "agents.tool_context",
+            "ToolContext.from_agent_context",
+            GenAICapturingContext.capture_tool_call_attributes,
         )
         # disables http spans created from spans sent OpenAI's tracing backend
         try_wrap("agents.tracing.processors", "BackendSpanExporter.export", _suppress_http_instrumentation)

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/openai_agents/_gen_ai_context_capture.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/openai_agents/_gen_ai_context_capture.py
@@ -1,28 +1,37 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from contextvars import ContextVar
+import logging
 from dataclasses import dataclass, field
 from inspect import isawaitable, iscoroutinefunction
-from typing import Any, Optional
+from typing import Any, Optional, TypeVar
 
 from openai import NotGiven, Omit
 from wrapt import ObjectProxy
 
 from amazon.opentelemetry.distro.instrumentation.common.instrumentation_utils import get_value
+from opentelemetry import context as otel_context
+from opentelemetry.context import Context
+
+_GEN_AI_CAPTURING_CONTEXT_KEY = otel_context.create_key("aws_otel_openai_agents_capturing_context")
+_CapturingContextT = TypeVar("_CapturingContextT", bound="GenAICapturingContext")
+_logger = logging.getLogger(__name__)
 
 
-@dataclass
-class ModelCapturingContext:
-    model_impl: Optional[str] = None
-    request_params: dict[str, Any] = field(default_factory=dict)
-    responses: list[dict[str, Any]] = field(default_factory=list)
+def set_gen_ai_capturing_context_in_context(
+    capture: "GenAICapturingContext",
+    context: Optional[Context] = None,
+) -> Context:
+    ctx = otel_context.set_value(_GEN_AI_CAPTURING_CONTEXT_KEY, capture, context=context)
+    return ctx
 
 
-@dataclass
-class ToolCapturingContext:
-    name: Optional[str] = None
-    call_id: Optional[str] = None
+def get_gen_ai_capturing_context(
+    capturing_context_type: type[_CapturingContextT],
+    context: Optional[Context] = None,
+) -> Optional[_CapturingContextT]:
+    capture = otel_context.get_value(_GEN_AI_CAPTURING_CONTEXT_KEY, context)
+    return capture if isinstance(capture, capturing_context_type) else None
 
 
 class _ResponseCapturingStream(ObjectProxy):
@@ -33,7 +42,10 @@ class _ResponseCapturingStream(ObjectProxy):
 
     def __next__(self) -> Any:
         chunk = next(self.__wrapped__)
-        GenAIContextCapture.capture_model_response_attributes(chunk)
+        try:
+            GenAICapturingContext.capture_model_response_attributes(chunk)
+        except Exception:  # pylint: disable=broad-exception-caught
+            _logger.debug("Failed to capture GenAI stream response attributes", exc_info=True)
         return chunk
 
     def __aiter__(self) -> Any:
@@ -41,37 +53,51 @@ class _ResponseCapturingStream(ObjectProxy):
 
     async def __anext__(self) -> Any:
         chunk = await self.__wrapped__.__anext__()
-        GenAIContextCapture.capture_model_response_attributes(chunk)
+        try:
+            GenAICapturingContext.capture_model_response_attributes(chunk)
+        except Exception:  # pylint: disable=broad-exception-caught
+            _logger.debug("Failed to capture GenAI stream response attributes", exc_info=True)
         return chunk
 
 
-class GenAIContextCapture:
+class GenAICapturingContext:
     """Capture GenAI call details that the OpenAI Agents tracing callbacks do not expose."""
 
-    _current_model_context: ContextVar[Optional[ModelCapturingContext]] = ContextVar(
-        "aws_otel_openai_agents_current_model_context", default=None
-    )
-    _current_tool_context: ContextVar[Optional[ToolCapturingContext]] = ContextVar(
-        "aws_otel_openai_agents_current_tool_context", default=None
-    )
+    @classmethod
+    def for_model(cls, model_impl: Optional[str] = None) -> "GenAICapturingContext":
+        return ModelCapturingContext(model_impl=model_impl)
+
+    @classmethod
+    def for_tool(cls) -> "GenAICapturingContext":
+        return ToolCapturingContext()
 
     @classmethod
     def capture_openai_request_attributes(cls, wrapped: Any, instance: Any, args: Any, kwargs: Any) -> Any:
         """Wrap OpenAI Responses create methods to capture request attributes."""
-        cls.capture_model_request_attributes(instance, kwargs)
+        try:
+            cls.capture_model_request_attributes(instance, kwargs)
+        except Exception:  # pylint: disable=broad-exception-caught
+            _logger.debug("Failed to capture GenAI request attributes", exc_info=True)
         return wrapped(*args, **kwargs)
 
     @classmethod
     def capture_openai_completion_attributes(cls, wrapped: Any, instance: Any, args: Any, kwargs: Any) -> Any:
         """Wrap OpenAI Chat Completions create methods to capture request and response attributes."""
-        current_model_context = cls.get_current_model_context()
+        current_model_context = get_gen_ai_capturing_context(ModelCapturingContext)
         if current_model_context is None or current_model_context.model_impl == "litellm":
             return wrapped(*args, **kwargs)
-        cls.capture_model_request_attributes(instance, kwargs)
+        try:
+            cls.capture_model_request_attributes(instance, kwargs)
+        except Exception:  # pylint: disable=broad-exception-caught
+            _logger.debug("Failed to capture GenAI request attributes", exc_info=True)
         response = wrapped(*args, **kwargs)
-        if isawaitable(response):
-            return cls._capture_acompletion_response_attributes(response, kwargs.get("stream"))
-        return cls._capture_completion_response_attributes(response, kwargs.get("stream"))
+        try:
+            if isawaitable(response):
+                return cls._capture_acompletion_response_attributes(response, kwargs.get("stream"))
+            return cls._capture_completion_response_attributes(response, kwargs.get("stream"))
+        except Exception:  # pylint: disable=broad-exception-caught
+            _logger.debug("Failed to prepare GenAI response capture", exc_info=True)
+            return response
 
     @classmethod
     def capture_litellm_completion_attributes(cls, wrapped: Any, instance: Any, args: Any, kwargs: Any) -> Any:
@@ -79,19 +105,33 @@ class GenAIContextCapture:
         # LiteLLM's acompletion calls completion(..., acompletion=True); capture the request only once.
         if kwargs.get("acompletion") and not iscoroutinefunction(wrapped):
             return wrapped(*args, **kwargs)
-        if cls.get_current_model_context() is None:
+        if get_gen_ai_capturing_context(ModelCapturingContext) is None:
             return wrapped(*args, **kwargs)
-        cls.capture_model_request_attributes(instance, kwargs)
+        try:
+            cls.capture_model_request_attributes(instance, kwargs)
+        except Exception:  # pylint: disable=broad-exception-caught
+            _logger.debug("Failed to capture GenAI request attributes", exc_info=True)
         response = wrapped(*args, **kwargs)
-        if isawaitable(response):
-            return cls._capture_acompletion_response_attributes(response, kwargs.get("stream"))
-        return cls._capture_completion_response_attributes(response, kwargs.get("stream"))
+        try:
+            if isawaitable(response):
+                return cls._capture_acompletion_response_attributes(response, kwargs.get("stream"))
+            return cls._capture_completion_response_attributes(response, kwargs.get("stream"))
+        except Exception:  # pylint: disable=broad-exception-caught
+            _logger.debug("Failed to prepare GenAI response capture", exc_info=True)
+            return response
 
     @classmethod
     def _capture_completion_response_attributes(cls, response: Any, stream: Any) -> Any:
         if stream and (hasattr(response, "__iter__") or hasattr(response, "__aiter__")):
-            return _ResponseCapturingStream(response)
-        cls.capture_model_response_attributes(response)
+            try:
+                return _ResponseCapturingStream(response)
+            except Exception:  # pylint: disable=broad-exception-caught
+                _logger.debug("Failed to wrap GenAI response stream", exc_info=True)
+                return response
+        try:
+            cls.capture_model_response_attributes(response)
+        except Exception:  # pylint: disable=broad-exception-caught
+            _logger.debug("Failed to capture GenAI response attributes", exc_info=True)
         return response
 
     @classmethod
@@ -101,18 +141,21 @@ class GenAIContextCapture:
     @classmethod
     def capture_tool_call_attributes(cls, wrapped: Any, instance: Any, args: Any, kwargs: Any) -> Any:
         """Wrap OpenAI Agents tool-call helpers to capture the tool name and call ID attributes."""
-        tool_call = kwargs.get("tool_call") or (args[0] if args else None)
-        name = get_value(tool_call, "name")
-        call_id = get_value(tool_call, "call_id")
-        current_tool_context = cls.get_current_tool_context()
-        if current_tool_context is not None and (name or call_id):
-            current_tool_context.name = name
-            current_tool_context.call_id = call_id
+        try:
+            tool_call = kwargs.get("tool_call") or (args[0] if args else None)
+            name = get_value(tool_call, "name")
+            call_id = get_value(tool_call, "call_id")
+            current_tool_context = get_gen_ai_capturing_context(ToolCapturingContext)
+            if current_tool_context is not None and (name or call_id):
+                current_tool_context.name = name
+                current_tool_context.call_id = call_id
+        except Exception:  # pylint: disable=broad-exception-caught
+            _logger.debug("Failed to capture GenAI tool attributes", exc_info=True)
         return wrapped(*args, **kwargs)
 
     @classmethod
     def capture_model_request_attributes(cls, instance: Any, kwargs: Any) -> None:
-        current_model_context = cls.get_current_model_context()
+        current_model_context = get_gen_ai_capturing_context(ModelCapturingContext)
         if current_model_context is None:
             return
         current_model_context.request_params = {
@@ -162,7 +205,7 @@ class GenAIContextCapture:
 
     @classmethod
     def capture_model_response_attributes(cls, response: Any) -> None:
-        current_model_context = cls.get_current_model_context()
+        current_model_context = get_gen_ai_capturing_context(ModelCapturingContext)
         if current_model_context is None:
             return
         response_params: dict[str, Any] = {}
@@ -224,18 +267,18 @@ class GenAIContextCapture:
         if response_params:
             current_model_context.responses.append(response_params)
 
-    @classmethod
-    def reset_current_model_context(cls, model_impl: Optional[str] = None) -> None:
-        cls._current_model_context.set(ModelCapturingContext(model_impl=model_impl))
 
-    @classmethod
-    def get_current_model_context(cls) -> Optional[ModelCapturingContext]:
-        return cls._current_model_context.get()
+INVALID_GEN_AI_CAPTURING_CONTEXT = GenAICapturingContext()
 
-    @classmethod
-    def reset_current_tool_context(cls) -> None:
-        cls._current_tool_context.set(ToolCapturingContext())
 
-    @classmethod
-    def get_current_tool_context(cls) -> Optional[ToolCapturingContext]:
-        return cls._current_tool_context.get()
+@dataclass
+class ModelCapturingContext(GenAICapturingContext):
+    model_impl: Optional[str] = None
+    request_params: dict[str, Any] = field(default_factory=dict)
+    responses: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class ToolCapturingContext(GenAICapturingContext):
+    name: Optional[str] = None
+    call_id: Optional[str] = None

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/openai_agents/_processor.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/openai_agents/_processor.py
@@ -81,7 +81,14 @@ from opentelemetry.semconv.attributes.server_attributes import SERVER_ADDRESS, S
 from opentelemetry.trace import Span, SpanKind, Status, StatusCode, Tracer, set_span_in_context
 from opentelemetry.util.types import AttributeValue
 
-from ._gen_ai_context_capture import GenAIContextCapture
+from ._gen_ai_context_capture import (
+    INVALID_GEN_AI_CAPTURING_CONTEXT,
+    GenAICapturingContext,
+    ModelCapturingContext,
+    ToolCapturingContext,
+    get_gen_ai_capturing_context,
+    set_gen_ai_capturing_context_in_context,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -128,7 +135,9 @@ class OpenTelemetryTracingProcessor(TracingProcessor):
             kind=SpanKind.INTERNAL,
             attributes=attributes,
         )
-        token = context.attach(set_span_in_context(span))
+        otel_context = set_span_in_context(span)
+        otel_context = set_gen_ai_capturing_context_in_context(INVALID_GEN_AI_CAPTURING_CONTEXT, otel_context)
+        token = context.attach(otel_context)
         self._openai_trace_id_to_otel_workflow_entry.put(trace.trace_id, _SpanEntry(span=span, token=token))
 
     @override
@@ -154,12 +163,6 @@ class OpenTelemetryTracingProcessor(TracingProcessor):
                     _SpanEntry(span=parent_entry.span, agent_content=parent_entry.agent_content),
                 )
             return
-
-        if isinstance(span_data, (GenerationSpanData, ResponseSpanData)):
-            model_config = get_value(span_data, "model_config") or {}
-            GenAIContextCapture.reset_current_model_context(get_value(model_config, "model_impl"))
-        if isinstance(span_data, (FunctionSpanData, HandoffSpanData)):
-            GenAIContextCapture.reset_current_tool_context()
 
         agent_content = parent_entry.agent_content if parent_entry is not None else None
         if isinstance(span_data, AgentSpanData):
@@ -198,7 +201,17 @@ class OpenTelemetryTracingProcessor(TracingProcessor):
             kind=self._set_span_kind(span_data),
             attributes=attributes,
         )
-        token = context.attach(set_span_in_context(otel_span))
+        otel_context = set_span_in_context(otel_span)
+        if isinstance(span_data, (GenerationSpanData, ResponseSpanData)):
+            model_config = get_value(span_data, "model_config") or {}
+            capture = GenAICapturingContext.for_model(get_value(model_config, "model_impl"))
+            otel_context = set_gen_ai_capturing_context_in_context(capture, otel_context)
+        elif isinstance(span_data, (FunctionSpanData, HandoffSpanData)):
+            capture = GenAICapturingContext.for_tool()
+            otel_context = set_gen_ai_capturing_context_in_context(capture, otel_context)
+        else:
+            otel_context = set_gen_ai_capturing_context_in_context(INVALID_GEN_AI_CAPTURING_CONTEXT, otel_context)
+        token = context.attach(otel_context)
         self._openai_span_id_to_otel_span_entry.put(
             span.span_id,
             _SpanEntry(span=otel_span, token=token, agent_content=agent_content),
@@ -214,8 +227,6 @@ class OpenTelemetryTracingProcessor(TracingProcessor):
             return
         if entry is None or entry.token is None:
             return
-
-        try_detach(entry.token)
         otel_span = entry.span
 
         try:
@@ -243,6 +254,7 @@ class OpenTelemetryTracingProcessor(TracingProcessor):
         except Exception as error:  # pylint: disable=broad-exception-caught
             _logger.warning("Failed to enrich OpenAI Agents span %s: %s", span.span_id, error)
         finally:
+            try_detach(entry.token)
             self._set_span_status(otel_span, span.error)
             self._record_trace_error(span)
             otel_span.end()
@@ -457,7 +469,7 @@ class OpenTelemetryTracingProcessor(TracingProcessor):
         OpenTelemetryTracingProcessor._set_attribute(
             attributes,
             GEN_AI_TOOL_CALL_ID,
-            get_value(GenAIContextCapture.get_current_tool_context(), "call_id"),
+            get_value(get_gen_ai_capturing_context(ToolCapturingContext), "call_id"),
         )
         OpenTelemetryTracingProcessor._set_attribute(
             attributes, GEN_AI_TOOL_CALL_ARGUMENTS, to_tool_attribute_value(span_data.input)
@@ -477,7 +489,7 @@ class OpenTelemetryTracingProcessor(TracingProcessor):
         OpenTelemetryTracingProcessor._set_attribute(
             attributes,
             GEN_AI_TOOL_CALL_ID,
-            get_value(GenAIContextCapture.get_current_tool_context(), "call_id"),
+            get_value(get_gen_ai_capturing_context(ToolCapturingContext), "call_id"),
         )
         OpenTelemetryTracingProcessor._set_attribute(
             attributes,
@@ -512,7 +524,7 @@ class OpenTelemetryTracingProcessor(TracingProcessor):
         model_config: Mapping[str, Any],
         fallback_model: Any,
     ) -> None:
-        current_model_context = GenAIContextCapture.get_current_model_context()
+        current_model_context = get_gen_ai_capturing_context(ModelCapturingContext)
         request_params = get_value(current_model_context, "request_params") or {}
         model_config = {**model_config, **request_params}
         request_model = first_not_none(request_params.get("model"), fallback_model)
@@ -599,7 +611,7 @@ class OpenTelemetryTracingProcessor(TracingProcessor):
         detailed_usage: Any = None,
     ) -> list[str]:
         OpenTelemetryTracingProcessor._set_usage_attributes(attributes, usage, detailed_usage)
-        current_model_context = GenAIContextCapture.get_current_model_context()
+        current_model_context = get_gen_ai_capturing_context(ModelCapturingContext)
         responses = [(fallback_response, False)] if fallback_response is not None else []
         responses.extend((response, True) for response in get_value(current_model_context, "responses") or [])
         finish_reasons: list[str] = []
@@ -886,7 +898,7 @@ class OpenTelemetryTracingProcessor(TracingProcessor):
 
     @staticmethod
     def _get_handoff_tool_name(span_data: HandoffSpanData) -> str:
-        tool_name = get_value(GenAIContextCapture.get_current_tool_context(), "name")
+        tool_name = get_value(get_gen_ai_capturing_context(ToolCapturingContext), "name")
         if tool_name:
             return str(tool_name)
         if not span_data.to_agent:

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/conftest.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/conftest.py
@@ -58,6 +58,7 @@ def call_mock_llm(
 
     is_async = kwargs.get("is_async", False)
     model = kwargs.get("model", config["model"])
+    responses = iter(kwargs["responses"]) if "responses" in kwargs else None
 
     if provider in ("openai", "litellm"):
         import asyncio
@@ -69,6 +70,12 @@ def call_mock_llm(
             raise NotImplementedError("Async LiteLLM mock calls are not supported")
 
         def openai_response(request):
+            if responses is not None:
+                try:
+                    response = next(responses)
+                except StopIteration as error:
+                    raise AssertionError("Mock LLM response sequence exhausted") from error
+                return httpx.Response(200, request=request, json=response)
             return httpx.Response(
                 200,
                 request=request,

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/openai_agents/test_openai_agents_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/openai_agents/test_openai_agents_instrumentor.py
@@ -19,7 +19,7 @@ from openai import NOT_GIVEN, Omit
 from pydantic import BaseModel
 
 from amazon.opentelemetry.distro.instrumentation.openai_agents import OpenAIAgentsInstrumentor
-from amazon.opentelemetry.distro.instrumentation.openai_agents._gen_ai_context_capture import GenAIContextCapture
+from amazon.opentelemetry.distro.instrumentation.openai_agents._gen_ai_context_capture import GenAICapturingContext
 from amazon.opentelemetry.distro.instrumentation.openai_agents._processor import (
     GEN_AI_REQUEST_REASONING_LEVEL,
     OpenTelemetryTracingProcessor,
@@ -81,7 +81,7 @@ def _passthrough(*args, **kwargs):
 
 
 def _record_tool_call(name=None, call_id=None):
-    return GenAIContextCapture.capture_tool_call_attributes(
+    return GenAICapturingContext.capture_tool_call_attributes(
         _passthrough,
         None,
         (),
@@ -91,7 +91,7 @@ def _record_tool_call(name=None, call_id=None):
 
 def _record_request(base_url=None, **kwargs):
     instance = SimpleNamespace(_client=SimpleNamespace(base_url=base_url)) if base_url else None
-    return GenAIContextCapture.capture_openai_completion_attributes(_passthrough, instance, (), kwargs)
+    return GenAICapturingContext.capture_openai_completion_attributes(_passthrough, instance, (), kwargs)
 
 
 def _litellm_response(model, finish_reasons):
@@ -292,7 +292,7 @@ class TestOpenAIAgentsTracingProcessor(unittest.TestCase):
                 if hasattr(response_trace_span.span_data, "usage"):
                     response_trace_span.span_data.usage = {"input_tokens": 7, "output_tokens": 3}
                 with response_trace_span:
-                    GenAIContextCapture.capture_openai_request_attributes(
+                    GenAICapturingContext.capture_openai_request_attributes(
                         _passthrough,
                         None,
                         (),
@@ -920,6 +920,197 @@ class TestOpenAIAgentsTracingProcessor(unittest.TestCase):
         self.assertNotIn(GEN_AI_REQUEST_TEMPERATURE, span.attributes)
         self.assertNotIn(GEN_AI_REQUEST_MAX_TOKENS, span.attributes)
         self.assertEqual(span.attributes[GEN_AI_REQUEST_TOP_P], 0.4)
+
+    def test_capture_failures_are_fail_open(self):
+        class InvalidBaseUrl:
+            def __str__(self):
+                raise RuntimeError("invalid base URL")
+
+        class InvalidToolCall:
+            @property
+            def name(self):
+                raise RuntimeError("invalid tool call")
+
+        response = SimpleNamespace(id="response-id", model="response-model", choices=1)
+        instance = SimpleNamespace(_client=SimpleNamespace(base_url=InvalidBaseUrl()))
+
+        with tracing.trace("Fail-open workflow"):
+            with tracing.generation_span(input=[], output=[], model="fallback-model"):
+                returned_response = GenAICapturingContext.capture_openai_completion_attributes(
+                    lambda **_kwargs: response,
+                    instance,
+                    (),
+                    {"model": "request-model"},
+                )
+                self.assertIs(returned_response, response)
+
+                returned_stream = GenAICapturingContext.capture_openai_completion_attributes(
+                    lambda **_kwargs: iter([response]),
+                    None,
+                    (),
+                    {"model": "request-model", "stream": True},
+                )
+                self.assertIs(next(returned_stream), response)
+
+            with tracing.function_span("fail-open tool"):
+                returned_tool_result = GenAICapturingContext.capture_tool_call_attributes(
+                    lambda **_kwargs: "tool result",
+                    None,
+                    (),
+                    {"tool_call": InvalidToolCall()},
+                )
+                self.assertEqual(returned_tool_result, "tool result")
+
+    def test_wrapped_exceptions_are_preserved(self):
+        class WrappedError(Exception):
+            pass
+
+        def fail(**_kwargs):
+            raise WrappedError("wrapped failure")
+
+        with tracing.trace("Wrapped error workflow"):
+            with tracing.generation_span(input=[], output=[], model="test-model"):
+                with self.assertRaisesRegex(WrappedError, "wrapped failure"):
+                    GenAICapturingContext.capture_openai_completion_attributes(
+                        fail,
+                        None,
+                        (),
+                        {"model": "test-model"},
+                    )
+
+    def test_nested_agent_tool_run_preserves_capture_context(self):
+        outer_model = "outer-model"
+        inner_model = "inner-model"
+
+        def completion(response_id, response_model, message, finish_reason):
+            return {
+                "id": response_id,
+                "object": "chat.completion",
+                "created": 1234567890,
+                "model": response_model,
+                "choices": [{"index": 0, "message": message, "finish_reason": finish_reason}],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+            }
+
+        responses = [
+            completion(
+                "outer-tool-response",
+                "outer-response-model",
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "outer-call",
+                            "type": "function",
+                            "function": {
+                                "name": "ask_inner",
+                                "arguments": json.dumps({"input": "Run the inner lookup"}),
+                            },
+                        }
+                    ],
+                },
+                "tool_calls",
+            ),
+            completion(
+                "inner-tool-response",
+                "inner-response-model",
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "inner-call",
+                            "type": "function",
+                            "function": {
+                                "name": "inner_lookup",
+                                "arguments": json.dumps({"query": "context"}),
+                            },
+                        }
+                    ],
+                },
+                "tool_calls",
+            ),
+            completion(
+                "inner-final-response",
+                "inner-response-model",
+                {"role": "assistant", "content": "Inner complete"},
+                "stop",
+            ),
+            completion(
+                "outer-final-response",
+                "outer-response-model",
+                {"role": "assistant", "content": "Outer complete"},
+                "stop",
+            ),
+        ]
+
+        instrumentor = OpenAIAgentsInstrumentor()
+        instrumentor.instrument(
+            tracer_provider=self.tracer_provider,
+            disable_openai_trace_export=True,
+            skip_dep_check=True,
+        )
+        self.addCleanup(instrumentor.uninstrument)
+
+        @function_tool
+        def inner_lookup(query: str) -> str:
+            """Look up a value."""
+            return f"Found {query}"
+
+        def invoke_agents(client):
+            inner_agent = Agent(
+                name="Inner agent",
+                model=OpenAIChatCompletionsModel(model=inner_model, openai_client=client),
+                tools=[inner_lookup],
+            )
+            outer_agent = Agent(
+                name="Outer agent",
+                model=OpenAIChatCompletionsModel(model=outer_model, openai_client=client),
+                tools=[
+                    inner_agent.as_tool(
+                        tool_name="ask_inner",
+                        tool_description="Ask the inner agent to perform a lookup.",
+                    )
+                ],
+            )
+            result = Runner.run_sync(outer_agent, "Start the nested run")
+            self.assertEqual(result.final_output, "Outer complete")
+
+        call_mock_llm(
+            "openai",
+            invoke_llm_callback=invoke_agents,
+            is_async=True,
+            responses=responses,
+        )
+
+        spans = self.exporter.get_finished_spans()
+        model_spans = {
+            span.attributes[GEN_AI_RESPONSE_ID]: span for span in spans if GEN_AI_RESPONSE_ID in span.attributes
+        }
+        request_models = [span.attributes[GEN_AI_REQUEST_MODEL] for span in model_spans.values()]
+        self.assertEqual(request_models.count(outer_model), 2)
+        self.assertEqual(request_models.count(inner_model), 2)
+        self.assertEqual(model_spans["outer-tool-response"].attributes[GEN_AI_REQUEST_MODEL], outer_model)
+        self.assertEqual(
+            model_spans["outer-tool-response"].attributes[GEN_AI_RESPONSE_MODEL],
+            "outer-response-model",
+        )
+        self.assertEqual(model_spans["inner-tool-response"].attributes[GEN_AI_REQUEST_MODEL], inner_model)
+        self.assertEqual(
+            model_spans["inner-tool-response"].attributes[GEN_AI_RESPONSE_MODEL],
+            "inner-response-model",
+        )
+        self.assertEqual(model_spans["inner-final-response"].attributes[GEN_AI_REQUEST_MODEL], inner_model)
+        self.assertEqual(model_spans["outer-final-response"].attributes[GEN_AI_REQUEST_MODEL], outer_model)
+
+        tool_spans = {
+            span.attributes[GEN_AI_TOOL_NAME]: span
+            for span in spans
+            if GEN_AI_TOOL_NAME in span.attributes and GEN_AI_TOOL_CALL_ID in span.attributes
+        }
+        self.assertEqual(tool_spans["ask_inner"].attributes[GEN_AI_TOOL_CALL_ID], "outer-call")
+        self.assertEqual(tool_spans["inner_lookup"].attributes[GEN_AI_TOOL_CALL_ID], "inner-call")
 
     def test_parenting_skips_unhandled_task_and_turn_spans(self):
         with tracing.trace("Parent workflow"):


### PR DESCRIPTION
Follow-up to #873.

## Summary
- scope model and tool capture state to the OpenTelemetry context attached to each OpenAI Agents span
- restore the correct capture state across nested agent and tool runs
- keep telemetry extraction fail-open so instrumentation failures do not affect application calls or exceptions
- add end-to-end nested agent/tool coverage and fail-open regression tests

## Testing
- latest OpenAI Agents dependency suite: 26 passed
- oldest OpenAI Agents dependency suite: 26 passed
- Black, isort, and `git diff --check`