### PR TITLE
feat: redact span, span event, and span link attributes via ADOT_REDACT_SPAN_ATTRIBUTES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
-- feat: add configurable span and span event attribute redaction via ADOT_REDACT_SPAN_ATTRIBUTES
+- feat: add separately configurable span and span event attribute redaction via
+  ADOT_REDACT_SPAN_ATTRIBUTES and ADOT_REDACT_SPAN_EVENT_ATTRIBUTES
   ([#886](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/886))
 - fix: stop logging a noisy `Invalid key/value pair (xrsr, None) found.` warning on span creation when no
   X-Ray sampling rule hash is available

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- feat: add configurable span and span event attribute redaction via ADOT_REDACT_SPAN_ATTRIBUTES
 - fix: stop logging a noisy `Invalid key/value pair (xrsr, None) found.` warning on span creation when no
   X-Ray sampling rule hash is available
   ([#874](https://github.com/aws-observability/aws-otel-python-instrumentation/issues/874))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
-- feat: add configurable span, span event, and span link attribute redaction via ADOT_REDACT_SPAN_ATTRIBUTES
+- feat: redact span, span event, and span link attributes via ADOT_REDACT_SPAN_ATTRIBUTES
   ([#886](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/886))
 - feat(langchain): classify LangGraph StateGraph invocations as agent or workflow spans through the Pregel runtime
   ([#888](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/888))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 ## Unreleased
 
 - feat: add configurable span and span event attribute redaction via ADOT_REDACT_SPAN_ATTRIBUTES
-  ([PR](https://github.com/aws-observability/aws-otel-python-instrumentation/compare/main...liustve:aws-otel-python-instrumentation:adot-redact-span-attributes?expand=1))
+  ([#886](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/886))
 - fix: stop logging a noisy `Invalid key/value pair (xrsr, None) found.` warning on span creation when no
   X-Ray sampling rule hash is available
   ([#874](https://github.com/aws-observability/aws-otel-python-instrumentation/issues/874))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 ## Unreleased
 
 - feat: add configurable span and span event attribute redaction via ADOT_REDACT_SPAN_ATTRIBUTES
+  ([PR](https://github.com/aws-observability/aws-otel-python-instrumentation/compare/main...liustve:aws-otel-python-instrumentation:adot-redact-span-attributes?expand=1))
 - fix: stop logging a noisy `Invalid key/value pair (xrsr, None) found.` warning on span creation when no
   X-Ray sampling rule hash is available
   ([#874](https://github.com/aws-observability/aws-otel-python-instrumentation/issues/874))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,7 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
-- feat: add separately configurable span and span event attribute redaction via
-  ADOT_REDACT_SPAN_ATTRIBUTES and ADOT_REDACT_SPAN_EVENT_ATTRIBUTES
+- feat: add configurable span, span event, and span link attribute redaction via ADOT_REDACT_SPAN_ATTRIBUTES
   ([#886](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/886))
 - feat(langchain): classify LangGraph StateGraph invocations as agent or workflow spans through the Pregel runtime
   ([#888](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/888))

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/attribute_redacting_span_processor.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/attribute_redacting_span_processor.py
@@ -1,0 +1,95 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import re
+from collections.abc import MutableMapping
+from typing import Collection, Optional
+
+from typing_extensions import override
+
+from opentelemetry.attributes import BoundedAttributes
+from opentelemetry.context import Context
+from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
+from opentelemetry.util import types
+
+ENV_ADOT_REDACT_SPAN_ATTRIBUTES = "ADOT_REDACT_SPAN_ATTRIBUTES"
+REDACTED_VALUE = "REDACTED"
+
+
+class AttributeRedactingSpanProcessor(SpanProcessor):
+    """
+    Redacts configured attributes on completed spans and their events.
+
+    Attribute names can be supplied to the constructor or through the
+    ``ADOT_REDACT_SPAN_ATTRIBUTES`` environment variable as a comma-separated
+    list. Each entry can be an exact attribute name or contain ``*`` wildcards.
+    Matching attribute values are replaced with ``REDACTED`` in place while
+    attribute names and non-matching values remain unchanged.
+
+    Examples:
+        Redact several exact attributes, every attribute beginning with
+        ``http.request.``, and matching GenAI content attributes:
+
+        ``ADOT_REDACT_SPAN_ATTRIBUTES=user.email,request.body,db.statement,http.request.*,gen_ai.*.content``
+
+        Redact every span and span event attribute:
+
+        ``ADOT_REDACT_SPAN_ATTRIBUTES=*``
+    """
+
+    def __init__(self, attributes_to_redact: Optional[Collection[str]] = None) -> None:
+        self.attributes_to_redact = (
+            list(attributes_to_redact)
+            if attributes_to_redact
+            else [
+                attribute.strip()
+                for attribute in os.environ.get(ENV_ADOT_REDACT_SPAN_ATTRIBUTES, "").split(",")
+                if attribute.strip()
+            ]
+        )
+
+    # pylint: disable=no-self-use
+    @override
+    def on_start(self, span: Span, parent_context: Optional[Context] = None) -> None:
+        return
+
+    @override
+    def on_end(self, span: ReadableSpan) -> None:
+        if not self.attributes_to_redact:
+            return
+
+        self._redact_attributes(span._attributes)  # noqa: SLF001
+
+        for event in span.events:
+            self._redact_attributes(event._attributes)  # noqa: SLF001
+
+    def _redact_attributes(self, attributes: types.Attributes) -> None:
+        if not attributes:
+            return
+
+        if isinstance(attributes, BoundedAttributes):
+            with attributes._lock:  # noqa: SLF001
+                for key in attributes._dict:  # noqa: SLF001
+                    if self._should_redact(key):
+                        attributes._dict[key] = REDACTED_VALUE  # noqa: SLF001
+        elif isinstance(attributes, MutableMapping):
+            for key in attributes:
+                if self._should_redact(key):
+                    attributes[key] = REDACTED_VALUE
+
+    def _should_redact(self, attribute_name: str) -> bool:
+        return any(
+            re.fullmatch(re.escape(attribute).replace(r"\*", ".*"), attribute_name)
+            for attribute in self.attributes_to_redact
+        )
+
+    # pylint: disable=no-self-use
+    @override
+    def shutdown(self) -> None:
+        return
+
+    # pylint: disable=no-self-use
+    @override
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        return True

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/attribute_redacting_span_processor.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/attribute_redacting_span_processor.py
@@ -48,14 +48,6 @@ class AttributeRedactingSpanProcessor(SpanProcessor):
                 if attribute.strip()
             ]
         )
-
-    @property
-    def attributes_to_redact(self) -> list[str]:
-        return self._attributes_to_redact
-
-    @attributes_to_redact.setter
-    def attributes_to_redact(self, attributes: Collection[str]) -> None:
-        self._attributes_to_redact = list(attributes)
         self._compiled_patterns = tuple(
             re.compile(re.escape(attribute).replace(r"\*", ".*")) for attribute in self.attributes_to_redact
         )

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/attribute_redacting_span_processor.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/attribute_redacting_span_processor.py
@@ -14,42 +14,65 @@ from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
 from opentelemetry.util import types
 
 ENV_ADOT_REDACT_SPAN_ATTRIBUTES = "ADOT_REDACT_SPAN_ATTRIBUTES"
+ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES = "ADOT_REDACT_SPAN_EVENT_ATTRIBUTES"
 REDACTED_VALUE = "REDACTED"
 
 
 class AttributeRedactingSpanProcessor(SpanProcessor):
     """
-    Redacts configured attributes on completed spans and their events.
+    Redacts separately configured attributes on completed spans and span events.
 
-    Attribute names can be supplied to the constructor or through the
-    ``ADOT_REDACT_SPAN_ATTRIBUTES`` environment variable as a comma-separated
-    list. Each entry can be an exact attribute name or contain ``*`` wildcards.
-    Matching attribute values are replaced with ``REDACTED`` in place while
-    attribute names and non-matching values remain unchanged.
+    Span and span event attribute names can be supplied to the constructor or
+    through the ``ADOT_REDACT_SPAN_ATTRIBUTES`` and
+    ``ADOT_REDACT_SPAN_EVENT_ATTRIBUTES`` environment variables as
+    comma-separated lists. Each entry can be an exact attribute name or contain
+    ``*`` wildcards. Matching attribute values are replaced with ``REDACTED`` in
+    place while attribute names and non-matching values remain unchanged.
 
     Examples:
-        Redact several exact attributes, every attribute beginning with
-        ``http.request.``, and matching GenAI content attributes:
+        Redact several exact span attributes and every span attribute beginning
+        with ``http.request.``:
 
-        ``ADOT_REDACT_SPAN_ATTRIBUTES=user.email,request.body,db.statement,http.request.*,gen_ai.*.content``
+        ``ADOT_REDACT_SPAN_ATTRIBUTES=user.email,request.body,db.statement,http.request.*``
 
-        Redact every span and span event attribute:
+        Redact matching GenAI content attributes from span events:
+
+        ``ADOT_REDACT_SPAN_EVENT_ATTRIBUTES=gen_ai.*.content``
+
+        Redact every span attribute and every span event attribute:
 
         ``ADOT_REDACT_SPAN_ATTRIBUTES=*``
+        ``ADOT_REDACT_SPAN_EVENT_ATTRIBUTES=*``
     """
 
-    def __init__(self, attributes_to_redact: Optional[Collection[str]] = None) -> None:
-        self.attributes_to_redact = (
-            list(attributes_to_redact)
-            if attributes_to_redact
+    def __init__(
+        self,
+        span_attributes_to_redact: Optional[Collection[str]] = None,
+        span_event_attributes_to_redact: Optional[Collection[str]] = None,
+    ) -> None:
+        self.span_attributes_to_redact = (
+            list(span_attributes_to_redact)
+            if span_attributes_to_redact
             else [
                 attribute.strip()
                 for attribute in os.environ.get(ENV_ADOT_REDACT_SPAN_ATTRIBUTES, "").split(",")
                 if attribute.strip()
             ]
         )
-        self._compiled_patterns = tuple(
-            re.compile(re.escape(attribute).replace(r"\*", ".*")) for attribute in self.attributes_to_redact
+        self.span_event_attributes_to_redact = (
+            list(span_event_attributes_to_redact)
+            if span_event_attributes_to_redact
+            else [
+                attribute.strip()
+                for attribute in os.environ.get(ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES, "").split(",")
+                if attribute.strip()
+            ]
+        )
+        self._compiled_span_attribute_patterns = tuple(
+            re.compile(re.escape(attribute).replace(r"\*", ".*")) for attribute in self.span_attributes_to_redact
+        )
+        self._compiled_span_event_attribute_patterns = tuple(
+            re.compile(re.escape(attribute).replace(r"\*", ".*")) for attribute in self.span_event_attributes_to_redact
         )
 
     # pylint: disable=no-self-use
@@ -59,15 +82,27 @@ class AttributeRedactingSpanProcessor(SpanProcessor):
 
     @override
     def on_end(self, span: ReadableSpan) -> None:
-        if not self.attributes_to_redact:
+        if not self.span_attributes_to_redact and not self.span_event_attributes_to_redact:
             return
 
-        self._redact_attributes(span._attributes)  # noqa: SLF001
+        if self.span_attributes_to_redact:
+            self._redact_attributes(  # noqa: SLF001
+                span._attributes,
+                self._compiled_span_attribute_patterns,
+            )
 
-        for event in span.events:
-            self._redact_attributes(event._attributes)  # noqa: SLF001
+        if self.span_event_attributes_to_redact:
+            for event in span.events:
+                self._redact_attributes(  # noqa: SLF001
+                    event._attributes,
+                    self._compiled_span_event_attribute_patterns,
+                )
 
-    def _redact_attributes(self, attributes: types.Attributes) -> None:
+    def _redact_attributes(
+        self,
+        attributes: types.Attributes,
+        compiled_patterns: Collection[re.Pattern[str]],
+    ) -> None:
         if not attributes:
             return
 
@@ -76,15 +111,16 @@ class AttributeRedactingSpanProcessor(SpanProcessor):
             # their public setter raises TypeError. Update existing values under its lock.
             with attributes._lock:  # noqa: SLF001
                 for key in attributes._dict:  # noqa: SLF001
-                    if self._should_redact(key):
+                    if self._should_redact(key, compiled_patterns):
                         attributes._dict[key] = REDACTED_VALUE  # noqa: SLF001
         elif isinstance(attributes, MutableMapping):
             for key in attributes:
-                if self._should_redact(key):
+                if self._should_redact(key, compiled_patterns):
                     attributes[key] = REDACTED_VALUE
 
-    def _should_redact(self, attribute_name: str) -> bool:
-        return any(pattern.fullmatch(attribute_name) for pattern in self._compiled_patterns)
+    @staticmethod
+    def _should_redact(attribute_name: str, compiled_patterns: Collection[re.Pattern[str]]) -> bool:
+        return any(pattern.fullmatch(attribute_name) for pattern in compiled_patterns)
 
     # pylint: disable=no-self-use
     @override

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/attribute_redacting_span_processor.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/attribute_redacting_span_processor.py
@@ -14,65 +14,42 @@ from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
 from opentelemetry.util import types
 
 ENV_ADOT_REDACT_SPAN_ATTRIBUTES = "ADOT_REDACT_SPAN_ATTRIBUTES"
-ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES = "ADOT_REDACT_SPAN_EVENT_ATTRIBUTES"
 REDACTED_VALUE = "REDACTED"
 
 
 class AttributeRedactingSpanProcessor(SpanProcessor):
     """
-    Redacts separately configured attributes on completed spans and span events.
+    Redacts configured attributes on completed spans, their events, and their links.
 
-    Span and span event attribute names can be supplied to the constructor or
-    through the ``ADOT_REDACT_SPAN_ATTRIBUTES`` and
-    ``ADOT_REDACT_SPAN_EVENT_ATTRIBUTES`` environment variables as
-    comma-separated lists. Each entry can be an exact attribute name or contain
-    ``*`` wildcards. Matching attribute values are replaced with ``REDACTED`` in
-    place while attribute names and non-matching values remain unchanged.
+    Attribute names can be supplied to the constructor or through the
+    ``ADOT_REDACT_SPAN_ATTRIBUTES`` environment variable as a comma-separated
+    list. Each entry can be an exact attribute name or contain ``*`` wildcards.
+    Matching attribute values are replaced with ``REDACTED`` in place while
+    attribute names and non-matching values remain unchanged.
 
     Examples:
-        Redact several exact span attributes and every span attribute beginning
-        with ``http.request.``:
+        Redact several exact attributes, every attribute beginning with
+        ``http.request.``, and matching GenAI content attributes:
 
-        ``ADOT_REDACT_SPAN_ATTRIBUTES=user.email,request.body,db.statement,http.request.*``
+        ``ADOT_REDACT_SPAN_ATTRIBUTES=user.email,request.body,db.statement,http.request.*,gen_ai.*.content``
 
-        Redact matching GenAI content attributes from span events:
-
-        ``ADOT_REDACT_SPAN_EVENT_ATTRIBUTES=gen_ai.*.content``
-
-        Redact every span attribute and every span event attribute:
+        Redact every span, span event, and span link attribute:
 
         ``ADOT_REDACT_SPAN_ATTRIBUTES=*``
-        ``ADOT_REDACT_SPAN_EVENT_ATTRIBUTES=*``
     """
 
-    def __init__(
-        self,
-        span_attributes_to_redact: Optional[Collection[str]] = None,
-        span_event_attributes_to_redact: Optional[Collection[str]] = None,
-    ) -> None:
-        self.span_attributes_to_redact = (
-            list(span_attributes_to_redact)
-            if span_attributes_to_redact
+    def __init__(self, attributes_to_redact: Optional[Collection[str]] = None) -> None:
+        self.attributes_to_redact = (
+            list(attributes_to_redact)
+            if attributes_to_redact
             else [
                 attribute.strip()
                 for attribute in os.environ.get(ENV_ADOT_REDACT_SPAN_ATTRIBUTES, "").split(",")
                 if attribute.strip()
             ]
         )
-        self.span_event_attributes_to_redact = (
-            list(span_event_attributes_to_redact)
-            if span_event_attributes_to_redact
-            else [
-                attribute.strip()
-                for attribute in os.environ.get(ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES, "").split(",")
-                if attribute.strip()
-            ]
-        )
-        self._compiled_span_attribute_patterns = tuple(
-            re.compile(re.escape(attribute).replace(r"\*", ".*")) for attribute in self.span_attributes_to_redact
-        )
-        self._compiled_span_event_attribute_patterns = tuple(
-            re.compile(re.escape(attribute).replace(r"\*", ".*")) for attribute in self.span_event_attributes_to_redact
+        self._compiled_patterns = tuple(
+            re.compile(re.escape(attribute).replace(r"\*", ".*")) for attribute in self.attributes_to_redact
         )
 
     # pylint: disable=no-self-use
@@ -82,45 +59,35 @@ class AttributeRedactingSpanProcessor(SpanProcessor):
 
     @override
     def on_end(self, span: ReadableSpan) -> None:
-        if not self.span_attributes_to_redact and not self.span_event_attributes_to_redact:
+        if not self.attributes_to_redact:
             return
 
-        if self.span_attributes_to_redact:
-            self._redact_attributes(  # noqa: SLF001
-                span._attributes,
-                self._compiled_span_attribute_patterns,
-            )
+        self._redact_attributes(span._attributes)  # noqa: SLF001
 
-        if self.span_event_attributes_to_redact:
-            for event in span.events:
-                self._redact_attributes(  # noqa: SLF001
-                    event._attributes,
-                    self._compiled_span_event_attribute_patterns,
-                )
+        for event in span.events:
+            self._redact_attributes(event._attributes)  # noqa: SLF001
 
-    def _redact_attributes(
-        self,
-        attributes: types.Attributes,
-        compiled_patterns: Collection[re.Pattern[str]],
-    ) -> None:
+        for link in span.links:
+            self._redact_attributes(link.attributes)
+
+    def _redact_attributes(self, attributes: types.Attributes) -> None:
         if not attributes:
             return
 
         if isinstance(attributes, BoundedAttributes):
-            # Completed spans and events expose immutable BoundedAttributes, so
+            # Completed spans, events, and links expose immutable BoundedAttributes, so
             # their public setter raises TypeError. Update existing values under its lock.
             with attributes._lock:  # noqa: SLF001
                 for key in attributes._dict:  # noqa: SLF001
-                    if self._should_redact(key, compiled_patterns):
+                    if self._should_redact(key):
                         attributes._dict[key] = REDACTED_VALUE  # noqa: SLF001
         elif isinstance(attributes, MutableMapping):
             for key in attributes:
-                if self._should_redact(key, compiled_patterns):
+                if self._should_redact(key):
                     attributes[key] = REDACTED_VALUE
 
-    @staticmethod
-    def _should_redact(attribute_name: str, compiled_patterns: Collection[re.Pattern[str]]) -> bool:
-        return any(pattern.fullmatch(attribute_name) for pattern in compiled_patterns)
+    def _should_redact(self, attribute_name: str) -> bool:
+        return any(pattern.fullmatch(attribute_name) for pattern in self._compiled_patterns)
 
     # pylint: disable=no-self-use
     @override

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/attribute_redacting_span_processor.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/attribute_redacting_span_processor.py
@@ -49,6 +49,17 @@ class AttributeRedactingSpanProcessor(SpanProcessor):
             ]
         )
 
+    @property
+    def attributes_to_redact(self) -> list[str]:
+        return self._attributes_to_redact
+
+    @attributes_to_redact.setter
+    def attributes_to_redact(self, attributes: Collection[str]) -> None:
+        self._attributes_to_redact = list(attributes)
+        self._compiled_patterns = tuple(
+            re.compile(re.escape(attribute).replace(r"\*", ".*")) for attribute in self.attributes_to_redact
+        )
+
     # pylint: disable=no-self-use
     @override
     def on_start(self, span: Span, parent_context: Optional[Context] = None) -> None:
@@ -69,6 +80,8 @@ class AttributeRedactingSpanProcessor(SpanProcessor):
             return
 
         if isinstance(attributes, BoundedAttributes):
+            # Completed spans and events expose immutable BoundedAttributes, so
+            # their public setter raises TypeError. Update existing values under its lock.
             with attributes._lock:  # noqa: SLF001
                 for key in attributes._dict:  # noqa: SLF001
                     if self._should_redact(key):
@@ -79,10 +92,7 @@ class AttributeRedactingSpanProcessor(SpanProcessor):
                     attributes[key] = REDACTED_VALUE
 
     def _should_redact(self, attribute_name: str) -> bool:
-        return any(
-            re.fullmatch(re.escape(attribute).replace(r"\*", ".*"), attribute_name)
-            for attribute in self.attributes_to_redact
-        )
+        return any(pattern.fullmatch(attribute_name) for pattern in self._compiled_patterns)
 
     # pylint: disable=no-self-use
     @override

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
@@ -22,6 +22,7 @@ from amazon.opentelemetry.distro.always_record_sampler import AlwaysRecordSample
 from amazon.opentelemetry.distro.attribute_propagating_span_processor_builder import (
     AttributePropagatingSpanProcessorBuilder,
 )
+from amazon.opentelemetry.distro.attribute_redacting_span_processor import AttributeRedactingSpanProcessor
 from amazon.opentelemetry.distro.aws_batch_unsampled_span_processor import BatchUnsampledSpanProcessor
 from amazon.opentelemetry.distro.aws_lambda_span_processor import AwsLambdaSpanProcessor
 from amazon.opentelemetry.distro.aws_metric_attributes_span_exporter_builder import (
@@ -342,6 +343,8 @@ def _init_tracing(
     # processors to ensure exporters observe the updated kind.
     if is_agent_observability_enabled():
         trace_provider.add_span_processor(GenAINestedClientSpanProcessor())
+
+    trace_provider.add_span_processor(AttributeRedactingSpanProcessor())
 
     for _, exporter_class in exporters.items():
         exporter_args: Dict[str, any] = {}

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_configurator.py
@@ -344,6 +344,8 @@ def _init_tracing(
     if is_agent_observability_enabled():
         trace_provider.add_span_processor(GenAINestedClientSpanProcessor())
 
+    # This processor modifies attributes in on_end, so it must run before batch
+    # processors to ensure exporters observe the redacted values.
     trace_provider.add_span_processor(AttributeRedactingSpanProcessor())
 
     for _, exporter_class in exporters.items():

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_attribute_redacting_span_processor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_attribute_redacting_span_processor.py
@@ -28,20 +28,6 @@ class RedactionTestData:
 
 
 class TestAttributeRedactingSpanProcessor(TestCase):
-    def setUp(self) -> None:
-        self.exporter = InMemorySpanExporter()
-        self.provider = TracerProvider()
-        with patch.dict(os.environ, {ENV_ADOT_REDACT_SPAN_ATTRIBUTES: ""}):
-            self.processor = AttributeRedactingSpanProcessor()
-        self.provider.add_span_processor(self.processor)
-        self.provider.add_span_processor(BatchSpanProcessor(self.exporter))
-        self.tracer = self.provider.get_tracer(__name__)
-
-    def tearDown(self) -> None:
-        self.provider.force_flush()
-        self.provider.shutdown()
-        self.exporter.clear()
-
     def test_should_redact_all_attributes_that_match_configured_patterns(self):
         test_cases = (
             RedactionTestData(
@@ -173,26 +159,8 @@ class TestAttributeRedactingSpanProcessor(TestCase):
         )
 
         for test_data in test_cases:
-            with self.subTest(name=test_data.name), patch.dict(
-                os.environ,
-                {ENV_ADOT_REDACT_SPAN_ATTRIBUTES: test_data.environment_value},
-            ):
-                self.processor.attributes_to_redact = AttributeRedactingSpanProcessor().attributes_to_redact
-                with self.tracer.start_as_current_span("test", attributes=test_data.span_attributes) as span:
-                    span.add_event("test.event", attributes=test_data.event_attributes)
-
-                try:
-                    self.assertTrue(self.provider.force_flush())
-                    finished_spans = self.exporter.get_finished_spans()
-                    self.assertEqual(len(finished_spans), 1)
-                    exported_span = finished_spans[0]
-                    self.assertEqual(dict(exported_span.attributes), test_data.expected_span_attributes)
-                    self.assertEqual(
-                        {event.name: dict(event.attributes) for event in exported_span.events},
-                        {"test.event": test_data.expected_event_attributes},
-                    )
-                finally:
-                    self.exporter.clear()
+            with self.subTest(name=test_data.name):
+                self._assert_redaction(test_data)
 
     def test_should_not_redact_attributes_for_invalid_configured_patterns(self):
         test_cases = (
@@ -291,23 +259,32 @@ class TestAttributeRedactingSpanProcessor(TestCase):
         )
 
         for test_data in test_cases:
-            with self.subTest(name=test_data.name), patch.dict(
-                os.environ,
-                {ENV_ADOT_REDACT_SPAN_ATTRIBUTES: test_data.environment_value},
-            ):
-                self.processor.attributes_to_redact = AttributeRedactingSpanProcessor().attributes_to_redact
-                with self.tracer.start_as_current_span("test", attributes=test_data.span_attributes) as span:
-                    span.add_event("test.event", attributes=test_data.event_attributes)
+            with self.subTest(name=test_data.name):
+                self._assert_redaction(test_data)
 
-                try:
-                    self.assertTrue(self.provider.force_flush())
-                    finished_spans = self.exporter.get_finished_spans()
-                    self.assertEqual(len(finished_spans), 1)
-                    exported_span = finished_spans[0]
-                    self.assertEqual(dict(exported_span.attributes), test_data.expected_span_attributes)
-                    self.assertEqual(
-                        {event.name: dict(event.attributes) for event in exported_span.events},
-                        {"test.event": test_data.expected_event_attributes},
-                    )
-                finally:
-                    self.exporter.clear()
+    def _assert_redaction(self, test_data: RedactionTestData) -> None:
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        with patch.dict(
+            os.environ,
+            {ENV_ADOT_REDACT_SPAN_ATTRIBUTES: test_data.environment_value},
+        ):
+            provider.add_span_processor(AttributeRedactingSpanProcessor())
+        provider.add_span_processor(BatchSpanProcessor(exporter))
+        tracer = provider.get_tracer(__name__)
+
+        try:
+            with tracer.start_as_current_span("test", attributes=test_data.span_attributes) as span:
+                span.add_event("test.event", attributes=test_data.event_attributes)
+
+            self.assertTrue(provider.force_flush())
+            finished_spans = exporter.get_finished_spans()
+            self.assertEqual(len(finished_spans), 1)
+            exported_span = finished_spans[0]
+            self.assertEqual(dict(exported_span.attributes), test_data.expected_span_attributes)
+            self.assertEqual(
+                {event.name: dict(event.attributes) for event in exported_span.events},
+                {"test.event": test_data.expected_event_attributes},
+            )
+        finally:
+            provider.shutdown()

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_attribute_redacting_span_processor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_attribute_redacting_span_processor.py
@@ -24,6 +24,7 @@ class RedactionTestData:
     environment_variables: dict[str, str]
     span_attributes: dict[str, AttributeValue]
     span_event_attributes: dict[str, AttributeValue]
+    span_link_attributes: dict[str, AttributeValue]
     expected_span_attributes: dict[str, AttributeValue]
     expected_span_event_attributes: dict[str, AttributeValue]
     expected_span_link_attributes: dict[str, AttributeValue]
@@ -53,6 +54,14 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     "gen_ai.prompt": "private event prompt",
                     "event.safe": "keep me",
                 },
+                span_link_attributes={
+                    "user.email": "link-user@example.com",
+                    "request.body": '{"link_password":"secret"}',
+                    "db.statement": "SELECT * FROM linked_users",
+                    "gen_ai.prompt": "private link prompt",
+                    "http.request.method": "POST",
+                    "server.address": "linked.example.com",
+                },
                 expected_span_attributes={
                     "user.email": REDACTED_VALUE,
                     "request.body": REDACTED_VALUE,
@@ -73,7 +82,7 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     "db.statement": REDACTED_VALUE,
                     "gen_ai.prompt": REDACTED_VALUE,
                     "http.request.method": "POST",
-                    "server.address": "example.com",
+                    "server.address": "linked.example.com",
                 },
             ),
             RedactionTestData(
@@ -83,6 +92,7 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                 },
                 span_attributes={"first": "secret", "second": 42, "third": True},
                 span_event_attributes={"event.first": "secret", "event.second": 42},
+                span_link_attributes={"link.first": "secret", "link.second": 42, "link.third": True},
                 expected_span_attributes={
                     "first": REDACTED_VALUE,
                     "second": REDACTED_VALUE,
@@ -93,9 +103,9 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     "event.second": REDACTED_VALUE,
                 },
                 expected_span_link_attributes={
-                    "first": REDACTED_VALUE,
-                    "second": REDACTED_VALUE,
-                    "third": REDACTED_VALUE,
+                    "link.first": REDACTED_VALUE,
+                    "link.second": REDACTED_VALUE,
+                    "link.third": REDACTED_VALUE,
                 },
             ),
             RedactionTestData(
@@ -112,6 +122,10 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     "http.request.header.authorization": "secret",
                     "event.safe": "keep me",
                 },
+                span_link_attributes={
+                    "http.link.header.authorization": "secret",
+                    "link.safe": "keep me",
+                },
                 expected_span_attributes={
                     "http.request.method": REDACTED_VALUE,
                     "http.response.status_code": REDACTED_VALUE,
@@ -122,9 +136,8 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     "event.safe": "keep me",
                 },
                 expected_span_link_attributes={
-                    "http.request.method": REDACTED_VALUE,
-                    "http.response.status_code": REDACTED_VALUE,
-                    "server.address": "example.com",
+                    "http.link.header.authorization": REDACTED_VALUE,
+                    "link.safe": "keep me",
                 },
             ),
             RedactionTestData(
@@ -134,6 +147,7 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                 },
                 span_attributes={"request.body": "secret", "response.body": "secret", "body.size": 42},
                 span_event_attributes={"message.body": "secret", "message.body.size": 42},
+                span_link_attributes={"link.body": "secret", "link.body.size": 42},
                 expected_span_attributes={
                     "request.body": REDACTED_VALUE,
                     "response.body": REDACTED_VALUE,
@@ -144,9 +158,8 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     "message.body.size": 42,
                 },
                 expected_span_link_attributes={
-                    "request.body": REDACTED_VALUE,
-                    "response.body": REDACTED_VALUE,
-                    "body.size": 42,
+                    "link.body": REDACTED_VALUE,
+                    "link.body.size": 42,
                 },
             ),
             RedactionTestData(
@@ -163,6 +176,10 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     "gen_ai.tool.content": "secret event",
                     "gen_ai.tool.name": "lookup",
                 },
+                span_link_attributes={
+                    "gen_ai.link.content": "secret link",
+                    "gen_ai.link.name": "lookup",
+                },
                 expected_span_attributes={
                     "gen_ai.input.content": REDACTED_VALUE,
                     "gen_ai.output.content": REDACTED_VALUE,
@@ -173,9 +190,8 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     "gen_ai.tool.name": "lookup",
                 },
                 expected_span_link_attributes={
-                    "gen_ai.input.content": REDACTED_VALUE,
-                    "gen_ai.output.content": REDACTED_VALUE,
-                    "gen_ai.request.model": "model",
+                    "gen_ai.link.content": REDACTED_VALUE,
+                    "gen_ai.link.name": "lookup",
                 },
             ),
             RedactionTestData(
@@ -189,6 +205,11 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     "http.response.body": "secret",
                     "event.safe": "keep me",
                 },
+                span_link_attributes={
+                    "user.email": "link-user@example.com",
+                    "http.link": "secret",
+                    "link.safe": "keep me",
+                },
                 expected_span_attributes={
                     "user.email": REDACTED_VALUE,
                     "http.route": REDACTED_VALUE,
@@ -201,8 +222,8 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                 },
                 expected_span_link_attributes={
                     "user.email": REDACTED_VALUE,
-                    "http.route": REDACTED_VALUE,
-                    "safe": "value",
+                    "http.link": REDACTED_VALUE,
+                    "link.safe": "keep me",
                 },
             ),
         )
@@ -220,9 +241,10 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                 },
                 span_attributes={"user.email": "user@example.com"},
                 span_event_attributes={"user.email": "event-user@example.com"},
+                span_link_attributes={"user.email": "link-user@example.com"},
                 expected_span_attributes={"user.email": "user@example.com"},
                 expected_span_event_attributes={"user.email": "event-user@example.com"},
-                expected_span_link_attributes={"user.email": "user@example.com"},
+                expected_span_link_attributes={"user.email": "link-user@example.com"},
             ),
             RedactionTestData(
                 name="empty comma-separated entries",
@@ -231,9 +253,10 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                 },
                 span_attributes={"request.body": "secret"},
                 span_event_attributes={"request.body": "event secret"},
+                span_link_attributes={"request.body": "link secret"},
                 expected_span_attributes={"request.body": "secret"},
                 expected_span_event_attributes={"request.body": "event secret"},
-                expected_span_link_attributes={"request.body": "secret"},
+                expected_span_link_attributes={"request.body": "link secret"},
             ),
             RedactionTestData(
                 name="whitespace-only configuration",
@@ -242,9 +265,10 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                 },
                 span_attributes={"db.statement": "SELECT * FROM users"},
                 span_event_attributes={"db.statement": "DELETE FROM users"},
+                span_link_attributes={"db.statement": "SELECT * FROM linked_users"},
                 expected_span_attributes={"db.statement": "SELECT * FROM users"},
                 expected_span_event_attributes={"db.statement": "DELETE FROM users"},
-                expected_span_link_attributes={"db.statement": "SELECT * FROM users"},
+                expected_span_link_attributes={"db.statement": "SELECT * FROM linked_users"},
             ),
             RedactionTestData(
                 name="unsupported regular expression",
@@ -253,9 +277,10 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                 },
                 span_attributes={"http.request.method": "POST"},
                 span_event_attributes={"http.request.body": "secret"},
+                span_link_attributes={"http.request.header": "secret"},
                 expected_span_attributes={"http.request.method": "POST"},
                 expected_span_event_attributes={"http.request.body": "secret"},
-                expected_span_link_attributes={"http.request.method": "POST"},
+                expected_span_link_attributes={"http.request.header": "secret"},
             ),
             RedactionTestData(
                 name="unsupported regular expression anchors",
@@ -264,9 +289,10 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                 },
                 span_attributes={"user.email": "user@example.com"},
                 span_event_attributes={"user.email": "event-user@example.com"},
+                span_link_attributes={"user.email": "link-user@example.com"},
                 expected_span_attributes={"user.email": "user@example.com"},
                 expected_span_event_attributes={"user.email": "event-user@example.com"},
-                expected_span_link_attributes={"user.email": "user@example.com"},
+                expected_span_link_attributes={"user.email": "link-user@example.com"},
             ),
             RedactionTestData(
                 name="unsupported regular expression character class",
@@ -275,9 +301,10 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                 },
                 span_attributes={"http.request.method": "POST"},
                 span_event_attributes={"http.request.body": "secret"},
+                span_link_attributes={"http.request.header": "secret"},
                 expected_span_attributes={"http.request.method": "POST"},
                 expected_span_event_attributes={"http.request.body": "secret"},
-                expected_span_link_attributes={"http.request.method": "POST"},
+                expected_span_link_attributes={"http.request.header": "secret"},
             ),
             RedactionTestData(
                 name="unsupported regular expression alternation",
@@ -292,6 +319,10 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     "user.email": "event-user@example.com",
                     "request.body": "event secret",
                 },
+                span_link_attributes={
+                    "user.email": "link-user@example.com",
+                    "request.body": "link secret",
+                },
                 expected_span_attributes={
                     "user.email": "user@example.com",
                     "request.body": "secret",
@@ -301,8 +332,8 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     "request.body": "event secret",
                 },
                 expected_span_link_attributes={
-                    "user.email": "user@example.com",
-                    "request.body": "secret",
+                    "user.email": "link-user@example.com",
+                    "request.body": "link secret",
                 },
             ),
             RedactionTestData(
@@ -312,9 +343,10 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                 },
                 span_attributes={"http.request.method": "POST"},
                 span_event_attributes={"http.request.body": "secret"},
+                span_link_attributes={"http.request.header": "secret"},
                 expected_span_attributes={"http.request.method": "POST"},
                 expected_span_event_attributes={"http.request.body": "secret"},
-                expected_span_link_attributes={"http.request.method": "POST"},
+                expected_span_link_attributes={"http.request.header": "secret"},
             ),
             RedactionTestData(
                 name="malformed bracket pattern",
@@ -323,9 +355,10 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                 },
                 span_attributes={"http.request.method": "POST"},
                 span_event_attributes={"http.request.body": "secret"},
+                span_link_attributes={"http.request.header": "secret"},
                 expected_span_attributes={"http.request.method": "POST"},
                 expected_span_event_attributes={"http.request.body": "secret"},
-                expected_span_link_attributes={"http.request.method": "POST"},
+                expected_span_link_attributes={"http.request.header": "secret"},
             ),
             RedactionTestData(
                 name="attribute name containing comma",
@@ -334,9 +367,10 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                 },
                 span_attributes={"custom,attribute": "secret"},
                 span_event_attributes={"custom,attribute": "event secret"},
+                span_link_attributes={"custom,attribute": "link secret"},
                 expected_span_attributes={"custom,attribute": "secret"},
                 expected_span_event_attributes={"custom,attribute": "event secret"},
-                expected_span_link_attributes={"custom,attribute": "secret"},
+                expected_span_link_attributes={"custom,attribute": "link secret"},
             ),
         )
 
@@ -358,7 +392,7 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                 is_remote=True,
                 trace_flags=TraceFlags(TraceFlags.SAMPLED),
             ),
-            attributes=test_data.span_attributes,
+            attributes=test_data.span_link_attributes,
         )
 
         try:

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_attribute_redacting_span_processor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_attribute_redacting_span_processor.py
@@ -7,8 +7,8 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from amazon.opentelemetry.distro.attribute_redacting_span_processor import (
-    ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES,
     ENV_ADOT_REDACT_SPAN_ATTRIBUTES,
+    ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES,
     REDACTED_VALUE,
     AttributeRedactingSpanProcessor,
 )

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_attribute_redacting_span_processor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_attribute_redacting_span_processor.py
@@ -3,7 +3,6 @@
 
 import os
 from dataclasses import dataclass
-from typing import Optional
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -22,12 +21,11 @@ from opentelemetry.util.types import AttributeValue
 @dataclass
 class RedactionTestData:
     name: str
-    environment_value: str
+    environment_variables: dict[str, str]
     span_attributes: dict[str, AttributeValue]
     event_attributes: dict[str, AttributeValue]
     expected_span_attributes: dict[str, AttributeValue]
     expected_event_attributes: dict[str, AttributeValue]
-    span_event_environment_value: Optional[str] = None
 
 
 class TestAttributeRedactingSpanProcessor(TestCase):
@@ -35,7 +33,12 @@ class TestAttributeRedactingSpanProcessor(TestCase):
         test_cases = (
             RedactionTestData(
                 name="independent configured attribute names",
-                environment_value=" user.email, request.body, db.statement, gen_ai.prompt, user.email ",
+                environment_variables={
+                    ENV_ADOT_REDACT_SPAN_ATTRIBUTES: (
+                        " user.email, request.body, db.statement, gen_ai.prompt, user.email "
+                    ),
+                    ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES: " db.statement, event.secret ",
+                },
                 span_attributes={
                     "user.email": "user@example.com",
                     "request.body": '{"password":"secret"}',
@@ -68,11 +71,13 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     "event.secret": REDACTED_VALUE,
                     "event.safe": "keep me",
                 },
-                span_event_environment_value=" db.statement, event.secret ",
             ),
             RedactionTestData(
                 name="wildcard only",
-                environment_value="*",
+                environment_variables={
+                    ENV_ADOT_REDACT_SPAN_ATTRIBUTES: "*",
+                    ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES: "*",
+                },
                 span_attributes={"first": "secret", "second": 42, "third": True},
                 event_attributes={"event.first": "secret", "event.second": 42},
                 expected_span_attributes={
@@ -87,7 +92,10 @@ class TestAttributeRedactingSpanProcessor(TestCase):
             ),
             RedactionTestData(
                 name="prefix wildcard",
-                environment_value="http.*",
+                environment_variables={
+                    ENV_ADOT_REDACT_SPAN_ATTRIBUTES: "http.*",
+                    ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES: "http.*",
+                },
                 span_attributes={
                     "http.request.method": "GET",
                     "http.response.status_code": 200,
@@ -109,7 +117,10 @@ class TestAttributeRedactingSpanProcessor(TestCase):
             ),
             RedactionTestData(
                 name="suffix wildcard",
-                environment_value="*.body",
+                environment_variables={
+                    ENV_ADOT_REDACT_SPAN_ATTRIBUTES: "*.body",
+                    ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES: "*.body",
+                },
                 span_attributes={"request.body": "secret", "response.body": "secret", "body.size": 42},
                 event_attributes={"message.body": "secret", "message.body.size": 42},
                 expected_span_attributes={
@@ -124,7 +135,10 @@ class TestAttributeRedactingSpanProcessor(TestCase):
             ),
             RedactionTestData(
                 name="multiple wildcard segments",
-                environment_value="gen_ai.*.content",
+                environment_variables={
+                    ENV_ADOT_REDACT_SPAN_ATTRIBUTES: "gen_ai.*.content",
+                    ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES: "gen_ai.*.content",
+                },
                 span_attributes={
                     "gen_ai.input.content": "secret input",
                     "gen_ai.output.content": "secret output",
@@ -146,7 +160,10 @@ class TestAttributeRedactingSpanProcessor(TestCase):
             ),
             RedactionTestData(
                 name="wildcard mixed with explicit names",
-                environment_value="user.email,http.*",
+                environment_variables={
+                    ENV_ADOT_REDACT_SPAN_ATTRIBUTES: "user.email,http.*",
+                    ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES: "user.email,http.*",
+                },
                 span_attributes={"user.email": "user@example.com", "http.route": "/users", "safe": "value"},
                 event_attributes={
                     "user.email": "event-user@example.com",
@@ -174,7 +191,10 @@ class TestAttributeRedactingSpanProcessor(TestCase):
         test_cases = (
             RedactionTestData(
                 name="empty configuration",
-                environment_value="",
+                environment_variables={
+                    ENV_ADOT_REDACT_SPAN_ATTRIBUTES: "",
+                    ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES: "",
+                },
                 span_attributes={"user.email": "user@example.com"},
                 event_attributes={"user.email": "event-user@example.com"},
                 expected_span_attributes={"user.email": "user@example.com"},
@@ -182,7 +202,10 @@ class TestAttributeRedactingSpanProcessor(TestCase):
             ),
             RedactionTestData(
                 name="empty comma-separated entries",
-                environment_value=" , , ",
+                environment_variables={
+                    ENV_ADOT_REDACT_SPAN_ATTRIBUTES: " , , ",
+                    ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES: " , , ",
+                },
                 span_attributes={"request.body": "secret"},
                 event_attributes={"request.body": "event secret"},
                 expected_span_attributes={"request.body": "secret"},
@@ -190,7 +213,10 @@ class TestAttributeRedactingSpanProcessor(TestCase):
             ),
             RedactionTestData(
                 name="whitespace-only configuration",
-                environment_value=" \t ",
+                environment_variables={
+                    ENV_ADOT_REDACT_SPAN_ATTRIBUTES: " \t ",
+                    ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES: " \t ",
+                },
                 span_attributes={"db.statement": "SELECT * FROM users"},
                 event_attributes={"db.statement": "DELETE FROM users"},
                 expected_span_attributes={"db.statement": "SELECT * FROM users"},
@@ -198,7 +224,10 @@ class TestAttributeRedactingSpanProcessor(TestCase):
             ),
             RedactionTestData(
                 name="unsupported regular expression",
-                environment_value=r"http\.request\..+",
+                environment_variables={
+                    ENV_ADOT_REDACT_SPAN_ATTRIBUTES: r"http\.request\..+",
+                    ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES: r"http\.request\..+",
+                },
                 span_attributes={"http.request.method": "POST"},
                 event_attributes={"http.request.body": "secret"},
                 expected_span_attributes={"http.request.method": "POST"},
@@ -206,7 +235,10 @@ class TestAttributeRedactingSpanProcessor(TestCase):
             ),
             RedactionTestData(
                 name="unsupported regular expression anchors",
-                environment_value="^user.email$",
+                environment_variables={
+                    ENV_ADOT_REDACT_SPAN_ATTRIBUTES: "^user.email$",
+                    ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES: "^user.email$",
+                },
                 span_attributes={"user.email": "user@example.com"},
                 event_attributes={"user.email": "event-user@example.com"},
                 expected_span_attributes={"user.email": "user@example.com"},
@@ -214,7 +246,10 @@ class TestAttributeRedactingSpanProcessor(TestCase):
             ),
             RedactionTestData(
                 name="unsupported regular expression character class",
-                environment_value="http.request.[a-z]+",
+                environment_variables={
+                    ENV_ADOT_REDACT_SPAN_ATTRIBUTES: "http.request.[a-z]+",
+                    ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES: "http.request.[a-z]+",
+                },
                 span_attributes={"http.request.method": "POST"},
                 event_attributes={"http.request.body": "secret"},
                 expected_span_attributes={"http.request.method": "POST"},
@@ -222,7 +257,10 @@ class TestAttributeRedactingSpanProcessor(TestCase):
             ),
             RedactionTestData(
                 name="unsupported regular expression alternation",
-                environment_value="user.email|request.body",
+                environment_variables={
+                    ENV_ADOT_REDACT_SPAN_ATTRIBUTES: "user.email|request.body",
+                    ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES: "user.email|request.body",
+                },
                 span_attributes={
                     "user.email": "user@example.com",
                     "request.body": "secret",
@@ -242,7 +280,10 @@ class TestAttributeRedactingSpanProcessor(TestCase):
             ),
             RedactionTestData(
                 name="unsupported question mark wildcard",
-                environment_value="http.request.?",
+                environment_variables={
+                    ENV_ADOT_REDACT_SPAN_ATTRIBUTES: "http.request.?",
+                    ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES: "http.request.?",
+                },
                 span_attributes={"http.request.method": "POST"},
                 event_attributes={"http.request.body": "secret"},
                 expected_span_attributes={"http.request.method": "POST"},
@@ -250,7 +291,10 @@ class TestAttributeRedactingSpanProcessor(TestCase):
             ),
             RedactionTestData(
                 name="malformed bracket pattern",
-                environment_value="http.request.[",
+                environment_variables={
+                    ENV_ADOT_REDACT_SPAN_ATTRIBUTES: "http.request.[",
+                    ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES: "http.request.[",
+                },
                 span_attributes={"http.request.method": "POST"},
                 event_attributes={"http.request.body": "secret"},
                 expected_span_attributes={"http.request.method": "POST"},
@@ -258,7 +302,10 @@ class TestAttributeRedactingSpanProcessor(TestCase):
             ),
             RedactionTestData(
                 name="attribute name containing comma",
-                environment_value="custom,attribute",
+                environment_variables={
+                    ENV_ADOT_REDACT_SPAN_ATTRIBUTES: "custom,attribute",
+                    ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES: "custom,attribute",
+                },
                 span_attributes={"custom,attribute": "secret"},
                 event_attributes={"custom,attribute": "event secret"},
                 expected_span_attributes={"custom,attribute": "secret"},
@@ -273,18 +320,7 @@ class TestAttributeRedactingSpanProcessor(TestCase):
     def _assert_redaction(self, test_data: RedactionTestData) -> None:
         exporter = InMemorySpanExporter()
         provider = TracerProvider()
-        span_event_environment_value = (
-            test_data.span_event_environment_value
-            if test_data.span_event_environment_value is not None
-            else test_data.environment_value
-        )
-        with patch.dict(
-            os.environ,
-            {
-                ENV_ADOT_REDACT_SPAN_ATTRIBUTES: test_data.environment_value,
-                ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES: span_event_environment_value,
-            },
-        ):
+        with patch.dict(os.environ, test_data.environment_variables):
             provider.add_span_processor(AttributeRedactingSpanProcessor())
         provider.add_span_processor(BatchSpanProcessor(exporter))
         tracer = provider.get_tracer(__name__)

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_attribute_redacting_span_processor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_attribute_redacting_span_processor.py
@@ -7,7 +7,6 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from amazon.opentelemetry.distro.attribute_redacting_span_processor import (
-    ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES,
     ENV_ADOT_REDACT_SPAN_ATTRIBUTES,
     REDACTED_VALUE,
     AttributeRedactingSpanProcessor,
@@ -15,6 +14,7 @@ from amazon.opentelemetry.distro.attribute_redacting_span_processor import (
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import Link, SpanContext, TraceFlags
 from opentelemetry.util.types import AttributeValue
 
 
@@ -26,25 +26,24 @@ class RedactionTestData:
     event_attributes: dict[str, AttributeValue]
     expected_span_attributes: dict[str, AttributeValue]
     expected_event_attributes: dict[str, AttributeValue]
+    expected_span_link_attributes: dict[str, AttributeValue]
 
 
 class TestAttributeRedactingSpanProcessor(TestCase):
     def test_should_redact_all_attributes_that_match_configured_patterns(self):
         test_cases = (
             RedactionTestData(
-                name="independent configured attribute names",
+                name="configured attribute names",
                 environment_variables={
                     ENV_ADOT_REDACT_SPAN_ATTRIBUTES: (
                         " user.email, request.body, db.statement, gen_ai.prompt, user.email "
                     ),
-                    ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES: " db.statement, event.secret ",
                 },
                 span_attributes={
                     "user.email": "user@example.com",
                     "request.body": '{"password":"secret"}',
                     "db.statement": "SELECT * FROM users",
                     "gen_ai.prompt": "private prompt",
-                    "event.secret": "span value",
                     "http.request.method": "POST",
                     "server.address": "example.com",
                 },
@@ -52,7 +51,6 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     "user.email": "event-user@example.com",
                     "db.statement": "UPDATE users SET password = 'secret'",
                     "gen_ai.prompt": "private event prompt",
-                    "event.secret": "event value",
                     "event.safe": "keep me",
                 },
                 expected_span_attributes={
@@ -60,23 +58,28 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     "request.body": REDACTED_VALUE,
                     "db.statement": REDACTED_VALUE,
                     "gen_ai.prompt": REDACTED_VALUE,
-                    "event.secret": "span value",
                     "http.request.method": "POST",
                     "server.address": "example.com",
                 },
                 expected_event_attributes={
-                    "user.email": "event-user@example.com",
+                    "user.email": REDACTED_VALUE,
                     "db.statement": REDACTED_VALUE,
-                    "gen_ai.prompt": "private event prompt",
-                    "event.secret": REDACTED_VALUE,
+                    "gen_ai.prompt": REDACTED_VALUE,
                     "event.safe": "keep me",
+                },
+                expected_span_link_attributes={
+                    "user.email": REDACTED_VALUE,
+                    "request.body": REDACTED_VALUE,
+                    "db.statement": REDACTED_VALUE,
+                    "gen_ai.prompt": REDACTED_VALUE,
+                    "http.request.method": "POST",
+                    "server.address": "example.com",
                 },
             ),
             RedactionTestData(
                 name="wildcard only",
                 environment_variables={
                     ENV_ADOT_REDACT_SPAN_ATTRIBUTES: "*",
-                    ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES: "*",
                 },
                 span_attributes={"first": "secret", "second": 42, "third": True},
                 event_attributes={"event.first": "secret", "event.second": 42},
@@ -89,12 +92,16 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     "event.first": REDACTED_VALUE,
                     "event.second": REDACTED_VALUE,
                 },
+                expected_span_link_attributes={
+                    "first": REDACTED_VALUE,
+                    "second": REDACTED_VALUE,
+                    "third": REDACTED_VALUE,
+                },
             ),
             RedactionTestData(
                 name="prefix wildcard",
                 environment_variables={
                     ENV_ADOT_REDACT_SPAN_ATTRIBUTES: "http.*",
-                    ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES: "http.*",
                 },
                 span_attributes={
                     "http.request.method": "GET",
@@ -114,12 +121,16 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     "http.request.header.authorization": REDACTED_VALUE,
                     "event.safe": "keep me",
                 },
+                expected_span_link_attributes={
+                    "http.request.method": REDACTED_VALUE,
+                    "http.response.status_code": REDACTED_VALUE,
+                    "server.address": "example.com",
+                },
             ),
             RedactionTestData(
                 name="suffix wildcard",
                 environment_variables={
                     ENV_ADOT_REDACT_SPAN_ATTRIBUTES: "*.body",
-                    ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES: "*.body",
                 },
                 span_attributes={"request.body": "secret", "response.body": "secret", "body.size": 42},
                 event_attributes={"message.body": "secret", "message.body.size": 42},
@@ -132,12 +143,16 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     "message.body": REDACTED_VALUE,
                     "message.body.size": 42,
                 },
+                expected_span_link_attributes={
+                    "request.body": REDACTED_VALUE,
+                    "response.body": REDACTED_VALUE,
+                    "body.size": 42,
+                },
             ),
             RedactionTestData(
                 name="multiple wildcard segments",
                 environment_variables={
                     ENV_ADOT_REDACT_SPAN_ATTRIBUTES: "gen_ai.*.content",
-                    ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES: "gen_ai.*.content",
                 },
                 span_attributes={
                     "gen_ai.input.content": "secret input",
@@ -157,12 +172,16 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     "gen_ai.tool.content": REDACTED_VALUE,
                     "gen_ai.tool.name": "lookup",
                 },
+                expected_span_link_attributes={
+                    "gen_ai.input.content": REDACTED_VALUE,
+                    "gen_ai.output.content": REDACTED_VALUE,
+                    "gen_ai.request.model": "model",
+                },
             ),
             RedactionTestData(
                 name="wildcard mixed with explicit names",
                 environment_variables={
                     ENV_ADOT_REDACT_SPAN_ATTRIBUTES: "user.email,http.*",
-                    ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES: "user.email,http.*",
                 },
                 span_attributes={"user.email": "user@example.com", "http.route": "/users", "safe": "value"},
                 event_attributes={
@@ -180,6 +199,11 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     "http.response.body": REDACTED_VALUE,
                     "event.safe": "keep me",
                 },
+                expected_span_link_attributes={
+                    "user.email": REDACTED_VALUE,
+                    "http.route": REDACTED_VALUE,
+                    "safe": "value",
+                },
             ),
         )
 
@@ -193,73 +217,72 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                 name="empty configuration",
                 environment_variables={
                     ENV_ADOT_REDACT_SPAN_ATTRIBUTES: "",
-                    ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES: "",
                 },
                 span_attributes={"user.email": "user@example.com"},
                 event_attributes={"user.email": "event-user@example.com"},
                 expected_span_attributes={"user.email": "user@example.com"},
                 expected_event_attributes={"user.email": "event-user@example.com"},
+                expected_span_link_attributes={"user.email": "user@example.com"},
             ),
             RedactionTestData(
                 name="empty comma-separated entries",
                 environment_variables={
                     ENV_ADOT_REDACT_SPAN_ATTRIBUTES: " , , ",
-                    ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES: " , , ",
                 },
                 span_attributes={"request.body": "secret"},
                 event_attributes={"request.body": "event secret"},
                 expected_span_attributes={"request.body": "secret"},
                 expected_event_attributes={"request.body": "event secret"},
+                expected_span_link_attributes={"request.body": "secret"},
             ),
             RedactionTestData(
                 name="whitespace-only configuration",
                 environment_variables={
                     ENV_ADOT_REDACT_SPAN_ATTRIBUTES: " \t ",
-                    ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES: " \t ",
                 },
                 span_attributes={"db.statement": "SELECT * FROM users"},
                 event_attributes={"db.statement": "DELETE FROM users"},
                 expected_span_attributes={"db.statement": "SELECT * FROM users"},
                 expected_event_attributes={"db.statement": "DELETE FROM users"},
+                expected_span_link_attributes={"db.statement": "SELECT * FROM users"},
             ),
             RedactionTestData(
                 name="unsupported regular expression",
                 environment_variables={
                     ENV_ADOT_REDACT_SPAN_ATTRIBUTES: r"http\.request\..+",
-                    ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES: r"http\.request\..+",
                 },
                 span_attributes={"http.request.method": "POST"},
                 event_attributes={"http.request.body": "secret"},
                 expected_span_attributes={"http.request.method": "POST"},
                 expected_event_attributes={"http.request.body": "secret"},
+                expected_span_link_attributes={"http.request.method": "POST"},
             ),
             RedactionTestData(
                 name="unsupported regular expression anchors",
                 environment_variables={
                     ENV_ADOT_REDACT_SPAN_ATTRIBUTES: "^user.email$",
-                    ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES: "^user.email$",
                 },
                 span_attributes={"user.email": "user@example.com"},
                 event_attributes={"user.email": "event-user@example.com"},
                 expected_span_attributes={"user.email": "user@example.com"},
                 expected_event_attributes={"user.email": "event-user@example.com"},
+                expected_span_link_attributes={"user.email": "user@example.com"},
             ),
             RedactionTestData(
                 name="unsupported regular expression character class",
                 environment_variables={
                     ENV_ADOT_REDACT_SPAN_ATTRIBUTES: "http.request.[a-z]+",
-                    ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES: "http.request.[a-z]+",
                 },
                 span_attributes={"http.request.method": "POST"},
                 event_attributes={"http.request.body": "secret"},
                 expected_span_attributes={"http.request.method": "POST"},
                 expected_event_attributes={"http.request.body": "secret"},
+                expected_span_link_attributes={"http.request.method": "POST"},
             ),
             RedactionTestData(
                 name="unsupported regular expression alternation",
                 environment_variables={
                     ENV_ADOT_REDACT_SPAN_ATTRIBUTES: "user.email|request.body",
-                    ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES: "user.email|request.body",
                 },
                 span_attributes={
                     "user.email": "user@example.com",
@@ -277,39 +300,43 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     "user.email": "event-user@example.com",
                     "request.body": "event secret",
                 },
+                expected_span_link_attributes={
+                    "user.email": "user@example.com",
+                    "request.body": "secret",
+                },
             ),
             RedactionTestData(
                 name="unsupported question mark wildcard",
                 environment_variables={
                     ENV_ADOT_REDACT_SPAN_ATTRIBUTES: "http.request.?",
-                    ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES: "http.request.?",
                 },
                 span_attributes={"http.request.method": "POST"},
                 event_attributes={"http.request.body": "secret"},
                 expected_span_attributes={"http.request.method": "POST"},
                 expected_event_attributes={"http.request.body": "secret"},
+                expected_span_link_attributes={"http.request.method": "POST"},
             ),
             RedactionTestData(
                 name="malformed bracket pattern",
                 environment_variables={
                     ENV_ADOT_REDACT_SPAN_ATTRIBUTES: "http.request.[",
-                    ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES: "http.request.[",
                 },
                 span_attributes={"http.request.method": "POST"},
                 event_attributes={"http.request.body": "secret"},
                 expected_span_attributes={"http.request.method": "POST"},
                 expected_event_attributes={"http.request.body": "secret"},
+                expected_span_link_attributes={"http.request.method": "POST"},
             ),
             RedactionTestData(
                 name="attribute name containing comma",
                 environment_variables={
                     ENV_ADOT_REDACT_SPAN_ATTRIBUTES: "custom,attribute",
-                    ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES: "custom,attribute",
                 },
                 span_attributes={"custom,attribute": "secret"},
                 event_attributes={"custom,attribute": "event secret"},
                 expected_span_attributes={"custom,attribute": "secret"},
                 expected_event_attributes={"custom,attribute": "event secret"},
+                expected_span_link_attributes={"custom,attribute": "secret"},
             ),
         )
 
@@ -324,9 +351,22 @@ class TestAttributeRedactingSpanProcessor(TestCase):
             provider.add_span_processor(AttributeRedactingSpanProcessor())
         provider.add_span_processor(BatchSpanProcessor(exporter))
         tracer = provider.get_tracer(__name__)
+        link = Link(
+            SpanContext(
+                trace_id=1,
+                span_id=1,
+                is_remote=True,
+                trace_flags=TraceFlags(TraceFlags.SAMPLED),
+            ),
+            attributes=test_data.span_attributes,
+        )
 
         try:
-            with tracer.start_as_current_span("test", attributes=test_data.span_attributes) as span:
+            with tracer.start_as_current_span(
+                "test",
+                attributes=test_data.span_attributes,
+                links=[link],
+            ) as span:
                 span.add_event("test.event", attributes=test_data.event_attributes)
 
             self.assertTrue(provider.force_flush())
@@ -334,6 +374,8 @@ class TestAttributeRedactingSpanProcessor(TestCase):
             self.assertEqual(len(finished_spans), 1)
             exported_span = finished_spans[0]
             self.assertEqual(dict(exported_span.attributes), test_data.expected_span_attributes)
+            self.assertEqual(len(exported_span.links), 1)
+            self.assertEqual(dict(exported_span.links[0].attributes), test_data.expected_span_link_attributes)
             self.assertEqual(
                 {event.name: dict(event.attributes) for event in exported_span.events},
                 {"test.event": test_data.expected_event_attributes},

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_attribute_redacting_span_processor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_attribute_redacting_span_processor.py
@@ -23,9 +23,9 @@ class RedactionTestData:
     name: str
     environment_variables: dict[str, str]
     span_attributes: dict[str, AttributeValue]
-    event_attributes: dict[str, AttributeValue]
+    span_event_attributes: dict[str, AttributeValue]
     expected_span_attributes: dict[str, AttributeValue]
-    expected_event_attributes: dict[str, AttributeValue]
+    expected_span_event_attributes: dict[str, AttributeValue]
     expected_span_link_attributes: dict[str, AttributeValue]
 
 
@@ -47,7 +47,7 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     "http.request.method": "POST",
                     "server.address": "example.com",
                 },
-                event_attributes={
+                span_event_attributes={
                     "user.email": "event-user@example.com",
                     "db.statement": "UPDATE users SET password = 'secret'",
                     "gen_ai.prompt": "private event prompt",
@@ -61,7 +61,7 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     "http.request.method": "POST",
                     "server.address": "example.com",
                 },
-                expected_event_attributes={
+                expected_span_event_attributes={
                     "user.email": REDACTED_VALUE,
                     "db.statement": REDACTED_VALUE,
                     "gen_ai.prompt": REDACTED_VALUE,
@@ -82,13 +82,13 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     ENV_ADOT_REDACT_SPAN_ATTRIBUTES: "*",
                 },
                 span_attributes={"first": "secret", "second": 42, "third": True},
-                event_attributes={"event.first": "secret", "event.second": 42},
+                span_event_attributes={"event.first": "secret", "event.second": 42},
                 expected_span_attributes={
                     "first": REDACTED_VALUE,
                     "second": REDACTED_VALUE,
                     "third": REDACTED_VALUE,
                 },
-                expected_event_attributes={
+                expected_span_event_attributes={
                     "event.first": REDACTED_VALUE,
                     "event.second": REDACTED_VALUE,
                 },
@@ -108,7 +108,7 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     "http.response.status_code": 200,
                     "server.address": "example.com",
                 },
-                event_attributes={
+                span_event_attributes={
                     "http.request.header.authorization": "secret",
                     "event.safe": "keep me",
                 },
@@ -117,7 +117,7 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     "http.response.status_code": REDACTED_VALUE,
                     "server.address": "example.com",
                 },
-                expected_event_attributes={
+                expected_span_event_attributes={
                     "http.request.header.authorization": REDACTED_VALUE,
                     "event.safe": "keep me",
                 },
@@ -133,13 +133,13 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     ENV_ADOT_REDACT_SPAN_ATTRIBUTES: "*.body",
                 },
                 span_attributes={"request.body": "secret", "response.body": "secret", "body.size": 42},
-                event_attributes={"message.body": "secret", "message.body.size": 42},
+                span_event_attributes={"message.body": "secret", "message.body.size": 42},
                 expected_span_attributes={
                     "request.body": REDACTED_VALUE,
                     "response.body": REDACTED_VALUE,
                     "body.size": 42,
                 },
-                expected_event_attributes={
+                expected_span_event_attributes={
                     "message.body": REDACTED_VALUE,
                     "message.body.size": 42,
                 },
@@ -159,7 +159,7 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     "gen_ai.output.content": "secret output",
                     "gen_ai.request.model": "model",
                 },
-                event_attributes={
+                span_event_attributes={
                     "gen_ai.tool.content": "secret event",
                     "gen_ai.tool.name": "lookup",
                 },
@@ -168,7 +168,7 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     "gen_ai.output.content": REDACTED_VALUE,
                     "gen_ai.request.model": "model",
                 },
-                expected_event_attributes={
+                expected_span_event_attributes={
                     "gen_ai.tool.content": REDACTED_VALUE,
                     "gen_ai.tool.name": "lookup",
                 },
@@ -184,7 +184,7 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     ENV_ADOT_REDACT_SPAN_ATTRIBUTES: "user.email,http.*",
                 },
                 span_attributes={"user.email": "user@example.com", "http.route": "/users", "safe": "value"},
-                event_attributes={
+                span_event_attributes={
                     "user.email": "event-user@example.com",
                     "http.response.body": "secret",
                     "event.safe": "keep me",
@@ -194,7 +194,7 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     "http.route": REDACTED_VALUE,
                     "safe": "value",
                 },
-                expected_event_attributes={
+                expected_span_event_attributes={
                     "user.email": REDACTED_VALUE,
                     "http.response.body": REDACTED_VALUE,
                     "event.safe": "keep me",
@@ -219,9 +219,9 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     ENV_ADOT_REDACT_SPAN_ATTRIBUTES: "",
                 },
                 span_attributes={"user.email": "user@example.com"},
-                event_attributes={"user.email": "event-user@example.com"},
+                span_event_attributes={"user.email": "event-user@example.com"},
                 expected_span_attributes={"user.email": "user@example.com"},
-                expected_event_attributes={"user.email": "event-user@example.com"},
+                expected_span_event_attributes={"user.email": "event-user@example.com"},
                 expected_span_link_attributes={"user.email": "user@example.com"},
             ),
             RedactionTestData(
@@ -230,9 +230,9 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     ENV_ADOT_REDACT_SPAN_ATTRIBUTES: " , , ",
                 },
                 span_attributes={"request.body": "secret"},
-                event_attributes={"request.body": "event secret"},
+                span_event_attributes={"request.body": "event secret"},
                 expected_span_attributes={"request.body": "secret"},
-                expected_event_attributes={"request.body": "event secret"},
+                expected_span_event_attributes={"request.body": "event secret"},
                 expected_span_link_attributes={"request.body": "secret"},
             ),
             RedactionTestData(
@@ -241,9 +241,9 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     ENV_ADOT_REDACT_SPAN_ATTRIBUTES: " \t ",
                 },
                 span_attributes={"db.statement": "SELECT * FROM users"},
-                event_attributes={"db.statement": "DELETE FROM users"},
+                span_event_attributes={"db.statement": "DELETE FROM users"},
                 expected_span_attributes={"db.statement": "SELECT * FROM users"},
-                expected_event_attributes={"db.statement": "DELETE FROM users"},
+                expected_span_event_attributes={"db.statement": "DELETE FROM users"},
                 expected_span_link_attributes={"db.statement": "SELECT * FROM users"},
             ),
             RedactionTestData(
@@ -252,9 +252,9 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     ENV_ADOT_REDACT_SPAN_ATTRIBUTES: r"http\.request\..+",
                 },
                 span_attributes={"http.request.method": "POST"},
-                event_attributes={"http.request.body": "secret"},
+                span_event_attributes={"http.request.body": "secret"},
                 expected_span_attributes={"http.request.method": "POST"},
-                expected_event_attributes={"http.request.body": "secret"},
+                expected_span_event_attributes={"http.request.body": "secret"},
                 expected_span_link_attributes={"http.request.method": "POST"},
             ),
             RedactionTestData(
@@ -263,9 +263,9 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     ENV_ADOT_REDACT_SPAN_ATTRIBUTES: "^user.email$",
                 },
                 span_attributes={"user.email": "user@example.com"},
-                event_attributes={"user.email": "event-user@example.com"},
+                span_event_attributes={"user.email": "event-user@example.com"},
                 expected_span_attributes={"user.email": "user@example.com"},
-                expected_event_attributes={"user.email": "event-user@example.com"},
+                expected_span_event_attributes={"user.email": "event-user@example.com"},
                 expected_span_link_attributes={"user.email": "user@example.com"},
             ),
             RedactionTestData(
@@ -274,9 +274,9 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     ENV_ADOT_REDACT_SPAN_ATTRIBUTES: "http.request.[a-z]+",
                 },
                 span_attributes={"http.request.method": "POST"},
-                event_attributes={"http.request.body": "secret"},
+                span_event_attributes={"http.request.body": "secret"},
                 expected_span_attributes={"http.request.method": "POST"},
-                expected_event_attributes={"http.request.body": "secret"},
+                expected_span_event_attributes={"http.request.body": "secret"},
                 expected_span_link_attributes={"http.request.method": "POST"},
             ),
             RedactionTestData(
@@ -288,7 +288,7 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     "user.email": "user@example.com",
                     "request.body": "secret",
                 },
-                event_attributes={
+                span_event_attributes={
                     "user.email": "event-user@example.com",
                     "request.body": "event secret",
                 },
@@ -296,7 +296,7 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     "user.email": "user@example.com",
                     "request.body": "secret",
                 },
-                expected_event_attributes={
+                expected_span_event_attributes={
                     "user.email": "event-user@example.com",
                     "request.body": "event secret",
                 },
@@ -311,9 +311,9 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     ENV_ADOT_REDACT_SPAN_ATTRIBUTES: "http.request.?",
                 },
                 span_attributes={"http.request.method": "POST"},
-                event_attributes={"http.request.body": "secret"},
+                span_event_attributes={"http.request.body": "secret"},
                 expected_span_attributes={"http.request.method": "POST"},
-                expected_event_attributes={"http.request.body": "secret"},
+                expected_span_event_attributes={"http.request.body": "secret"},
                 expected_span_link_attributes={"http.request.method": "POST"},
             ),
             RedactionTestData(
@@ -322,9 +322,9 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     ENV_ADOT_REDACT_SPAN_ATTRIBUTES: "http.request.[",
                 },
                 span_attributes={"http.request.method": "POST"},
-                event_attributes={"http.request.body": "secret"},
+                span_event_attributes={"http.request.body": "secret"},
                 expected_span_attributes={"http.request.method": "POST"},
-                expected_event_attributes={"http.request.body": "secret"},
+                expected_span_event_attributes={"http.request.body": "secret"},
                 expected_span_link_attributes={"http.request.method": "POST"},
             ),
             RedactionTestData(
@@ -333,9 +333,9 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     ENV_ADOT_REDACT_SPAN_ATTRIBUTES: "custom,attribute",
                 },
                 span_attributes={"custom,attribute": "secret"},
-                event_attributes={"custom,attribute": "event secret"},
+                span_event_attributes={"custom,attribute": "event secret"},
                 expected_span_attributes={"custom,attribute": "secret"},
-                expected_event_attributes={"custom,attribute": "event secret"},
+                expected_span_event_attributes={"custom,attribute": "event secret"},
                 expected_span_link_attributes={"custom,attribute": "secret"},
             ),
         )
@@ -367,7 +367,7 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                 attributes=test_data.span_attributes,
                 links=[link],
             ) as span:
-                span.add_event("test.event", attributes=test_data.event_attributes)
+                span.add_event("test.event", attributes=test_data.span_event_attributes)
 
             self.assertTrue(provider.force_flush())
             finished_spans = exporter.get_finished_spans()
@@ -378,7 +378,7 @@ class TestAttributeRedactingSpanProcessor(TestCase):
             self.assertEqual(dict(exported_span.links[0].attributes), test_data.expected_span_link_attributes)
             self.assertEqual(
                 {event.name: dict(event.attributes) for event in exported_span.events},
-                {"test.event": test_data.expected_event_attributes},
+                {"test.event": test_data.expected_span_event_attributes},
             )
         finally:
             provider.shutdown()

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_attribute_redacting_span_processor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_attribute_redacting_span_processor.py
@@ -3,10 +3,12 @@
 
 import os
 from dataclasses import dataclass
+from typing import Optional
 from unittest import TestCase
 from unittest.mock import patch
 
 from amazon.opentelemetry.distro.attribute_redacting_span_processor import (
+    ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES,
     ENV_ADOT_REDACT_SPAN_ATTRIBUTES,
     REDACTED_VALUE,
     AttributeRedactingSpanProcessor,
@@ -25,19 +27,21 @@ class RedactionTestData:
     event_attributes: dict[str, AttributeValue]
     expected_span_attributes: dict[str, AttributeValue]
     expected_event_attributes: dict[str, AttributeValue]
+    span_event_environment_value: Optional[str] = None
 
 
 class TestAttributeRedactingSpanProcessor(TestCase):
     def test_should_redact_all_attributes_that_match_configured_patterns(self):
         test_cases = (
             RedactionTestData(
-                name="configured attribute names",
+                name="independent configured attribute names",
                 environment_value=" user.email, request.body, db.statement, gen_ai.prompt, user.email ",
                 span_attributes={
                     "user.email": "user@example.com",
                     "request.body": '{"password":"secret"}',
                     "db.statement": "SELECT * FROM users",
                     "gen_ai.prompt": "private prompt",
+                    "event.secret": "span value",
                     "http.request.method": "POST",
                     "server.address": "example.com",
                 },
@@ -45,6 +49,7 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     "user.email": "event-user@example.com",
                     "db.statement": "UPDATE users SET password = 'secret'",
                     "gen_ai.prompt": "private event prompt",
+                    "event.secret": "event value",
                     "event.safe": "keep me",
                 },
                 expected_span_attributes={
@@ -52,15 +57,18 @@ class TestAttributeRedactingSpanProcessor(TestCase):
                     "request.body": REDACTED_VALUE,
                     "db.statement": REDACTED_VALUE,
                     "gen_ai.prompt": REDACTED_VALUE,
+                    "event.secret": "span value",
                     "http.request.method": "POST",
                     "server.address": "example.com",
                 },
                 expected_event_attributes={
-                    "user.email": REDACTED_VALUE,
+                    "user.email": "event-user@example.com",
                     "db.statement": REDACTED_VALUE,
-                    "gen_ai.prompt": REDACTED_VALUE,
+                    "gen_ai.prompt": "private event prompt",
+                    "event.secret": REDACTED_VALUE,
                     "event.safe": "keep me",
                 },
+                span_event_environment_value=" db.statement, event.secret ",
             ),
             RedactionTestData(
                 name="wildcard only",
@@ -265,9 +273,17 @@ class TestAttributeRedactingSpanProcessor(TestCase):
     def _assert_redaction(self, test_data: RedactionTestData) -> None:
         exporter = InMemorySpanExporter()
         provider = TracerProvider()
+        span_event_environment_value = (
+            test_data.span_event_environment_value
+            if test_data.span_event_environment_value is not None
+            else test_data.environment_value
+        )
         with patch.dict(
             os.environ,
-            {ENV_ADOT_REDACT_SPAN_ATTRIBUTES: test_data.environment_value},
+            {
+                ENV_ADOT_REDACT_SPAN_ATTRIBUTES: test_data.environment_value,
+                ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES: span_event_environment_value,
+            },
         ):
             provider.add_span_processor(AttributeRedactingSpanProcessor())
         provider.add_span_processor(BatchSpanProcessor(exporter))

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_attribute_redacting_span_processor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_attribute_redacting_span_processor.py
@@ -1,0 +1,313 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from dataclasses import dataclass
+from unittest import TestCase
+from unittest.mock import patch
+
+from amazon.opentelemetry.distro.attribute_redacting_span_processor import (
+    ENV_ADOT_REDACT_SPAN_ATTRIBUTES,
+    REDACTED_VALUE,
+    AttributeRedactingSpanProcessor,
+)
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.util.types import AttributeValue
+
+
+@dataclass
+class RedactionTestData:
+    name: str
+    environment_value: str
+    span_attributes: dict[str, AttributeValue]
+    event_attributes: dict[str, AttributeValue]
+    expected_span_attributes: dict[str, AttributeValue]
+    expected_event_attributes: dict[str, AttributeValue]
+
+
+class TestAttributeRedactingSpanProcessor(TestCase):
+    def setUp(self) -> None:
+        self.exporter = InMemorySpanExporter()
+        self.provider = TracerProvider()
+        with patch.dict(os.environ, {ENV_ADOT_REDACT_SPAN_ATTRIBUTES: ""}):
+            self.processor = AttributeRedactingSpanProcessor()
+        self.provider.add_span_processor(self.processor)
+        self.provider.add_span_processor(BatchSpanProcessor(self.exporter))
+        self.tracer = self.provider.get_tracer(__name__)
+
+    def tearDown(self) -> None:
+        self.provider.force_flush()
+        self.provider.shutdown()
+        self.exporter.clear()
+
+    def test_should_redact_all_attributes_that_match_configured_patterns(self):
+        test_cases = (
+            RedactionTestData(
+                name="configured attribute names",
+                environment_value=" user.email, request.body, db.statement, gen_ai.prompt, user.email ",
+                span_attributes={
+                    "user.email": "user@example.com",
+                    "request.body": '{"password":"secret"}',
+                    "db.statement": "SELECT * FROM users",
+                    "gen_ai.prompt": "private prompt",
+                    "http.request.method": "POST",
+                    "server.address": "example.com",
+                },
+                event_attributes={
+                    "user.email": "event-user@example.com",
+                    "db.statement": "UPDATE users SET password = 'secret'",
+                    "gen_ai.prompt": "private event prompt",
+                    "event.safe": "keep me",
+                },
+                expected_span_attributes={
+                    "user.email": REDACTED_VALUE,
+                    "request.body": REDACTED_VALUE,
+                    "db.statement": REDACTED_VALUE,
+                    "gen_ai.prompt": REDACTED_VALUE,
+                    "http.request.method": "POST",
+                    "server.address": "example.com",
+                },
+                expected_event_attributes={
+                    "user.email": REDACTED_VALUE,
+                    "db.statement": REDACTED_VALUE,
+                    "gen_ai.prompt": REDACTED_VALUE,
+                    "event.safe": "keep me",
+                },
+            ),
+            RedactionTestData(
+                name="wildcard only",
+                environment_value="*",
+                span_attributes={"first": "secret", "second": 42, "third": True},
+                event_attributes={"event.first": "secret", "event.second": 42},
+                expected_span_attributes={
+                    "first": REDACTED_VALUE,
+                    "second": REDACTED_VALUE,
+                    "third": REDACTED_VALUE,
+                },
+                expected_event_attributes={
+                    "event.first": REDACTED_VALUE,
+                    "event.second": REDACTED_VALUE,
+                },
+            ),
+            RedactionTestData(
+                name="prefix wildcard",
+                environment_value="http.*",
+                span_attributes={
+                    "http.request.method": "GET",
+                    "http.response.status_code": 200,
+                    "server.address": "example.com",
+                },
+                event_attributes={
+                    "http.request.header.authorization": "secret",
+                    "event.safe": "keep me",
+                },
+                expected_span_attributes={
+                    "http.request.method": REDACTED_VALUE,
+                    "http.response.status_code": REDACTED_VALUE,
+                    "server.address": "example.com",
+                },
+                expected_event_attributes={
+                    "http.request.header.authorization": REDACTED_VALUE,
+                    "event.safe": "keep me",
+                },
+            ),
+            RedactionTestData(
+                name="suffix wildcard",
+                environment_value="*.body",
+                span_attributes={"request.body": "secret", "response.body": "secret", "body.size": 42},
+                event_attributes={"message.body": "secret", "message.body.size": 42},
+                expected_span_attributes={
+                    "request.body": REDACTED_VALUE,
+                    "response.body": REDACTED_VALUE,
+                    "body.size": 42,
+                },
+                expected_event_attributes={
+                    "message.body": REDACTED_VALUE,
+                    "message.body.size": 42,
+                },
+            ),
+            RedactionTestData(
+                name="multiple wildcard segments",
+                environment_value="gen_ai.*.content",
+                span_attributes={
+                    "gen_ai.input.content": "secret input",
+                    "gen_ai.output.content": "secret output",
+                    "gen_ai.request.model": "model",
+                },
+                event_attributes={
+                    "gen_ai.tool.content": "secret event",
+                    "gen_ai.tool.name": "lookup",
+                },
+                expected_span_attributes={
+                    "gen_ai.input.content": REDACTED_VALUE,
+                    "gen_ai.output.content": REDACTED_VALUE,
+                    "gen_ai.request.model": "model",
+                },
+                expected_event_attributes={
+                    "gen_ai.tool.content": REDACTED_VALUE,
+                    "gen_ai.tool.name": "lookup",
+                },
+            ),
+            RedactionTestData(
+                name="wildcard mixed with explicit names",
+                environment_value="user.email,http.*",
+                span_attributes={"user.email": "user@example.com", "http.route": "/users", "safe": "value"},
+                event_attributes={
+                    "user.email": "event-user@example.com",
+                    "http.response.body": "secret",
+                    "event.safe": "keep me",
+                },
+                expected_span_attributes={
+                    "user.email": REDACTED_VALUE,
+                    "http.route": REDACTED_VALUE,
+                    "safe": "value",
+                },
+                expected_event_attributes={
+                    "user.email": REDACTED_VALUE,
+                    "http.response.body": REDACTED_VALUE,
+                    "event.safe": "keep me",
+                },
+            ),
+        )
+
+        for test_data in test_cases:
+            with self.subTest(name=test_data.name), patch.dict(
+                os.environ,
+                {ENV_ADOT_REDACT_SPAN_ATTRIBUTES: test_data.environment_value},
+            ):
+                self.processor.attributes_to_redact = AttributeRedactingSpanProcessor().attributes_to_redact
+                with self.tracer.start_as_current_span("test", attributes=test_data.span_attributes) as span:
+                    span.add_event("test.event", attributes=test_data.event_attributes)
+
+                try:
+                    self.assertTrue(self.provider.force_flush())
+                    finished_spans = self.exporter.get_finished_spans()
+                    self.assertEqual(len(finished_spans), 1)
+                    exported_span = finished_spans[0]
+                    self.assertEqual(dict(exported_span.attributes), test_data.expected_span_attributes)
+                    self.assertEqual(
+                        {event.name: dict(event.attributes) for event in exported_span.events},
+                        {"test.event": test_data.expected_event_attributes},
+                    )
+                finally:
+                    self.exporter.clear()
+
+    def test_should_not_redact_attributes_for_invalid_configured_patterns(self):
+        test_cases = (
+            RedactionTestData(
+                name="empty configuration",
+                environment_value="",
+                span_attributes={"user.email": "user@example.com"},
+                event_attributes={"user.email": "event-user@example.com"},
+                expected_span_attributes={"user.email": "user@example.com"},
+                expected_event_attributes={"user.email": "event-user@example.com"},
+            ),
+            RedactionTestData(
+                name="empty comma-separated entries",
+                environment_value=" , , ",
+                span_attributes={"request.body": "secret"},
+                event_attributes={"request.body": "event secret"},
+                expected_span_attributes={"request.body": "secret"},
+                expected_event_attributes={"request.body": "event secret"},
+            ),
+            RedactionTestData(
+                name="whitespace-only configuration",
+                environment_value=" \t ",
+                span_attributes={"db.statement": "SELECT * FROM users"},
+                event_attributes={"db.statement": "DELETE FROM users"},
+                expected_span_attributes={"db.statement": "SELECT * FROM users"},
+                expected_event_attributes={"db.statement": "DELETE FROM users"},
+            ),
+            RedactionTestData(
+                name="unsupported regular expression",
+                environment_value=r"http\.request\..+",
+                span_attributes={"http.request.method": "POST"},
+                event_attributes={"http.request.body": "secret"},
+                expected_span_attributes={"http.request.method": "POST"},
+                expected_event_attributes={"http.request.body": "secret"},
+            ),
+            RedactionTestData(
+                name="unsupported regular expression anchors",
+                environment_value="^user.email$",
+                span_attributes={"user.email": "user@example.com"},
+                event_attributes={"user.email": "event-user@example.com"},
+                expected_span_attributes={"user.email": "user@example.com"},
+                expected_event_attributes={"user.email": "event-user@example.com"},
+            ),
+            RedactionTestData(
+                name="unsupported regular expression character class",
+                environment_value="http.request.[a-z]+",
+                span_attributes={"http.request.method": "POST"},
+                event_attributes={"http.request.body": "secret"},
+                expected_span_attributes={"http.request.method": "POST"},
+                expected_event_attributes={"http.request.body": "secret"},
+            ),
+            RedactionTestData(
+                name="unsupported regular expression alternation",
+                environment_value="user.email|request.body",
+                span_attributes={
+                    "user.email": "user@example.com",
+                    "request.body": "secret",
+                },
+                event_attributes={
+                    "user.email": "event-user@example.com",
+                    "request.body": "event secret",
+                },
+                expected_span_attributes={
+                    "user.email": "user@example.com",
+                    "request.body": "secret",
+                },
+                expected_event_attributes={
+                    "user.email": "event-user@example.com",
+                    "request.body": "event secret",
+                },
+            ),
+            RedactionTestData(
+                name="unsupported question mark wildcard",
+                environment_value="http.request.?",
+                span_attributes={"http.request.method": "POST"},
+                event_attributes={"http.request.body": "secret"},
+                expected_span_attributes={"http.request.method": "POST"},
+                expected_event_attributes={"http.request.body": "secret"},
+            ),
+            RedactionTestData(
+                name="malformed bracket pattern",
+                environment_value="http.request.[",
+                span_attributes={"http.request.method": "POST"},
+                event_attributes={"http.request.body": "secret"},
+                expected_span_attributes={"http.request.method": "POST"},
+                expected_event_attributes={"http.request.body": "secret"},
+            ),
+            RedactionTestData(
+                name="attribute name containing comma",
+                environment_value="custom,attribute",
+                span_attributes={"custom,attribute": "secret"},
+                event_attributes={"custom,attribute": "event secret"},
+                expected_span_attributes={"custom,attribute": "secret"},
+                expected_event_attributes={"custom,attribute": "event secret"},
+            ),
+        )
+
+        for test_data in test_cases:
+            with self.subTest(name=test_data.name), patch.dict(
+                os.environ,
+                {ENV_ADOT_REDACT_SPAN_ATTRIBUTES: test_data.environment_value},
+            ):
+                self.processor.attributes_to_redact = AttributeRedactingSpanProcessor().attributes_to_redact
+                with self.tracer.start_as_current_span("test", attributes=test_data.span_attributes) as span:
+                    span.add_event("test.event", attributes=test_data.event_attributes)
+
+                try:
+                    self.assertTrue(self.provider.force_flush())
+                    finished_spans = self.exporter.get_finished_spans()
+                    self.assertEqual(len(finished_spans), 1)
+                    exported_span = finished_spans[0]
+                    self.assertEqual(dict(exported_span.attributes), test_data.expected_span_attributes)
+                    self.assertEqual(
+                        {event.name: dict(event.attributes) for event in exported_span.events},
+                        {"test.event": test_data.expected_event_attributes},
+                    )
+                finally:
+                    self.exporter.clear()

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_attribute_redacting_span_processor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_attribute_redacting_span_processor.py
@@ -7,8 +7,8 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from amazon.opentelemetry.distro.attribute_redacting_span_processor import (
-    ENV_ADOT_REDACT_SPAN_ATTRIBUTES,
     ENV_ADOT_REDACT_SPAN_EVENT_ATTRIBUTES,
+    ENV_ADOT_REDACT_SPAN_ATTRIBUTES,
     REDACTED_VALUE,
     AttributeRedactingSpanProcessor,
 )

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py
@@ -13,6 +13,7 @@ from requests import Session
 from amazon.opentelemetry.distro._aws_attribute_keys import AWS_LOCAL_SERVICE, AWS_SERVICE_TYPE
 from amazon.opentelemetry.distro.always_record_sampler import AlwaysRecordSampler
 from amazon.opentelemetry.distro.attribute_propagating_span_processor import AttributePropagatingSpanProcessor
+from amazon.opentelemetry.distro.attribute_redacting_span_processor import AttributeRedactingSpanProcessor
 from amazon.opentelemetry.distro.aws_batch_unsampled_span_processor import BatchUnsampledSpanProcessor
 from amazon.opentelemetry.distro.aws_lambda_span_processor import AwsLambdaSpanProcessor
 from amazon.opentelemetry.distro.aws_metric_attributes_span_exporter import AwsMetricAttributesSpanExporter
@@ -626,7 +627,8 @@ class TestAwsOpenTelemetryConfigurator(TestCase):
 
         processors = [call.args[0] for call in trace_provider.add_span_processor.call_args_list]
         self.assertIsInstance(processors[0], GenAINestedClientSpanProcessor)
-        self.assertIs(processors[1], batch_processor)
+        self.assertIsInstance(processors[1], AttributeRedactingSpanProcessor)
+        self.assertIs(processors[2], batch_processor)
 
         os.environ.pop("AGENT_OBSERVABILITY_ENABLED", None)
         os.environ.pop("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", None)


### PR DESCRIPTION
## Summary

- add an AttributeRedactingSpanProcessor for configured span, span event, and span link attributes
- support exact attribute names and * wildcard patterns through ADOT_REDACT_SPAN_ATTRIBUTES
- register the processor before batch processors so exporters observe redacted values

## Testing

- 68 passed, 16 subtests passed