### PR TITLE
fix(code-correlation): treat all site-packages files as third-party

### DIFF
--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/code_correlation/internal/packages_resolver.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/code_correlation/internal/packages_resolver.py
@@ -382,13 +382,7 @@ def is_user_code(file_path: str) -> bool:
     path_obj = Path(file_path)
     if is_standard_library(path_obj) or is_third_party_package(path_obj):
         return False
-
-    # Backstop: any file physically under site-packages is not user code, even
-    # when importlib.metadata resolution or the 3rd.txt allowlist fails to
-    # classify it. This covers namespace-package key collisions -- e.g. all
-    # opentelemetry/instrumentation/* files collapse to a single mapping key,
-    # so they can resolve to an arbitrary sibling distribution that may be
-    # absent from 3rd.txt and thus leak into captured code attributes.
+    
     resolved_path = path_obj
     if not resolved_path.is_absolute() or resolved_path.is_symlink():
         resolved_path = resolved_path.resolve()

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/code_correlation/internal/packages_resolver.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/code_correlation/internal/packages_resolver.py
@@ -382,7 +382,7 @@ def is_user_code(file_path: str) -> bool:
     path_obj = Path(file_path)
     if is_standard_library(path_obj) or is_third_party_package(path_obj):
         return False
-    
+
     resolved_path = path_obj
     if not resolved_path.is_absolute() or resolved_path.is_symlink():
         resolved_path = resolved_path.resolve()

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/code_correlation/internal/packages_resolver.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/code_correlation/internal/packages_resolver.py
@@ -380,4 +380,19 @@ def is_user_code(file_path: str) -> bool:
         True if the path represents user code, False otherwise
     """
     path_obj = Path(file_path)
-    return not (is_standard_library(path_obj) or is_third_party_package(path_obj))
+    if is_standard_library(path_obj) or is_third_party_package(path_obj):
+        return False
+
+    # Backstop: any file physically under site-packages is not user code, even
+    # when importlib.metadata resolution or the 3rd.txt allowlist fails to
+    # classify it. This covers namespace-package key collisions -- e.g. all
+    # opentelemetry/instrumentation/* files collapse to a single mapping key,
+    # so they can resolve to an arbitrary sibling distribution that may be
+    # absent from 3rd.txt and thus leak into captured code attributes.
+    resolved_path = path_obj
+    if not resolved_path.is_absolute() or resolved_path.is_symlink():
+        resolved_path = resolved_path.resolve()
+    if resolved_path.is_relative_to(_PURELIB_PATH) or resolved_path.is_relative_to(_PLATLIB_PATH):
+        return False
+
+    return True


### PR DESCRIPTION
Fixes `code_attributes_test` failing consistently (`41 != 408`): client spans were capturing the OpenTelemetry instrumentation wrapper's line number instead of the user's call site. Root cause is a namespace-package collision — every `opentelemetry-instrumentation-*` distribution collapses to one mapping key, so `is_user_code()` resolves the frame to an arbitrary sibling (`opentelemetry-instrumentation-exceptions`) that isn't in `3rd.txt` and gets misclassified as user code. Fix adds a site-packages backstop: any file under `purelib`/`platlib` is never treated as user code, regardless of metadata/allowlist resolution. Verified the captured line flips from the wrapper frame back to the user call site, and the existing `test_packages_resolver` suite still passes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

