### PR TITLE
feat(langchain): classify LangGraph StateGraph invocations as agent or workflow spans through the Pregel runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- feat(langchain): classify LangGraph StateGraph invocations as agent or workflow spans through the Pregel runtime
+  ([#888](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/888))
 - fix: stop logging a noisy `Invalid key/value pair (xrsr, None) found.` warning on span creation when no
   X-Ray sampling rule hash is available
   ([#874](https://github.com/aws-observability/aws-otel-python-instrumentation/issues/874))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,7 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
-- feat(langchain): classify LangGraph StateGraph invocations as agent or workflow spans through the Pregel runtime;
-  `otel_workflow_span=True` overrides automatic agent classification, while `otel_agent_span=False` alone does not
-  disable the StateGraph agent fallback
+- feat(langchain): classify LangGraph StateGraph invocations as agent or workflow spans through the Pregel runtime
   ([#888](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/888))
 - fix: stop logging a noisy `Invalid key/value pair (xrsr, None) found.` warning on span creation when no
   X-Ray sampling rule hash is available

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
-- feat(langchain): classify LangGraph StateGraph invocations as agent or workflow spans through the Pregel runtime
+- feat(langchain): classify LangGraph StateGraph invocations as agent or workflow spans through the Pregel runtime;
+  `otel_workflow_span=True` overrides automatic agent classification, while `otel_agent_span=False` alone does not
+  disable the StateGraph agent fallback
   ([#888](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/888))
 - fix: stop logging a noisy `Invalid key/value pair (xrsr, None) found.` warning on span creation when no
   X-Ray sampling rule hash is available

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/langchain/__init__.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/langchain/__init__.py
@@ -28,6 +28,7 @@ class LangChainInstrumentor(BaseInstrumentor):
             _BaseCallbackManagerInitWrapper,
         )
         from amazon.opentelemetry.distro.instrumentation.langchain.span_processor import LangChainSpanProcessor
+        from amazon.opentelemetry.distro.instrumentation.langchain.wrapper import PregelWrapper
 
         tracer_provider = kwargs.get("tracer_provider") or trace.get_tracer_provider()
         tracer = trace.get_tracer(__name__, __version__, tracer_provider=tracer_provider)
@@ -40,9 +41,21 @@ class LangChainInstrumentor(BaseInstrumentor):
             "BaseCallbackManager.__init__",
             _BaseCallbackManagerInitWrapper(OpenTelemetryCallbackHandler(tracer)),
         )
+        try_wrap(
+            "langgraph.pregel",
+            "Pregel.stream",
+            PregelWrapper(),
+        )
+        try_wrap(
+            "langgraph.pregel",
+            "Pregel.astream",
+            PregelWrapper(is_async=True),
+        )
 
     def _uninstrument(self, **kwargs: Any) -> None:  # pylint: disable=no-self-use
         # pylint: disable=import-outside-toplevel
         from langchain_core.callbacks import BaseCallbackManager
 
         try_unwrap(BaseCallbackManager, "__init__")
+        try_unwrap("langgraph.pregel.Pregel", "stream")
+        try_unwrap("langgraph.pregel.Pregel", "astream")

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/langchain/callback_handler.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/langchain/callback_handler.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import logging
 from contextvars import Token
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional
 from uuid import UUID
 
@@ -22,6 +23,7 @@ from amazon.opentelemetry.distro.instrumentation.common.instrumentation_utils im
     to_tool_attribute_value,
     try_detach,
 )
+from amazon.opentelemetry.distro.instrumentation.langchain.wrapper import PregelWrapper
 from opentelemetry import context
 from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
     GEN_AI_AGENT_NAME,
@@ -55,6 +57,7 @@ from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
     GEN_AI_USAGE_INPUT_TOKENS,
     GEN_AI_USAGE_OUTPUT_TOKENS,
     GEN_AI_USAGE_REASONING_OUTPUT_TOKENS,
+    GEN_AI_WORKFLOW_NAME,
     GenAiOperationNameValues,
 )
 from opentelemetry.semconv.attributes.error_attributes import ERROR_TYPE
@@ -71,6 +74,14 @@ _logger = logging.getLogger(__name__)
 
 LANGGRAPH_STEP_SPAN_ATTR = "langgraph.step"
 LANGGRAPH_NODE_SPAN_ATTR = "langgraph.node"
+
+
+@dataclass(frozen=True)
+class _SpanEntry:
+    # Run that created this span, so a skipped child run sharing this entry cannot end it.
+    run_id: UUID
+    span: Span
+    token: Token
 
 
 class _BaseCallbackManagerInitWrapper:
@@ -104,6 +115,8 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
         super().__init__()
         self.tracer = tracer
         self.should_suppress_internal_chains = should_suppress_internal_chains
+        # Every callback run maps directly to its own span entry or the nearest
+        # ancestor span entry when that run is intentionally suppressed.
         self.run_id_to_span_map: DictWithLock = DictWithLock()
 
     @skip_instrumentation_if_suppressed
@@ -182,10 +195,11 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
         self, response: LLMResult, *, run_id: UUID, **kwargs: Any
     ) -> None:
 
-        entry = self._safe_get_span(run_id)
+        entry = self._safe_get_owned_span(run_id)
         if not entry:
+            self._end_span(run_id)
             return
-        span, _ = entry
+        span = entry.span
         llm_output: dict | None = response.llm_output
         model: str | None = (llm_output.get("model_name") or llm_output.get("model_id")) if llm_output else None
         response_id: str | None = llm_output.get("id") if llm_output else None
@@ -299,6 +313,7 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
 
         name: str | None = self._get_name_from_callback(serialized, **kwargs)
         if self._should_skip_chain(serialized, name, metadata):
+            self.run_id_to_span_map.put(run_id, self._safe_get_span(parent_run_id))
             return
 
         # AgentExecutor is the legacy LangChain agent node, lc_agent_name metadata was added in
@@ -306,16 +321,39 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
         # otherwise if no name is given it defaults to "LangGraph".
         # langgraph_node check ensures we only match against agent nodes, not unwanted
         # internal nodes.
-        is_agent_chain: bool = bool(name) and (
-            "AgentExecutor" in name or name == "LangGraph" or name == (metadata or {}).get("lc_agent_name")
+        # Explicit OTel markers take precedence, while Pregel.stream/astream provides
+        # the automatic fallback for raw StateGraph invocations.
+        chain_metadata = metadata or {}
+        pregel_agent_name = PregelWrapper.get_active_agent_name()
+        declared_agent_name = chain_metadata.get("agent_name")
+        lc_agent_name = chain_metadata.get("lc_agent_name")
+        # Does the explicit OTel agent name belong to the graph currently being classified?
+        does_declared_agent_name_apply = bool(declared_agent_name) and (
+            not chain_metadata.get("langgraph_node") or declared_agent_name == name
         )
+        # Does LangChain's native agent name belong to the graph currently being classified?
+        does_lc_agent_name_apply = bool(lc_agent_name) and (
+            not chain_metadata.get("langgraph_node") or lc_agent_name == name
+        )
+        # Is this callback an agent-chain invocation?
+        is_agent_chain = self._is_agent_chain(name, metadata, pregel_agent_name)
+        # Is this callback an explicitly marked workflow-chain invocation?
+        is_workflow_chain = self._is_workflow_chain(name, metadata)
 
         provider: str | None = self._extract_llm_provider(serialized, kwargs)
-        agent_name: str | None = (metadata.get("lc_agent_name") if metadata else None) or (
-            name if is_agent_chain else None
+        agent_name: str | None = (
+            (declared_agent_name if does_declared_agent_name_apply else None)
+            or (lc_agent_name if does_lc_agent_name_apply else None)
+            or (pregel_agent_name if name == pregel_agent_name else None)
+            or (name if is_agent_chain else None)
         )
-        operation: str = GenAiOperationNameValues.INVOKE_AGENT.value if is_agent_chain else "chain"
-        span_name: str = f"{operation} {name}" if name else operation
+        operation: str = (
+            GenAiOperationNameValues.INVOKE_AGENT.value
+            if is_agent_chain
+            else GenAiOperationNameValues.INVOKE_WORKFLOW.value if is_workflow_chain else "chain"
+        )
+        operation_target = agent_name if is_agent_chain else name
+        span_name: str = f"{operation} {operation_target}" if operation_target else operation
 
         span: Span = self._start_span(run_id, parent_run_id, span_name)
 
@@ -323,6 +361,11 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
         self._set_span_attribute(span, GEN_AI_PROVIDER_NAME, provider)
         if is_agent_chain:
             self._set_span_attribute(span, GEN_AI_OPERATION_NAME, GenAiOperationNameValues.INVOKE_AGENT.value)
+        if is_workflow_chain:
+            self._set_span_attribute(span, GEN_AI_OPERATION_NAME, GenAiOperationNameValues.INVOKE_WORKFLOW.value)
+            self._set_span_attribute(span, GEN_AI_WORKFLOW_NAME, name)
+
+        if is_agent_chain or is_workflow_chain:
             payload = inputs.get("messages") or inputs.get("input") if isinstance(inputs, dict) else None
             if payload:
                 _, conversation = self._format_lc_messages(
@@ -334,17 +377,27 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
 
     @skip_instrumentation_if_suppressed
     def on_chain_end(self, outputs: dict[str, Any], *, run_id: UUID, **kwargs: Any) -> None:
-        entry = self._safe_get_span(run_id)
-        if entry:
-            span, _ = entry
-            payload = outputs.get("messages") or outputs.get("output") if isinstance(outputs, dict) else None
-            if payload and GenAiOperationNameValues.INVOKE_AGENT.value in getattr(span, "name", ""):
-                messages = convert_to_messages([payload] if isinstance(payload, str) else payload)
-                _, conversation = self._format_lc_messages([messages])
-                if conversation:
-                    finish_reason = self._extract_finish_reason(messages[-1]) if messages else "stop"
-                    message = {**conversation[-1], "role": "assistant", "finish_reason": finish_reason}
-                    self._set_span_attribute(span, GEN_AI_OUTPUT_MESSAGES, serialize_to_json_string([message]))
+        entry = self._safe_get_owned_span(run_id)
+        if not entry:
+            self._end_span(run_id)
+            return
+
+        span = entry.span
+        payload = outputs.get("messages") or outputs.get("output") if isinstance(outputs, dict) else None
+        is_agent_or_workflow_span = any(
+            operation in getattr(span, "name", "")
+            for operation in (
+                GenAiOperationNameValues.INVOKE_AGENT.value,
+                GenAiOperationNameValues.INVOKE_WORKFLOW.value,
+            )
+        )
+        if payload and is_agent_or_workflow_span:
+            messages = convert_to_messages([payload] if isinstance(payload, str) else payload)
+            _, conversation = self._format_lc_messages([messages])
+            if conversation:
+                finish_reason = self._extract_finish_reason(messages[-1]) if messages else "stop"
+                message = {**conversation[-1], "role": "assistant", "finish_reason": finish_reason}
+                self._set_span_attribute(span, GEN_AI_OUTPUT_MESSAGES, serialize_to_json_string([message]))
         self._end_span(run_id)
 
     def on_chain_error(self, error: BaseException, *, run_id: UUID, **kwargs: Any) -> None:
@@ -388,10 +441,11 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
     @skip_instrumentation_if_suppressed
     def on_tool_end(self, output: Any, *, run_id: UUID, **kwargs: Any) -> None:
 
-        entry = self._safe_get_span(run_id)
+        entry = self._safe_get_owned_span(run_id)
         if not entry:
+            self._end_span(run_id)
             return
-        span, _ = entry
+        span = entry.span
         self._set_span_attribute(span, GEN_AI_TOOL_CALL_RESULT, to_tool_attribute_value(output))
         self._end_span(run_id)
 
@@ -787,20 +841,76 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
         # We suppress internal nodes that have langgraph metadata, except for nodes that
         # contain the agent name metadata as those are used for invoke_agent spans.
         if metadata and any(k.startswith("langgraph_") for k in metadata):
+            # Is this chain recognized by the original LangGraph agent fallback?
             is_agent = "lc_agent_name" in metadata or (name and ("LangGraph" == name or "AgentExecutor" in name))
-            return not is_agent
+            if is_agent:
+                return False
+
+            pregel_agent_name = PregelWrapper.get_active_agent_name()
+            return not (
+                self._is_agent_chain(name, metadata, pregel_agent_name) or self._is_workflow_chain(name, metadata)
+            )
         return False
+
+    @staticmethod
+    def _is_agent_chain(
+        name: Optional[str],
+        metadata: Optional[dict] = None,
+        pregel_agent_name: Optional[str] = None,
+    ) -> bool:
+        chain_metadata = metadata or {}
+        declared_agent_name = chain_metadata.get("agent_name")
+        # Does the explicit metadata belong to this graph rather than an enclosing graph?
+        does_marker_apply_to_current_graph = not chain_metadata.get("langgraph_node") or bool(
+            name and declared_agent_name == name
+        )
+        # Does this graph explicitly declare agent semantics through OTel metadata?
+        is_explicit_agent = does_marker_apply_to_current_graph and bool(
+            chain_metadata.get("otel_agent_span") is True or declared_agent_name or chain_metadata.get("agent_type")
+        )
+        # Does this graph explicitly declare workflow semantics through OTel metadata?
+        is_explicit_workflow = does_marker_apply_to_current_graph and chain_metadata.get("otel_workflow_span") is True
+        # Did this graph explicitly opt out of agent-span classification?
+        did_agent_opt_out = (
+            does_marker_apply_to_current_graph
+            and chain_metadata.get("otel_agent_span") is False
+            and not is_explicit_agent
+        )
+        # Is this chain recognized as an agent by existing LangChain naming metadata?
+        is_framework_agent = bool(name) and (
+            "AgentExecutor" in name or name == "LangGraph" or name == chain_metadata.get("lc_agent_name")
+        )
+        active_pregel_agent_name = pregel_agent_name or PregelWrapper.get_active_agent_name()
+        # Is this callback the active raw graph identified by the Pregel wrapper?
+        is_active_pregel_agent = bool(name) and name == active_pregel_agent_name
+        return is_explicit_agent or (
+            not is_explicit_workflow and not did_agent_opt_out and (is_framework_agent or is_active_pregel_agent)
+        )
+
+    @staticmethod
+    def _is_workflow_chain(name: Optional[str], metadata: Optional[dict] = None) -> bool:
+        chain_metadata = metadata or {}
+        declared_agent_name = chain_metadata.get("agent_name")
+        # Does the explicit metadata belong to this graph rather than an enclosing graph?
+        does_marker_apply_to_current_graph = not chain_metadata.get("langgraph_node") or bool(
+            name and declared_agent_name == name
+        )
+        # Does this graph explicitly declare agent semantics through OTel metadata?
+        is_explicit_agent = does_marker_apply_to_current_graph and bool(
+            chain_metadata.get("otel_agent_span") is True or declared_agent_name or chain_metadata.get("agent_type")
+        )
+        # Does this graph explicitly declare workflow semantics through OTel metadata?
+        is_explicit_workflow = does_marker_apply_to_current_graph and chain_metadata.get("otel_workflow_span") is True
+        return is_explicit_workflow and not is_explicit_agent
 
     @skip_instrumentation_if_suppressed
     def _handle_error(self, error: BaseException, run_id: UUID, **kwargs: Any) -> None:
 
-        entry = self._safe_get_span(run_id)
-        if not entry:
-            return
-        span, _ = entry
-        span.record_exception(error)
-        span.set_status(Status(StatusCode.ERROR, str(error)))
-        span.set_attribute(ERROR_TYPE, type(error).__qualname__)
+        entry = self._safe_get_owned_span(run_id)
+        if entry:
+            entry.span.record_exception(error)
+            entry.span.set_status(Status(StatusCode.ERROR, str(error)))
+            entry.span.set_attribute(ERROR_TYPE, type(error).__qualname__)
         self._end_span(run_id)
 
     def _start_span(
@@ -810,24 +920,22 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
         span_name: str,
         kind: SpanKind = SpanKind.INTERNAL,
     ) -> Span:
-        parent_entry = self.run_id_to_span_map.get(parent_run_id) if parent_run_id else None
+        parent_entry = self._safe_get_span(parent_run_id)
         if parent_entry:
-            parent_span, _ = parent_entry
-            span = self.tracer.start_span(span_name, context=set_span_in_context(parent_span), kind=kind)
+            span = self.tracer.start_span(span_name, context=set_span_in_context(parent_entry.span), kind=kind)
         else:
             span = self.tracer.start_span(span_name, kind=kind)
 
         token = context.attach(set_span_in_context(span))
-        self.run_id_to_span_map.put(run_id, (span, token))
+        self.run_id_to_span_map.put(run_id, _SpanEntry(run_id=run_id, span=span, token=token))
         return span
 
     def _end_span(self, run_id: UUID) -> None:
         entry = self.run_id_to_span_map.pop(run_id)
-        if not entry:
+        if not entry or entry.run_id != run_id:
             return
-        span, token = entry
-        try_detach(token)
-        span.end()
+        try_detach(entry.token)
+        entry.span.end()
 
     @staticmethod
     def _get_name_from_callback(serialized: dict[str, Any], **kwargs: Any) -> Optional[str]:
@@ -890,8 +998,12 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
 
         return None
 
-    def _safe_get_span(self, run_id: UUID) -> Optional[tuple[Span, Token]]:
+    def _safe_get_span(self, run_id: Optional[UUID]) -> Optional[_SpanEntry]:
         return self.run_id_to_span_map.get(run_id)
+
+    def _safe_get_owned_span(self, run_id: UUID) -> Optional[_SpanEntry]:
+        entry = self._safe_get_span(run_id)
+        return entry if entry and entry.run_id == run_id else None
 
     @staticmethod
     def _set_span_attribute(span: Span, name: str, value: Optional[AttributeValue]):

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/langchain/callback_handler.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/langchain/callback_handler.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import logging
 from contextvars import Token
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Literal, Optional
 from uuid import UUID
 
 from langchain_core.callbacks import BaseCallbackHandler
@@ -329,24 +329,25 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
         declared_agent_name = chain_metadata.get("agent_name")
         lc_agent_name = chain_metadata.get("lc_agent_name")
         # Does the explicit OTel agent name belong to the graph currently being classified?
-        does_declared_agent_name_apply = bool(declared_agent_name) and (
-            not chain_metadata.get("langgraph_node") or declared_agent_name == name
+        does_declared_agent_name_apply = self._does_metadata_name_apply_to_current_graph(
+            name, declared_agent_name, chain_metadata
         )
         # Does LangChain's native agent name belong to the graph currently being classified?
-        does_lc_agent_name_apply = bool(lc_agent_name) and (
-            not chain_metadata.get("langgraph_node") or lc_agent_name == name
-        )
-        # Is this callback an agent-chain invocation?
-        is_agent_chain = self._is_agent_chain(name, metadata, pregel_agent_name)
-        # Is this callback an explicitly marked workflow-chain invocation?
-        is_workflow_chain = self._is_workflow_chain(name, metadata)
+        does_lc_agent_name_apply = self._does_metadata_name_apply_to_current_graph(name, lc_agent_name, chain_metadata)
+        chain_type = self._classify_chain(name, metadata)
+        is_agent_chain = chain_type == "agent"
+        is_workflow_chain = chain_type == "workflow"
 
         provider: str | None = self._extract_llm_provider(serialized, kwargs)
         agent_name: str | None = (
-            (declared_agent_name if does_declared_agent_name_apply else None)
-            or (lc_agent_name if does_lc_agent_name_apply else None)
-            or (pregel_agent_name if name == pregel_agent_name else None)
-            or (name if is_agent_chain else None)
+            (
+                (declared_agent_name if does_declared_agent_name_apply else None)
+                or (lc_agent_name if does_lc_agent_name_apply else None)
+                or (pregel_agent_name if name == pregel_agent_name else None)
+                or name
+            )
+            if is_agent_chain
+            else None
         )
         operation: str = (
             GenAiOperationNameValues.INVOKE_AGENT.value
@@ -847,57 +848,60 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
             if is_agent:
                 return False
 
-            pregel_agent_name = PregelWrapper.get_active_agent_name()
-            return not (
-                self._is_agent_chain(name, metadata, pregel_agent_name) or self._is_workflow_chain(name, metadata)
-            )
+            return self._classify_chain(name, metadata) == "chain"
         return False
 
-    @staticmethod
-    def _is_agent_chain(
-        name: Optional[str],
-        metadata: Optional[dict] = None,
-        pregel_agent_name: Optional[str] = None,
-    ) -> bool:
+    @classmethod
+    def _is_agent_chain(cls, name: Optional[str], metadata: Optional[dict] = None) -> bool:
+        """Return whether this chain callback should emit an invoke_agent span."""
+        return cls._classify_chain(name, metadata) == "agent"
+
+    @classmethod
+    def _is_workflow_chain(cls, name: Optional[str], metadata: Optional[dict] = None) -> bool:
+        """Return whether this chain callback should emit an invoke_workflow span."""
+        return cls._classify_chain(name, metadata) == "workflow"
+
+    @classmethod
+    def _classify_chain(
+        cls, name: Optional[str], metadata: Optional[dict] = None
+    ) -> Literal["agent", "workflow", "chain"]:
+        """Determine whether this is an agent chain or a workflow chain."""
         chain_metadata = metadata or {}
         declared_agent_name = chain_metadata.get("agent_name")
         # Do the OTel marker fields belong to this graph rather than an enclosing graph?
         is_otel_marker_for_current_graph = not chain_metadata.get("langgraph_node") or bool(
-            name and declared_agent_name == name
-        )
-        # Does this graph have an OTel agent marker?
-        has_otel_agent_marker = is_otel_marker_for_current_graph and bool(
-            chain_metadata.get("otel_agent_span") is True or declared_agent_name or chain_metadata.get("agent_type")
+            cls._does_metadata_name_apply_to_current_graph(name, declared_agent_name, chain_metadata)
         )
         # Does this graph have the OTel workflow marker?
         has_otel_workflow_marker = is_otel_marker_for_current_graph and chain_metadata.get("otel_workflow_span") is True
+        # Does this graph have an OTel agent marker?
+        has_otel_agent_marker = is_otel_marker_for_current_graph and bool(
+            chain_metadata.get("otel_agent_span") is True
+            or (not has_otel_workflow_marker and (declared_agent_name or chain_metadata.get("agent_type")))
+        )
         # Does this callback use legacy AgentExecutor naming?
         is_legacy_agent_executor = bool(name) and "AgentExecutor" in name
         # Does this callback use naming emitted by LangChain create_agent?
         is_langchain_create_agent = bool(name) and (name == "LangGraph" or name == chain_metadata.get("lc_agent_name"))
-        active_pregel_agent_name = pregel_agent_name or PregelWrapper.get_active_agent_name()
         # Does this callback name match the StateGraph currently running through Pregel?
-        is_pregel_stategraph = bool(name) and name == active_pregel_agent_name
-        return has_otel_agent_marker or (
+        is_pregel_stategraph = bool(name) and name == PregelWrapper.get_active_agent_name()
+        is_agent_chain = has_otel_agent_marker or (
             not has_otel_workflow_marker
             and (is_legacy_agent_executor or is_langchain_create_agent or is_pregel_stategraph)
         )
+        is_workflow_chain = has_otel_workflow_marker and not has_otel_agent_marker
+        if is_agent_chain:
+            return "agent"
+        if is_workflow_chain:
+            return "workflow"
+        return "chain"
 
     @staticmethod
-    def _is_workflow_chain(name: Optional[str], metadata: Optional[dict] = None) -> bool:
-        chain_metadata = metadata or {}
-        declared_agent_name = chain_metadata.get("agent_name")
-        # Do the OTel marker fields belong to this graph rather than an enclosing graph?
-        is_otel_marker_for_current_graph = not chain_metadata.get("langgraph_node") or bool(
-            name and declared_agent_name == name
-        )
-        # Does this graph have an OTel agent marker?
-        has_otel_agent_marker = is_otel_marker_for_current_graph and bool(
-            chain_metadata.get("otel_agent_span") is True or declared_agent_name or chain_metadata.get("agent_type")
-        )
-        # Does this graph have the OTel workflow marker?
-        has_otel_workflow_marker = is_otel_marker_for_current_graph and chain_metadata.get("otel_workflow_span") is True
-        return has_otel_workflow_marker and not has_otel_agent_marker
+    def _does_metadata_name_apply_to_current_graph(
+        name: Optional[str], metadata_name: Any, metadata: dict[str, Any]
+    ) -> bool:
+        """Return whether a metadata name identifies this graph rather than an enclosing graph."""
+        return bool(metadata_name) and (not metadata.get("langgraph_node") or metadata_name == name)
 
     @skip_instrumentation_if_suppressed
     def _handle_error(self, error: BaseException, run_id: UUID, **kwargs: Any) -> None:
@@ -995,9 +999,11 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
         return None
 
     def _safe_get_span(self, run_id: Optional[UUID]) -> Optional[_SpanEntry]:
+        """Return the span entry mapped to a run, including entries inherited by skipped runs."""
         return self.run_id_to_span_map.get(run_id)
 
     def _safe_get_owned_span(self, run_id: UUID) -> Optional[_SpanEntry]:
+        """Return a span only when this run created it, so skipped children cannot end ancestor spans."""
         entry = self._safe_get_span(run_id)
         return entry if entry and entry.run_id == run_id else None
 

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/langchain/callback_handler.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/langchain/callback_handler.py
@@ -1,5 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+# pylint: disable=too-many-lines
 
 from __future__ import annotations
 

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/langchain/callback_handler.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/langchain/callback_handler.py
@@ -861,48 +861,43 @@ class OpenTelemetryCallbackHandler(BaseCallbackHandler):
     ) -> bool:
         chain_metadata = metadata or {}
         declared_agent_name = chain_metadata.get("agent_name")
-        # Does the explicit metadata belong to this graph rather than an enclosing graph?
-        does_marker_apply_to_current_graph = not chain_metadata.get("langgraph_node") or bool(
+        # Do the OTel marker fields belong to this graph rather than an enclosing graph?
+        is_otel_marker_for_current_graph = not chain_metadata.get("langgraph_node") or bool(
             name and declared_agent_name == name
         )
-        # Does this graph explicitly declare agent semantics through OTel metadata?
-        is_explicit_agent = does_marker_apply_to_current_graph and bool(
+        # Does this graph have an OTel agent marker?
+        has_otel_agent_marker = is_otel_marker_for_current_graph and bool(
             chain_metadata.get("otel_agent_span") is True or declared_agent_name or chain_metadata.get("agent_type")
         )
-        # Does this graph explicitly declare workflow semantics through OTel metadata?
-        is_explicit_workflow = does_marker_apply_to_current_graph and chain_metadata.get("otel_workflow_span") is True
-        # Did this graph explicitly opt out of agent-span classification?
-        did_agent_opt_out = (
-            does_marker_apply_to_current_graph
-            and chain_metadata.get("otel_agent_span") is False
-            and not is_explicit_agent
-        )
-        # Is this chain recognized as an agent by existing LangChain naming metadata?
-        is_framework_agent = bool(name) and (
-            "AgentExecutor" in name or name == "LangGraph" or name == chain_metadata.get("lc_agent_name")
-        )
+        # Does this graph have the OTel workflow marker?
+        has_otel_workflow_marker = is_otel_marker_for_current_graph and chain_metadata.get("otel_workflow_span") is True
+        # Does this callback use legacy AgentExecutor naming?
+        is_legacy_agent_executor = bool(name) and "AgentExecutor" in name
+        # Does this callback use naming emitted by LangChain create_agent?
+        is_langchain_create_agent = bool(name) and (name == "LangGraph" or name == chain_metadata.get("lc_agent_name"))
         active_pregel_agent_name = pregel_agent_name or PregelWrapper.get_active_agent_name()
-        # Is this callback the active raw graph identified by the Pregel wrapper?
-        is_active_pregel_agent = bool(name) and name == active_pregel_agent_name
-        return is_explicit_agent or (
-            not is_explicit_workflow and not did_agent_opt_out and (is_framework_agent or is_active_pregel_agent)
+        # Does this callback name match the StateGraph currently running through Pregel?
+        is_pregel_stategraph = bool(name) and name == active_pregel_agent_name
+        return has_otel_agent_marker or (
+            not has_otel_workflow_marker
+            and (is_legacy_agent_executor or is_langchain_create_agent or is_pregel_stategraph)
         )
 
     @staticmethod
     def _is_workflow_chain(name: Optional[str], metadata: Optional[dict] = None) -> bool:
         chain_metadata = metadata or {}
         declared_agent_name = chain_metadata.get("agent_name")
-        # Does the explicit metadata belong to this graph rather than an enclosing graph?
-        does_marker_apply_to_current_graph = not chain_metadata.get("langgraph_node") or bool(
+        # Do the OTel marker fields belong to this graph rather than an enclosing graph?
+        is_otel_marker_for_current_graph = not chain_metadata.get("langgraph_node") or bool(
             name and declared_agent_name == name
         )
-        # Does this graph explicitly declare agent semantics through OTel metadata?
-        is_explicit_agent = does_marker_apply_to_current_graph and bool(
+        # Does this graph have an OTel agent marker?
+        has_otel_agent_marker = is_otel_marker_for_current_graph and bool(
             chain_metadata.get("otel_agent_span") is True or declared_agent_name or chain_metadata.get("agent_type")
         )
-        # Does this graph explicitly declare workflow semantics through OTel metadata?
-        is_explicit_workflow = does_marker_apply_to_current_graph and chain_metadata.get("otel_workflow_span") is True
-        return is_explicit_workflow and not is_explicit_agent
+        # Does this graph have the OTel workflow marker?
+        has_otel_workflow_marker = is_otel_marker_for_current_graph and chain_metadata.get("otel_workflow_span") is True
+        return has_otel_workflow_marker and not has_otel_agent_marker
 
     @skip_instrumentation_if_suppressed
     def _handle_error(self, error: BaseException, run_id: UUID, **kwargs: Any) -> None:

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/langchain/wrapper.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/langchain/wrapper.py
@@ -1,0 +1,81 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+from typing import Any, Optional
+
+from opentelemetry import context
+
+
+class PregelWrapper:
+    """Wrap LangGraph's Pregel runtime so agents built with StateGraph can be classified as agent spans.
+
+    https://docs.langchain.com/oss/python/langgraph/graph-api
+    """
+
+    _CONTEXT_KEY = "amazon.langchain.langgraph.pregel.agent_name"
+
+    def __init__(self, is_async: bool = False):
+        self.is_async = is_async
+
+    def __call__(self, wrapped, instance, args, kwargs):
+        graph_name = self._get_graph_name(instance, args, kwargs)
+        if self.is_async:
+            iterator = wrapped(*args, **kwargs).__aiter__()
+            return self._aiterate_with_graph_context(iterator, graph_name)
+
+        iterator = iter(wrapped(*args, **kwargs))
+        return self._iterate_with_graph_context(iterator, graph_name)
+
+    @classmethod
+    def get_active_agent_name(cls) -> Optional[str]:
+        """Return the name of the LangGraph currently executing through Pregel."""
+        value = context.get_value(cls._CONTEXT_KEY)
+        return value if isinstance(value, str) else None
+
+    @staticmethod
+    def _get_graph_name(instance: Any, args: tuple[Any, ...], kwargs: dict[str, Any]) -> str:
+        """Resolve the graph name using the same precedence as LangGraph."""
+        config = args[1] if len(args) > 1 else kwargs.get("config")
+        if isinstance(config, dict) and (run_name := config.get("run_name")):
+            return str(run_name)
+
+        instance_config = getattr(instance, "config", None)
+        if isinstance(instance_config, dict) and (run_name := instance_config.get("run_name")):
+            return str(run_name)
+
+        get_name = getattr(instance, "get_name", None)
+        if callable(get_name):
+            try:
+                if graph_name := get_name():
+                    return str(graph_name)
+            except Exception:  # pylint: disable=broad-except
+                pass
+
+        return "LangGraph"
+
+    @classmethod
+    def _iterate_with_graph_context(cls, iterator: Iterator[Any], graph_name: str) -> Iterator[Any]:
+        while True:
+            token = context.attach(context.set_value(cls._CONTEXT_KEY, graph_name))
+            try:
+                item = next(iterator)
+            except StopIteration:
+                return
+            finally:
+                context.detach(token)
+            yield item
+
+    @classmethod
+    async def _aiterate_with_graph_context(cls, iterator: AsyncIterator[Any], graph_name: str) -> AsyncIterator[Any]:
+        while True:
+            token = context.attach(context.set_value(cls._CONTEXT_KEY, graph_name))
+            try:
+                item = await anext(iterator)
+            except StopAsyncIteration:
+                return
+            finally:
+                context.detach(token)
+            yield item

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/langchain/wrapper.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/langchain/wrapper.py
@@ -18,9 +18,11 @@ class PregelWrapper:
     _CONTEXT_KEY = "amazon.langchain.langgraph.pregel.agent_name"
 
     def __init__(self, is_async: bool = False):
+        """Create a wrapper for either Pregel.stream or Pregel.astream."""
         self.is_async = is_async
 
     def __call__(self, wrapped, instance, args, kwargs):
+        """Return the original Pregel iterator with graph identity scoped to each iteration."""
         graph_name = self._get_graph_name(instance, args, kwargs)
         if self.is_async:
             iterator = wrapped(*args, **kwargs).__aiter__()
@@ -52,30 +54,53 @@ class PregelWrapper:
                 if graph_name := get_name():
                     return str(graph_name)
             except Exception:  # pylint: disable=broad-except
+                # Agent detection is best effort and must not break graph execution if name resolution fails.
                 pass
 
         return "LangGraph"
 
     @classmethod
     def _iterate_with_graph_context(cls, iterator: Iterator[Any], graph_name: str) -> Iterator[Any]:
-        while True:
-            token = context.attach(context.set_value(cls._CONTEXT_KEY, graph_name))
-            try:
-                item = next(iterator)
-            except StopIteration:
-                return
-            finally:
-                context.detach(token)
-            yield item
+        """Advance a sync iterator without exposing the Pregel context to its consumer."""
+        try:
+            while True:
+                token = context.attach(context.set_value(cls._CONTEXT_KEY, graph_name))
+                try:
+                    item = next(iterator)
+                except StopIteration as exception:
+                    return exception.value
+                finally:
+                    context.detach(token)
+                yield item
+        except GeneratorExit:
+            close = getattr(iterator, "close", None)
+            if callable(close):
+                token = context.attach(context.set_value(cls._CONTEXT_KEY, graph_name))
+                try:
+                    close()
+                finally:
+                    context.detach(token)
+            raise
 
     @classmethod
     async def _aiterate_with_graph_context(cls, iterator: AsyncIterator[Any], graph_name: str) -> AsyncIterator[Any]:
-        while True:
-            token = context.attach(context.set_value(cls._CONTEXT_KEY, graph_name))
-            try:
-                item = await anext(iterator)
-            except StopAsyncIteration:
-                return
-            finally:
-                context.detach(token)
-            yield item
+        """Advance an async iterator without exposing the Pregel context to its consumer."""
+        try:
+            while True:
+                token = context.attach(context.set_value(cls._CONTEXT_KEY, graph_name))
+                try:
+                    item = await anext(iterator)
+                except StopAsyncIteration:
+                    return
+                finally:
+                    context.detach(token)
+                yield item
+        except GeneratorExit:
+            aclose = getattr(iterator, "aclose", None)
+            if callable(aclose):
+                token = context.attach(context.set_value(cls._CONTEXT_KEY, graph_name))
+                try:
+                    await aclose()
+                finally:
+                    context.detach(token)
+            raise

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/conftest.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/conftest.py
@@ -277,5 +277,9 @@ def call_mock_llm(
             "metrics": {"latencyMs": 1},
         }
         with Stubber(client) as stubber:
-            stubber.add_response("converse", response)
+            if responses is None:
+                stubber.add_response("converse", response)
+            else:
+                for stubbed_response in responses:
+                    stubber.add_response("converse", stubbed_response)
             invoke_llm_callback(client)

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/langchain/test_langchain_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/langchain/test_langchain_instrumentor.py
@@ -368,7 +368,7 @@ class TestLangChainInstrumentor(TestCase):
         self.assertIn(GEN_AI_OUTPUT_MESSAGES, workflow_spans[0].attributes)
         self.assertFalse(any(span.name == "invoke_agent ExplicitStateGraphWorkflow" for span in spans))
 
-    def test_skipped_chains_parent_model_span_to_nearest_ancestor_e2e(self):
+    def test_skipped_chains_parent_model_span_to_nearest_ancestor(self):
         try:
             from langchain_aws import ChatBedrockConverse
             from langgraph.graph import END, START, MessagesState, StateGraph
@@ -401,6 +401,181 @@ class TestLangChainInstrumentor(TestCase):
         )
         self.assertEqual(chat_span.context.trace_id, agent_span.context.trace_id)
         self.assertEqual(chat_span.parent.span_id, agent_span.context.span_id)
+        self.assertFalse(any("Runnable" in span.name for span in spans))
+
+    def test_stategraph_with_create_agents_and_nested_stategraph_preserves_agent_hierarchy(self):
+        try:
+            from langchain_aws import ChatBedrockConverse
+            from langgraph.graph import END, START, MessagesState, StateGraph
+        except ImportError:
+            self.skipTest("langgraph or langchain-aws is not available")
+        if not create_agent:
+            self.skipTest("langchain create_agent is not available")
+
+        @tool
+        def search_knowledge_base(query: str) -> str:
+            """Search the internal knowledge base."""
+            return f"Found research for: {query}"
+
+        @tool
+        def check_draft(draft: str) -> str:
+            """Check a draft for correctness."""
+            return f"Draft approved: {draft}"
+
+        def text_response(text: str) -> dict:
+            return {
+                "output": {"message": {"role": "assistant", "content": [{"text": text}]}},
+                "stopReason": "end_turn",
+                "usage": {"inputTokens": 10, "outputTokens": 20, "totalTokens": 30},
+                "metrics": {"latencyMs": 1},
+            }
+
+        def tool_response(tool_use_id: str, tool_name: str, tool_input: dict) -> dict:
+            return {
+                "output": {
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "toolUse": {
+                                    "toolUseId": tool_use_id,
+                                    "name": tool_name,
+                                    "input": tool_input,
+                                }
+                            }
+                        ],
+                    }
+                },
+                "stopReason": "tool_use",
+                "usage": {"inputTokens": 10, "outputTokens": 5, "totalTokens": 15},
+                "metrics": {"latencyMs": 1},
+            }
+
+        def invoke_graph(client):
+            llm = ChatBedrockConverse(model="anthropic.claude-fable-5", client=client)
+            research_agent = create_agent(llm, tools=[search_knowledge_base], name="ResearchCreateAgent")
+            writer_agent = create_agent(llm, tools=[], name="WriterCreateAgent")
+            review_agent = create_agent(llm, tools=[check_draft], name="ReviewCreateAgent")
+
+            synthesis_builder = StateGraph(MessagesState)
+            synthesis_builder.add_node(
+                "synthesize",
+                lambda _: {"messages": [AIMessage(content="StateGraph synthesis complete.")]},
+            )
+            synthesis_builder.add_edge(START, "synthesize")
+            synthesis_builder.add_edge("synthesize", END)
+            nested_synthesis_graph = synthesis_builder.compile(name="NestedSynthesisStateGraph")
+
+            supervisor_builder = StateGraph(MessagesState)
+            supervisor_builder.add_node(
+                "prepare",
+                RunnableLambda(lambda _: {"messages": [HumanMessage(content="Prepared for the nested agent.")]}),
+            )
+            supervisor_builder.add_node("research_agent", research_agent)
+            supervisor_builder.add_node("nested_synthesis_graph", nested_synthesis_graph)
+            supervisor_builder.add_node("writer_agent", writer_agent)
+            supervisor_builder.add_node("review_agent", review_agent)
+            supervisor_builder.add_edge(START, "prepare")
+            supervisor_builder.add_edge("prepare", "research_agent")
+            supervisor_builder.add_edge("research_agent", "nested_synthesis_graph")
+            supervisor_builder.add_edge("nested_synthesis_graph", "writer_agent")
+            supervisor_builder.add_edge("writer_agent", "review_agent")
+            supervisor_builder.add_edge("review_agent", END)
+            supervisor = supervisor_builder.compile(name="MixedStateGraphSupervisor")
+
+            supervisor.invoke({"messages": [HumanMessage(content="Start the mixed graph.")]})
+
+        call_mock_llm(
+            "bedrock",
+            invoke_llm_callback=invoke_graph,
+            responses=[
+                tool_response("research-tool-use", "search_knowledge_base", {"query": "agent tracing"}),
+                text_response("Research complete."),
+                text_response("Draft complete."),
+                tool_response("review-tool-use", "check_draft", {"draft": "Draft complete."}),
+                text_response("Review complete."),
+            ],
+        )
+
+        spans = self.span_exporter.get_finished_spans()
+        supervisor_span = next(span for span in spans if span.name == "invoke_agent MixedStateGraphSupervisor")
+        create_agent_spans = [
+            next(span for span in spans if span.name == f"invoke_agent {agent_name}")
+            for agent_name in ("ResearchCreateAgent", "WriterCreateAgent", "ReviewCreateAgent")
+        ]
+        synthesis_graph_span = next(span for span in spans if span.name == "invoke_agent NestedSynthesisStateGraph")
+        chat_spans = [
+            span for span in spans if span.attributes.get(GEN_AI_OPERATION_NAME) == GenAiOperationNameValues.CHAT.value
+        ]
+        tool_spans = [
+            span
+            for span in spans
+            if span.attributes.get(GEN_AI_OPERATION_NAME) == GenAiOperationNameValues.EXECUTE_TOOL.value
+        ]
+        model_step_spans = [span for span in spans if span.name == "chain model"]
+        tool_step_spans = [span for span in spans if span.name == "chain tools"]
+
+        for create_agent_span in create_agent_spans:
+            self.assertEqual(create_agent_span.parent.span_id, supervisor_span.context.span_id)
+        self.assertEqual(synthesis_graph_span.parent.span_id, supervisor_span.context.span_id)
+        self.assertEqual(
+            [
+                (span.attributes["langgraph.node"], span.attributes["langgraph.step"])
+                for span in (*create_agent_spans, synthesis_graph_span)
+            ],
+            [
+                ("research_agent", 2),
+                ("writer_agent", 4),
+                ("review_agent", 5),
+                ("nested_synthesis_graph", 3),
+            ],
+        )
+        self.assertEqual(len(chat_spans), 5)
+        self.assertEqual(len(model_step_spans), 5)
+        self.assertEqual(len(tool_step_spans), 2)
+        self.assertEqual(
+            [(span.attributes["langgraph.node"], span.attributes["langgraph.step"]) for span in model_step_spans],
+            [("model", 1), ("model", 3), ("model", 1), ("model", 1), ("model", 3)],
+        )
+        self.assertEqual(
+            [(span.attributes["langgraph.node"], span.attributes["langgraph.step"]) for span in tool_step_spans],
+            [("tools", 2), ("tools", 2)],
+        )
+        model_step_parent_span_ids = [span.parent.span_id for span in model_step_spans]
+        self.assertEqual(model_step_parent_span_ids.count(create_agent_spans[0].context.span_id), 2)
+        self.assertEqual(model_step_parent_span_ids.count(create_agent_spans[1].context.span_id), 1)
+        self.assertEqual(model_step_parent_span_ids.count(create_agent_spans[2].context.span_id), 2)
+        self.assertEqual(
+            {span.parent.span_id for span in chat_spans},
+            {span.context.span_id for span in model_step_spans},
+        )
+        self.assertEqual(
+            {span.attributes[GEN_AI_TOOL_NAME] for span in tool_spans},
+            {"search_knowledge_base", "check_draft"},
+        )
+        self.assertEqual(
+            {span.parent.span_id for span in tool_step_spans},
+            {create_agent_spans[0].context.span_id, create_agent_spans[2].context.span_id},
+        )
+        self.assertEqual(
+            {span.parent.span_id for span in tool_spans},
+            {span.context.span_id for span in tool_step_spans},
+        )
+        self.assertEqual(
+            {
+                span.context.trace_id
+                for span in (
+                    supervisor_span,
+                    synthesis_graph_span,
+                    *create_agent_spans,
+                    *model_step_spans,
+                    *tool_step_spans,
+                    *chat_spans,
+                    *tool_spans,
+                )
+            },
+            {supervisor_span.context.trace_id},
+        )
         self.assertFalse(any("Runnable" in span.name for span in spans))
 
     def test_nested_raw_stategraph_uses_pregel_fallback_under_explicit_agent(self):

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/langchain/test_langchain_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/langchain/test_langchain_instrumentor.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 import json
 import sys
 import unittest
@@ -34,6 +35,7 @@ from langchain_core.runnables import RunnableLambda, RunnablePassthrough
 from langchain_core.tools import StructuredTool, tool
 
 from amazon.opentelemetry.distro.instrumentation.langchain import LangChainInstrumentor
+from amazon.opentelemetry.distro.instrumentation.langchain.wrapper import PregelWrapper
 from opentelemetry import context
 from opentelemetry.context import _SUPPRESS_INSTRUMENTATION_KEY
 from opentelemetry.sdk.trace import TracerProvider
@@ -70,6 +72,7 @@ from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
     GEN_AI_USAGE_INPUT_TOKENS,
     GEN_AI_USAGE_OUTPUT_TOKENS,
     GEN_AI_USAGE_REASONING_OUTPUT_TOKENS,
+    GEN_AI_WORKFLOW_NAME,
     GenAiOperationNameValues,
     GenAiProviderNameValues,
 )
@@ -250,6 +253,193 @@ class TestLangChainInstrumentor(TestCase):
         output_messages = json.loads(agent_span.attributes[GEN_AI_OUTPUT_MESSAGES])
         validate_otel_genai_schema(output_messages, "gen-ai-output-messages")
         self.assertTrue(any(message.get("role") == "assistant" for message in output_messages))
+
+    def test_raw_stategraph_stream_creates_invoke_agent_span(self):
+        try:
+            from langgraph.graph import END, START, MessagesState, StateGraph
+        except ImportError:
+            self.skipTest("langgraph is not available")
+
+        graph_builder = StateGraph(MessagesState)
+        graph_builder.add_node("respond", lambda _: {"messages": [AIMessage(content="Done.")]})
+        graph_builder.add_edge(START, "respond")
+        graph_builder.add_edge("respond", END)
+        graph = graph_builder.compile(name="RawStateGraph")
+
+        list(graph.stream({"messages": [HumanMessage(content="Hello")]}))
+
+        spans = self.span_exporter.get_finished_spans()
+        agent_spans = [span for span in spans if span.name == "invoke_agent RawStateGraph"]
+        self.assertEqual(len(agent_spans), 1)
+        self.assertEqual(
+            agent_spans[0].attributes[GEN_AI_OPERATION_NAME],
+            GenAiOperationNameValues.INVOKE_AGENT.value,
+        )
+        self.assertEqual(agent_spans[0].attributes[GEN_AI_AGENT_NAME], "RawStateGraph")
+        self.assertIn(GEN_AI_INPUT_MESSAGES, agent_spans[0].attributes)
+        self.assertIn(GEN_AI_OUTPUT_MESSAGES, agent_spans[0].attributes)
+        self.assertIsNone(PregelWrapper.get_active_agent_name())
+
+    def test_raw_stategraph_astream_creates_invoke_agent_span(self):
+        try:
+            from langgraph.graph import END, START, MessagesState, StateGraph
+        except ImportError:
+            self.skipTest("langgraph is not available")
+
+        graph_builder = StateGraph(MessagesState)
+        graph_builder.add_node("respond", lambda _: {"messages": [AIMessage(content="Done.")]})
+        graph_builder.add_edge(START, "respond")
+        graph_builder.add_edge("respond", END)
+        graph = graph_builder.compile(name="AsyncRawStateGraph")
+
+        async def consume_graph():
+            return [chunk async for chunk in graph.astream({"messages": [HumanMessage(content="Hello")]})]
+
+        asyncio.run(consume_graph())
+
+        spans = self.span_exporter.get_finished_spans()
+        agent_spans = [span for span in spans if span.name == "invoke_agent AsyncRawStateGraph"]
+        self.assertEqual(len(agent_spans), 1)
+        self.assertEqual(
+            agent_spans[0].attributes[GEN_AI_OPERATION_NAME],
+            GenAiOperationNameValues.INVOKE_AGENT.value,
+        )
+        self.assertEqual(agent_spans[0].attributes[GEN_AI_AGENT_NAME], "AsyncRawStateGraph")
+        self.assertIn(GEN_AI_INPUT_MESSAGES, agent_spans[0].attributes)
+        self.assertIn(GEN_AI_OUTPUT_MESSAGES, agent_spans[0].attributes)
+        self.assertIsNone(PregelWrapper.get_active_agent_name())
+
+    def test_explicit_agent_marker_takes_precedence_over_pregel_fallback(self):
+        try:
+            from langgraph.graph import END, START, MessagesState, StateGraph
+        except ImportError:
+            self.skipTest("langgraph is not available")
+
+        graph_builder = StateGraph(MessagesState)
+        graph_builder.add_node("respond", lambda _: {"messages": [AIMessage(content="Done.")]})
+        graph_builder.add_edge(START, "respond")
+        graph_builder.add_edge("respond", END)
+        graph = graph_builder.compile(name="RawStateGraph").with_config(
+            {
+                "metadata": {
+                    "otel_agent_span": True,
+                    "agent_name": "ExplicitStateGraphAgent",
+                    "agent_type": "stategraph",
+                }
+            }
+        )
+
+        graph.invoke({"messages": [HumanMessage(content="Hello")]})
+
+        spans = self.span_exporter.get_finished_spans()
+        agent_spans = [span for span in spans if span.name == "invoke_agent ExplicitStateGraphAgent"]
+        self.assertEqual(len(agent_spans), 1)
+        self.assertEqual(agent_spans[0].attributes[GEN_AI_AGENT_NAME], "ExplicitStateGraphAgent")
+        self.assertEqual(
+            agent_spans[0].attributes[GEN_AI_OPERATION_NAME],
+            GenAiOperationNameValues.INVOKE_AGENT.value,
+        )
+
+    def test_explicit_workflow_marker_overrides_pregel_fallback(self):
+        try:
+            from langgraph.graph import END, START, MessagesState, StateGraph
+        except ImportError:
+            self.skipTest("langgraph is not available")
+
+        graph_builder = StateGraph(MessagesState)
+        graph_builder.add_node("respond", lambda _: {"messages": [AIMessage(content="Done.")]})
+        graph_builder.add_edge(START, "respond")
+        graph_builder.add_edge("respond", END)
+        graph = graph_builder.compile(name="ExplicitStateGraphWorkflow").with_config(
+            {"metadata": {"otel_workflow_span": True}}
+        )
+
+        graph.invoke({"messages": [HumanMessage(content="Hello")]})
+
+        spans = self.span_exporter.get_finished_spans()
+        workflow_spans = [span for span in spans if span.name == "invoke_workflow ExplicitStateGraphWorkflow"]
+        self.assertEqual(len(workflow_spans), 1)
+        self.assertEqual(
+            workflow_spans[0].attributes[GEN_AI_OPERATION_NAME],
+            GenAiOperationNameValues.INVOKE_WORKFLOW.value,
+        )
+        self.assertEqual(workflow_spans[0].attributes[GEN_AI_WORKFLOW_NAME], "ExplicitStateGraphWorkflow")
+        self.assertIn(GEN_AI_INPUT_MESSAGES, workflow_spans[0].attributes)
+        self.assertIn(GEN_AI_OUTPUT_MESSAGES, workflow_spans[0].attributes)
+        self.assertFalse(any(span.name == "invoke_agent ExplicitStateGraphWorkflow" for span in spans))
+
+    def test_skipped_chains_parent_model_span_to_nearest_ancestor_e2e(self):
+        try:
+            from langchain_aws import ChatBedrockConverse
+            from langgraph.graph import END, START, MessagesState, StateGraph
+        except ImportError:
+            self.skipTest("langgraph or langchain-aws is not available")
+
+        def invoke_graph(client):
+            llm = ChatBedrockConverse(model="anthropic.claude-fable-5", client=client)
+            nested_runnables = (
+                RunnableLambda(lambda state: state["messages"])
+                | RunnableLambda(lambda messages: messages)
+                | llm
+                | RunnableLambda(lambda message: {"messages": [message]})
+            )
+
+            graph_builder = StateGraph(MessagesState)
+            graph_builder.add_node("nested_runnables", nested_runnables)
+            graph_builder.add_edge(START, "nested_runnables")
+            graph_builder.add_edge("nested_runnables", END)
+            graph = graph_builder.compile(name="SkippedChainParentingAgent")
+
+            graph.invoke({"messages": [HumanMessage(content="Hello")]})
+
+        call_mock_llm("bedrock", invoke_llm_callback=invoke_graph)
+
+        spans = self.span_exporter.get_finished_spans()
+        agent_span = next(span for span in spans if span.name == "invoke_agent SkippedChainParentingAgent")
+        chat_span = next(
+            span for span in spans if span.attributes.get(GEN_AI_OPERATION_NAME) == GenAiOperationNameValues.CHAT.value
+        )
+        self.assertEqual(chat_span.context.trace_id, agent_span.context.trace_id)
+        self.assertEqual(chat_span.parent.span_id, agent_span.context.span_id)
+        self.assertFalse(any("Runnable" in span.name for span in spans))
+
+    def test_nested_raw_stategraph_uses_pregel_fallback_under_explicit_agent(self):
+        try:
+            from langgraph.graph import END, START, MessagesState, StateGraph
+        except ImportError:
+            self.skipTest("langgraph is not available")
+
+        child_builder = StateGraph(MessagesState)
+        child_builder.add_node("respond", lambda _: {"messages": [AIMessage(content="Child done.")]})
+        child_builder.add_edge(START, "respond")
+        child_builder.add_edge("respond", END)
+        child = child_builder.compile(name="RawChildStateGraph")
+
+        parent_builder = StateGraph(MessagesState)
+        parent_builder.add_node("child", child)
+        parent_builder.add_edge(START, "child")
+        parent_builder.add_edge("child", END)
+        parent = parent_builder.compile(name="ExplicitParentStateGraph").with_config(
+            {
+                "metadata": {
+                    "otel_agent_span": True,
+                    "agent_name": "ExplicitParentStateGraph",
+                    "agent_type": "stategraph",
+                }
+            }
+        )
+
+        parent.invoke({"messages": [HumanMessage(content="Hello")]})
+
+        spans = self.span_exporter.get_finished_spans()
+        agent_spans = [span for span in spans if span.name.startswith("invoke_agent")]
+        agent_span_names = [span.name for span in agent_spans]
+        self.assertEqual(agent_span_names.count("invoke_agent ExplicitParentStateGraph"), 1)
+        self.assertEqual(agent_span_names.count("invoke_agent RawChildStateGraph"), 1)
+        parent_span = next(span for span in agent_spans if span.name == "invoke_agent ExplicitParentStateGraph")
+        child_span = next(span for span in agent_spans if span.name == "invoke_agent RawChildStateGraph")
+        self.assertEqual(child_span.context.trace_id, parent_span.context.trace_id)
+        self.assertEqual(child_span.parent.span_id, parent_span.context.span_id)
 
     def test_tool_span_has_all_attributes(self):
         def add_numbers(a: int, b: int) -> int:

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/langchain/test_langchain_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/langchain/test_langchain_instrumentor.py
@@ -309,6 +309,201 @@ class TestLangChainInstrumentor(TestCase):
         self.assertIn(GEN_AI_OUTPUT_MESSAGES, agent_spans[0].attributes)
         self.assertIsNone(PregelWrapper.get_active_agent_name())
 
+    def test_raw_stategraph_invoke_uses_stream_fallback(self):
+        try:
+            from langgraph.graph import END, START, MessagesState, StateGraph
+        except ImportError:
+            self.skipTest("langgraph is not available")
+
+        graph_builder = StateGraph(MessagesState)
+        graph_builder.add_node("respond", lambda _: {"messages": [AIMessage(content="Done.")]})
+        graph_builder.add_edge(START, "respond")
+        graph_builder.add_edge("respond", END)
+        graph = graph_builder.compile(name="InvokedRawStateGraph")
+
+        result = graph.invoke({"messages": [HumanMessage(content="Hello")]})
+
+        self.assertEqual(result["messages"][-1].content, "Done.")
+        agent_spans = [
+            span for span in self.span_exporter.get_finished_spans() if span.name == "invoke_agent InvokedRawStateGraph"
+        ]
+        self.assertEqual(len(agent_spans), 1)
+        self.assertIsNone(PregelWrapper.get_active_agent_name())
+
+    def test_raw_stategraph_ainvoke_uses_astream_fallback(self):
+        try:
+            from langgraph.graph import END, START, MessagesState, StateGraph
+        except ImportError:
+            self.skipTest("langgraph is not available")
+
+        graph_builder = StateGraph(MessagesState)
+        graph_builder.add_node("respond", lambda _: {"messages": [AIMessage(content="Done.")]})
+        graph_builder.add_edge(START, "respond")
+        graph_builder.add_edge("respond", END)
+        graph = graph_builder.compile(name="AsyncInvokedRawStateGraph")
+
+        result = asyncio.run(graph.ainvoke({"messages": [HumanMessage(content="Hello")]}))
+
+        self.assertEqual(result["messages"][-1].content, "Done.")
+        agent_spans = [
+            span
+            for span in self.span_exporter.get_finished_spans()
+            if span.name == "invoke_agent AsyncInvokedRawStateGraph"
+        ]
+        self.assertEqual(len(agent_spans), 1)
+        self.assertIsNone(PregelWrapper.get_active_agent_name())
+
+    def test_raw_stategraph_stream_close_preserves_application_behavior(self):
+        try:
+            from langgraph.graph import END, START, MessagesState, StateGraph
+        except ImportError:
+            self.skipTest("langgraph is not available")
+
+        executed_nodes = []
+
+        def first_node(_):
+            self.assertEqual(PregelWrapper.get_active_agent_name(), "ClosableRawStateGraph")
+            executed_nodes.append("first")
+            return {"messages": [AIMessage(content="First node complete.")]}
+
+        def second_node(_):
+            executed_nodes.append("second")
+            return {"messages": [AIMessage(content="Second node complete.")]}
+
+        graph_builder = StateGraph(MessagesState)
+        graph_builder.add_node("first", first_node)
+        graph_builder.add_node("second", second_node)
+        graph_builder.add_edge(START, "first")
+        graph_builder.add_edge("first", "second")
+        graph_builder.add_edge("second", END)
+        graph = graph_builder.compile(name="ClosableRawStateGraph")
+
+        stream = graph.stream(
+            {"messages": [HumanMessage(content="Hello")]},
+            stream_mode="updates",
+        )
+        first_update = next(stream)
+        self.assertEqual(first_update["first"]["messages"][0].content, "First node complete.")
+        self.assertIsNone(PregelWrapper.get_active_agent_name())
+
+        stream.close()
+
+        self.assertEqual(executed_nodes, ["first"])
+        self.assertIsNone(PregelWrapper.get_active_agent_name())
+        agent_spans = [
+            span
+            for span in self.span_exporter.get_finished_spans()
+            if span.name == "invoke_agent ClosableRawStateGraph"
+        ]
+        self.assertEqual(len(agent_spans), 1)
+
+    def test_raw_stategraph_astream_aclose_preserves_application_behavior(self):
+        try:
+            from langgraph.graph import END, START, MessagesState, StateGraph
+        except ImportError:
+            self.skipTest("langgraph is not available")
+
+        executed_nodes = []
+
+        async def first_node(_):
+            self.assertEqual(PregelWrapper.get_active_agent_name(), "ClosableAsyncRawStateGraph")
+            executed_nodes.append("first")
+            return {"messages": [AIMessage(content="First async node complete.")]}
+
+        async def second_node(_):
+            executed_nodes.append("second")
+            return {"messages": [AIMessage(content="Second async node complete.")]}
+
+        graph_builder = StateGraph(MessagesState)
+        graph_builder.add_node("first", first_node)
+        graph_builder.add_node("second", second_node)
+        graph_builder.add_edge(START, "first")
+        graph_builder.add_edge("first", "second")
+        graph_builder.add_edge("second", END)
+        graph = graph_builder.compile(name="ClosableAsyncRawStateGraph")
+
+        async def consume_first_update():
+            stream = graph.astream(
+                {"messages": [HumanMessage(content="Hello")]},
+                stream_mode="updates",
+            )
+            first_update = await anext(stream)
+            self.assertEqual(first_update["first"]["messages"][0].content, "First async node complete.")
+            self.assertIsNone(PregelWrapper.get_active_agent_name())
+            await stream.aclose()
+
+        asyncio.run(consume_first_update())
+
+        self.assertEqual(executed_nodes, ["first"])
+        self.assertIsNone(PregelWrapper.get_active_agent_name())
+        agent_spans = [
+            span
+            for span in self.span_exporter.get_finished_spans()
+            if span.name == "invoke_agent ClosableAsyncRawStateGraph"
+        ]
+        self.assertEqual(len(agent_spans), 1)
+
+    def test_raw_stategraph_stream_propagates_application_error(self):
+        try:
+            from langgraph.graph import END, START, MessagesState, StateGraph
+        except ImportError:
+            self.skipTest("langgraph is not available")
+
+        expected_error = RuntimeError("sync graph failed")
+
+        def failing_node(_):
+            self.assertEqual(PregelWrapper.get_active_agent_name(), "FailingRawStateGraph")
+            raise expected_error
+
+        graph_builder = StateGraph(MessagesState)
+        graph_builder.add_node("fail", failing_node)
+        graph_builder.add_edge(START, "fail")
+        graph_builder.add_edge("fail", END)
+        graph = graph_builder.compile(name="FailingRawStateGraph")
+
+        with self.assertRaises(RuntimeError) as raised:
+            list(graph.stream({"messages": [HumanMessage(content="Hello")]}))
+
+        self.assertIs(raised.exception, expected_error)
+        self.assertIsNone(PregelWrapper.get_active_agent_name())
+        agent_span = next(
+            span for span in self.span_exporter.get_finished_spans() if span.name == "invoke_agent FailingRawStateGraph"
+        )
+        self.assertEqual(agent_span.status.status_code, StatusCode.ERROR)
+
+    def test_raw_stategraph_astream_propagates_application_error(self):
+        try:
+            from langgraph.graph import END, START, MessagesState, StateGraph
+        except ImportError:
+            self.skipTest("langgraph is not available")
+
+        expected_error = RuntimeError("async graph failed")
+
+        async def failing_node(_):
+            self.assertEqual(PregelWrapper.get_active_agent_name(), "FailingAsyncRawStateGraph")
+            raise expected_error
+
+        graph_builder = StateGraph(MessagesState)
+        graph_builder.add_node("fail", failing_node)
+        graph_builder.add_edge(START, "fail")
+        graph_builder.add_edge("fail", END)
+        graph = graph_builder.compile(name="FailingAsyncRawStateGraph")
+
+        async def consume_graph():
+            return [chunk async for chunk in graph.astream({"messages": [HumanMessage(content="Hello")]})]
+
+        with self.assertRaises(RuntimeError) as raised:
+            asyncio.run(consume_graph())
+
+        self.assertIs(raised.exception, expected_error)
+        self.assertIsNone(PregelWrapper.get_active_agent_name())
+        agent_span = next(
+            span
+            for span in self.span_exporter.get_finished_spans()
+            if span.name == "invoke_agent FailingAsyncRawStateGraph"
+        )
+        self.assertEqual(agent_span.status.status_code, StatusCode.ERROR)
+
     def test_explicit_agent_marker_takes_precedence_over_pregel_fallback(self):
         try:
             from langgraph.graph import END, START, MessagesState, StateGraph
@@ -340,6 +535,28 @@ class TestLangChainInstrumentor(TestCase):
             GenAiOperationNameValues.INVOKE_AGENT.value,
         )
 
+    def test_otel_agent_span_false_does_not_disable_pregel_fallback(self):
+        try:
+            from langgraph.graph import END, START, MessagesState, StateGraph
+        except ImportError:
+            self.skipTest("langgraph is not available")
+
+        graph_builder = StateGraph(MessagesState)
+        graph_builder.add_node("respond", lambda _: {"messages": [AIMessage(content="Done.")]})
+        graph_builder.add_edge(START, "respond")
+        graph_builder.add_edge("respond", END)
+        graph = graph_builder.compile(name="AutomaticStateGraphAgent").with_config(
+            {"metadata": {"otel_agent_span": False}}
+        )
+
+        graph.invoke({"messages": [HumanMessage(content="Hello")]})
+
+        spans = self.span_exporter.get_finished_spans()
+        self.assertEqual(
+            len([span for span in spans if span.name == "invoke_agent AutomaticStateGraphAgent"]),
+            1,
+        )
+
     def test_explicit_workflow_marker_overrides_pregel_fallback(self):
         try:
             from langgraph.graph import END, START, MessagesState, StateGraph
@@ -367,6 +584,36 @@ class TestLangChainInstrumentor(TestCase):
         self.assertIn(GEN_AI_INPUT_MESSAGES, workflow_spans[0].attributes)
         self.assertIn(GEN_AI_OUTPUT_MESSAGES, workflow_spans[0].attributes)
         self.assertFalse(any(span.name == "invoke_agent ExplicitStateGraphWorkflow" for span in spans))
+
+    def test_explicit_workflow_marker_overrides_incidental_agent_metadata(self):
+        try:
+            from langgraph.graph import END, START, MessagesState, StateGraph
+        except ImportError:
+            self.skipTest("langgraph is not available")
+
+        graph_builder = StateGraph(MessagesState)
+        graph_builder.add_node("respond", lambda _: {"messages": [AIMessage(content="Done.")]})
+        graph_builder.add_edge(START, "respond")
+        graph_builder.add_edge("respond", END)
+        graph = graph_builder.compile(name="WorkflowWithAgentMetadata").with_config(
+            {
+                "metadata": {
+                    "otel_workflow_span": True,
+                    "agent_name": "UpstreamAgentName",
+                }
+            }
+        )
+
+        graph.invoke({"messages": [HumanMessage(content="Hello")]})
+
+        spans = self.span_exporter.get_finished_spans()
+        workflow_span = next(span for span in spans if span.name == "invoke_workflow WorkflowWithAgentMetadata")
+        self.assertEqual(
+            workflow_span.attributes[GEN_AI_OPERATION_NAME],
+            GenAiOperationNameValues.INVOKE_WORKFLOW.value,
+        )
+        self.assertNotIn(GEN_AI_AGENT_NAME, workflow_span.attributes)
+        self.assertFalse(any(span.name.startswith("invoke_agent") for span in spans))
 
     def test_skipped_chains_parent_model_span_to_nearest_ancestor(self):
         try:
@@ -401,6 +648,8 @@ class TestLangChainInstrumentor(TestCase):
         )
         self.assertEqual(chat_span.context.trace_id, agent_span.context.trace_id)
         self.assertEqual(chat_span.parent.span_id, agent_span.context.span_id)
+        self.assertLess(agent_span.start_time, chat_span.start_time)
+        self.assertGreater(agent_span.end_time, chat_span.end_time)
         self.assertFalse(any("Runnable" in span.name for span in spans))
 
     def test_stategraph_with_create_agents_and_nested_stategraph_preserves_agent_hierarchy(self):
@@ -518,7 +767,7 @@ class TestLangChainInstrumentor(TestCase):
         for create_agent_span in create_agent_spans:
             self.assertEqual(create_agent_span.parent.span_id, supervisor_span.context.span_id)
         self.assertEqual(synthesis_graph_span.parent.span_id, supervisor_span.context.span_id)
-        self.assertEqual(
+        self.assertCountEqual(
             [
                 (span.attributes["langgraph.node"], span.attributes["langgraph.step"])
                 for span in (*create_agent_spans, synthesis_graph_span)
@@ -533,11 +782,11 @@ class TestLangChainInstrumentor(TestCase):
         self.assertEqual(len(chat_spans), 5)
         self.assertEqual(len(model_step_spans), 5)
         self.assertEqual(len(tool_step_spans), 2)
-        self.assertEqual(
+        self.assertCountEqual(
             [(span.attributes["langgraph.node"], span.attributes["langgraph.step"]) for span in model_step_spans],
             [("model", 1), ("model", 3), ("model", 1), ("model", 1), ("model", 3)],
         )
-        self.assertEqual(
+        self.assertCountEqual(
             [(span.attributes["langgraph.node"], span.attributes["langgraph.step"]) for span in tool_step_spans],
             [("tools", 2), ("tools", 2)],
         )


### PR DESCRIPTION
## Summary

- wrap LangGraph Pregel `stream` and `astream` to expose the active StateGraph name for callback-based agent classification without creating duplicate spans
- support explicit agent and workflow metadata while preserving existing LangChain agent detection
- keep child model and tool spans attached to the nearest emitted ancestor span when internal chain callbacks are suppressed
- add sync, async, nested graph, workflow marker, and mocked Bedrock end-to-end coverage

## Testing

- `pytest tests/amazon/opentelemetry/distro/instrumentation/langchain/test_langchain_instrumentor.py -k "raw_stategraph or explicit_agent_marker or explicit_workflow_marker or nested_raw_stategraph or internal_nodes_suppressed or skipped_chains_parent_model_span" -q` (7 passed)
- `black --check` on changed Python files
- `isort --check-only` on changed Python files