### PR TITLE
change fable to opus in langchain tests

### DIFF
--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/langchain/test_langchain_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/langchain/test_langchain_instrumentor.py
@@ -581,7 +581,7 @@ class TestLangChainInstrumentor(TestCase):
 
                     def invoke_anthropic(client):
                         llm = ChatAnthropic(
-                            model="claude-fable-5",
+                            model="claude-opus-5",
                             api_key="fake-key",
                             max_tokens=100,
                             temperature=1.0,
@@ -595,7 +595,7 @@ class TestLangChainInstrumentor(TestCase):
 
                     call_mock_llm("anthropic", invoke_llm_callback=invoke_anthropic)
                     expected_request_attributes = {
-                        GEN_AI_REQUEST_MODEL: "claude-fable-5",
+                        GEN_AI_REQUEST_MODEL: "claude-opus-5",
                         GEN_AI_REQUEST_TEMPERATURE: 1.0,
                         GEN_AI_REQUEST_TOP_P: 0.9,
                         GEN_AI_REQUEST_TOP_K: 40,


### PR DESCRIPTION
change fable to opus in the langchain unit tests because the new release that adds fable 5.1 support also added if checks that specifically target fable 5, you are no longer allowed to use top_k, temperature, top_p attributes if using fable 5 (which we do in our tests) so the easiest fix is to simply move our mock calls to use another model.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

