### PR TITLE
feat(genai): add AWS instrumentation controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ If your change does not need a CHANGELOG entry, add the "skip changelog" label t
 
 ## Unreleased
 
+- feat(genai): add ADOT-prefixed controls for GenAI instrumentation, MCP HTTP suppression, and OpenAI Agents
+  trace export, and deprecate the previous environment variable names
+  ([#893](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/893))
 - fix: restrict native GenAI instrumentations to supported dependency major versions
   ([#884](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/884))
 - fix(langchain): propagate first input, last output, and system instructions to internal agent spans

--- a/aws-opentelemetry-distro/README.rst
+++ b/aws-opentelemetry-distro/README.rst
@@ -11,6 +11,21 @@ Installation
 
 This package provides Amazon Web Services distribution of the OpenTelemetry Python Instrumentation, which allows for auto-instrumentation of Python applications.
 
+GenAI instrumentation environment variables
+--------------------------------------------
+
+``ADOT_GENAI_INSTRUMENTATION``
+    Controls AWS native GenAI instrumentations when agent observability is enabled. Supported values are ``auto``
+    (default), ``enabled``, and ``disabled``. ``AWS_AGENTIC_INSTRUMENTATION`` is a deprecated alias.
+
+``ADOT_INSTRUMENTATION_MCP_SUPPRESS_HTTP_INSTRUMENTATION``
+    Controls whether MCP instrumentation suppresses HTTP client and ASGI spans. The default is ``true``.
+    ``OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION`` is a deprecated alias.
+
+``ADOT_INSTRUMENTATION_OPENAI_AGENTS_DISABLE_TRACE_EXPORT``
+    Set to ``true`` to prevent the OpenAI Agents SDK from exporting traces to the OpenAI backend while retaining
+    ADOT instrumentation. The default is ``false``.
+
 References
 ----------
 

--- a/aws-opentelemetry-distro/README.rst
+++ b/aws-opentelemetry-distro/README.rst
@@ -11,21 +11,6 @@ Installation
 
 This package provides Amazon Web Services distribution of the OpenTelemetry Python Instrumentation, which allows for auto-instrumentation of Python applications.
 
-GenAI instrumentation environment variables
---------------------------------------------
-
-``ADOT_GENAI_INSTRUMENTATION``
-    Controls AWS native GenAI instrumentations when agent observability is enabled. Supported values are ``auto``
-    (default), ``enabled``, and ``disabled``. ``AWS_AGENTIC_INSTRUMENTATION`` is a deprecated alias.
-
-``ADOT_INSTRUMENTATION_MCP_SUPPRESS_HTTP_INSTRUMENTATION``
-    Controls whether MCP instrumentation suppresses HTTP client and ASGI spans. The default is ``true``.
-    ``OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION`` is a deprecated alias.
-
-``ADOT_INSTRUMENTATION_OPENAI_AGENTS_DISABLE_TRACE_EXPORT``
-    Set to ``true`` to prevent the OpenAI Agents SDK from exporting traces to the OpenAI backend while retaining
-    ADOT instrumentation. The default is ``false``.
-
 References
 ----------
 

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_utils.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_utils.py
@@ -15,6 +15,11 @@ OTEL_METRICS_ADD_APPLICATION_SIGNALS_DIMENSIONS = "OTEL_METRICS_ADD_APPLICATION_
 AWS_GENAI_CONTENT_EXTRACTION_OPT_OUT = "AWS_GENAI_CONTENT_EXTRACTION_OPT_OUT"
 
 
+def get_env(name: str, fallback_name: str, default: Optional[str] = None) -> Optional[str]:
+    """Get an environment variable, falling back to another name when unset."""
+    return os.environ.get(name, os.environ.get(fallback_name, default))
+
+
 def is_installed(req: str) -> bool:
     """Is the given required package installed?"""
     req = Requirement(req)

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_utils.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_utils.py
@@ -14,30 +14,6 @@ AGENT_OBSERVABILITY_ENABLED = "AGENT_OBSERVABILITY_ENABLED"
 OTEL_METRICS_ADD_APPLICATION_SIGNALS_DIMENSIONS = "OTEL_METRICS_ADD_APPLICATION_SIGNALS_DIMENSIONS"
 AWS_GENAI_CONTENT_EXTRACTION_OPT_OUT = "AWS_GENAI_CONTENT_EXTRACTION_OPT_OUT"
 
-_DEPRECATED_ENVIRONMENT_VARIABLES_WARNED = set()
-
-
-def get_env_with_deprecated_alias(name: str, deprecated_name: str, default: Optional[str] = None) -> Optional[str]:
-    """Return an environment variable while supporting a deprecated alias.
-
-    The preferred variable takes precedence when both names are set.
-    """
-    value = os.environ.get(name)
-    deprecated_value = os.environ.get(deprecated_name)
-
-    if deprecated_value is not None and deprecated_name not in _DEPRECATED_ENVIRONMENT_VARIABLES_WARNED:
-        if value is None:
-            _logger.warning("%s is deprecated; use %s instead.", deprecated_name, name)
-        else:
-            _logger.warning("%s is deprecated and ignored because %s is set.", deprecated_name, name)
-        _DEPRECATED_ENVIRONMENT_VARIABLES_WARNED.add(deprecated_name)
-
-    if value is not None:
-        return value
-    if deprecated_value is not None:
-        return deprecated_value
-    return default
-
 
 def is_installed(req: str) -> bool:
     """Is the given required package installed?"""

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_utils.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/_utils.py
@@ -14,6 +14,30 @@ AGENT_OBSERVABILITY_ENABLED = "AGENT_OBSERVABILITY_ENABLED"
 OTEL_METRICS_ADD_APPLICATION_SIGNALS_DIMENSIONS = "OTEL_METRICS_ADD_APPLICATION_SIGNALS_DIMENSIONS"
 AWS_GENAI_CONTENT_EXTRACTION_OPT_OUT = "AWS_GENAI_CONTENT_EXTRACTION_OPT_OUT"
 
+_DEPRECATED_ENVIRONMENT_VARIABLES_WARNED = set()
+
+
+def get_env_with_deprecated_alias(name: str, deprecated_name: str, default: Optional[str] = None) -> Optional[str]:
+    """Return an environment variable while supporting a deprecated alias.
+
+    The preferred variable takes precedence when both names are set.
+    """
+    value = os.environ.get(name)
+    deprecated_value = os.environ.get(deprecated_name)
+
+    if deprecated_value is not None and deprecated_name not in _DEPRECATED_ENVIRONMENT_VARIABLES_WARNED:
+        if value is None:
+            _logger.warning("%s is deprecated; use %s instead.", deprecated_name, name)
+        else:
+            _logger.warning("%s is deprecated and ignored because %s is set.", deprecated_name, name)
+        _DEPRECATED_ENVIRONMENT_VARIABLES_WARNED.add(deprecated_name)
+
+    if value is not None:
+        return value
+    if deprecated_value is not None:
+        return deprecated_value
+    return default
+
 
 def is_installed(req: str) -> bool:
     """Is the given required package installed?"""

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
@@ -274,12 +274,15 @@ class AwsOpenTelemetryDistro(OpenTelemetryDistro):
         if not is_native:
             return False
 
+        mode_variable = (
+            ADOT_GENAI_INSTRUMENTATION if ADOT_GENAI_INSTRUMENTATION in os.environ else AWS_AGENTIC_INSTRUMENTATION
+        )
         raw_mode = get_env(ADOT_GENAI_INSTRUMENTATION, AWS_AGENTIC_INSTRUMENTATION, "auto")
         mode = raw_mode.lower()
         if mode not in ("auto", "enabled", "disabled"):
             _logger.warning(
                 "Unknown %s=%r — falling back to 'auto'. Valid values: auto, enabled, disabled.",
-                ADOT_GENAI_INSTRUMENTATION,
+                mode_variable,
                 raw_mode,
             )
             mode = "auto"
@@ -287,7 +290,7 @@ class AwsOpenTelemetryDistro(OpenTelemetryDistro):
         if mode == "enabled":
             return False
         if mode == "disabled":
-            _logger.debug("Skipping %s: ADOT_GENAI_INSTRUMENTATION=disabled", entry_point.name)
+            _logger.debug("Skipping %s: %s=disabled", entry_point.name, mode_variable)
             return True
 
         # mode == "auto": skip the native side if a same-library third-party is registered.

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
@@ -260,9 +260,9 @@ class AwsOpenTelemetryDistro(OpenTelemetryDistro):
         """Skip AWS native agentic instrumentors that should not load.
 
         When agent observability is enabled:
-        - ADOT_GENAI_INSTRUMENTATION (auto/enabled/disabled) governs the aws_* side only.
-          See the constant docstring for semantics. Third-party instrumentors are never
-          touched here.
+        - ADOT_GENAI_INSTRUMENTATION or AWS_AGENTIC_INSTRUMENTATION
+          (auto/enabled/disabled) governs the aws_* side only. Third-party
+          instrumentors are never touched here.
         """
         if is_agent_observability_enabled() and self._should_skip_instrumentor(entry_point):
             return

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
@@ -121,10 +121,6 @@ ADOT_GENAI_INSTRUMENTATION = "ADOT_GENAI_INSTRUMENTATION"
 # Deprecated: use ADOT_GENAI_INSTRUMENTATION.
 AWS_AGENTIC_INSTRUMENTATION = "AWS_AGENTIC_INSTRUMENTATION"
 
-# Opt-in control for replacing the OpenAI Agents SDK trace processors with the
-# ADOT processor, preventing export to the OpenAI trace backend.
-ADOT_INSTRUMENTATION_OPENAI_AGENTS_DISABLE_TRACE_EXPORT = "ADOT_INSTRUMENTATION_OPENAI_AGENTS_DISABLE_TRACE_EXPORT"
-
 # Maps third-party instrumentor entry point names to their AWS native equivalents.
 # Used for mutual exclusion: only one side instruments each library at a time.
 _THIRDPARTY_TO_AWS_NATIVE = {
@@ -270,12 +266,6 @@ class AwsOpenTelemetryDistro(OpenTelemetryDistro):
         """
         if is_agent_observability_enabled() and self._should_skip_instrumentor(entry_point):
             return
-
-        if (
-            entry_point.name == "aws_openai_agents"
-            and os.environ.get(ADOT_INSTRUMENTATION_OPENAI_AGENTS_DISABLE_TRACE_EXPORT, "false").lower() == "true"
-        ):
-            kwargs["disable_openai_trace_export"] = True
 
         super().load_instrumentor(entry_point, **kwargs)
 

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
@@ -69,6 +69,7 @@ from logging import ERROR, Logger, getLogger
 from amazon.opentelemetry.distro._utils import (
     OTEL_METRICS_ADD_APPLICATION_SIGNALS_DIMENSIONS,
     get_aws_region,
+    get_env_with_deprecated_alias,
     is_agent_observability_enabled,
     is_installed,
 )
@@ -116,7 +117,13 @@ _load._logger.setLevel(LEVELS.get(os.environ.get(OTEL_PYTHON_LOG_LEVEL, "error")
 #   "auto" (default, also when unset): load aws_* unless a same-library third-party is registered.
 #   "enabled" : load all aws_* unconditionally.
 #   "disabled": skip all aws_*.
+ADOT_GENAI_INSTRUMENTATION = "ADOT_GENAI_INSTRUMENTATION"
+# Deprecated: use ADOT_GENAI_INSTRUMENTATION.
 AWS_AGENTIC_INSTRUMENTATION = "AWS_AGENTIC_INSTRUMENTATION"
+
+# Opt-in control for replacing the OpenAI Agents SDK trace processors with the
+# ADOT processor, preventing export to the OpenAI trace backend.
+ADOT_INSTRUMENTATION_OPENAI_AGENTS_DISABLE_TRACE_EXPORT = "ADOT_INSTRUMENTATION_OPENAI_AGENTS_DISABLE_TRACE_EXPORT"
 
 # Maps third-party instrumentor entry point names to their AWS native equivalents.
 # Used for mutual exclusion: only one side instruments each library at a time.
@@ -257,12 +264,19 @@ class AwsOpenTelemetryDistro(OpenTelemetryDistro):
         """Skip AWS native agentic instrumentors that should not load.
 
         When agent observability is enabled:
-        - AWS_AGENTIC_INSTRUMENTATION (auto/enabled/disabled) governs the aws_* side only.
+        - ADOT_GENAI_INSTRUMENTATION (auto/enabled/disabled) governs the aws_* side only.
           See the constant docstring for semantics. Third-party instrumentors are never
           touched here.
         """
         if is_agent_observability_enabled() and self._should_skip_instrumentor(entry_point):
             return
+
+        if (
+            entry_point.name == "aws_openai_agents"
+            and os.environ.get(ADOT_INSTRUMENTATION_OPENAI_AGENTS_DISABLE_TRACE_EXPORT, "false").lower() == "true"
+        ):
+            kwargs["disable_openai_trace_export"] = True
+
         super().load_instrumentor(entry_point, **kwargs)
 
     @staticmethod
@@ -271,12 +285,16 @@ class AwsOpenTelemetryDistro(OpenTelemetryDistro):
         if not is_native:
             return False
 
-        raw_mode = os.environ.get(AWS_AGENTIC_INSTRUMENTATION, "auto")
+        raw_mode = get_env_with_deprecated_alias(
+            ADOT_GENAI_INSTRUMENTATION,
+            AWS_AGENTIC_INSTRUMENTATION,
+            "auto",
+        )
         mode = raw_mode.lower()
         if mode not in ("auto", "enabled", "disabled"):
             _logger.warning(
                 "Unknown %s=%r — falling back to 'auto'. Valid values: auto, enabled, disabled.",
-                AWS_AGENTIC_INSTRUMENTATION,
+                ADOT_GENAI_INSTRUMENTATION,
                 raw_mode,
             )
             mode = "auto"
@@ -284,7 +302,7 @@ class AwsOpenTelemetryDistro(OpenTelemetryDistro):
         if mode == "enabled":
             return False
         if mode == "disabled":
-            _logger.debug("Skipping %s: AWS_AGENTIC_INSTRUMENTATION=disabled", entry_point.name)
+            _logger.debug("Skipping %s: ADOT_GENAI_INSTRUMENTATION=disabled", entry_point.name)
             return True
 
         # mode == "auto": skip the native side if a same-library third-party is registered.

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
@@ -69,6 +69,7 @@ from logging import ERROR, Logger, getLogger
 from amazon.opentelemetry.distro._utils import (
     OTEL_METRICS_ADD_APPLICATION_SIGNALS_DIMENSIONS,
     get_aws_region,
+    get_env,
     is_agent_observability_enabled,
     is_installed,
 )
@@ -273,16 +274,12 @@ class AwsOpenTelemetryDistro(OpenTelemetryDistro):
         if not is_native:
             return False
 
-        mode_variable = ADOT_GENAI_INSTRUMENTATION
-        raw_mode = os.environ.get(mode_variable)
-        if raw_mode is None:
-            mode_variable = AWS_AGENTIC_INSTRUMENTATION
-            raw_mode = os.environ.get(mode_variable, "auto")
+        raw_mode = get_env(ADOT_GENAI_INSTRUMENTATION, AWS_AGENTIC_INSTRUMENTATION, "auto")
         mode = raw_mode.lower()
         if mode not in ("auto", "enabled", "disabled"):
             _logger.warning(
                 "Unknown %s=%r — falling back to 'auto'. Valid values: auto, enabled, disabled.",
-                mode_variable,
+                ADOT_GENAI_INSTRUMENTATION,
                 raw_mode,
             )
             mode = "auto"
@@ -290,7 +287,7 @@ class AwsOpenTelemetryDistro(OpenTelemetryDistro):
         if mode == "enabled":
             return False
         if mode == "disabled":
-            _logger.debug("Skipping %s: %s=disabled", entry_point.name, mode_variable)
+            _logger.debug("Skipping %s: ADOT_GENAI_INSTRUMENTATION=disabled", entry_point.name)
             return True
 
         # mode == "auto": skip the native side if a same-library third-party is registered.

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/aws_opentelemetry_distro.py
@@ -69,7 +69,6 @@ from logging import ERROR, Logger, getLogger
 from amazon.opentelemetry.distro._utils import (
     OTEL_METRICS_ADD_APPLICATION_SIGNALS_DIMENSIONS,
     get_aws_region,
-    get_env_with_deprecated_alias,
     is_agent_observability_enabled,
     is_installed,
 )
@@ -266,7 +265,6 @@ class AwsOpenTelemetryDistro(OpenTelemetryDistro):
         """
         if is_agent_observability_enabled() and self._should_skip_instrumentor(entry_point):
             return
-
         super().load_instrumentor(entry_point, **kwargs)
 
     @staticmethod
@@ -275,16 +273,16 @@ class AwsOpenTelemetryDistro(OpenTelemetryDistro):
         if not is_native:
             return False
 
-        raw_mode = get_env_with_deprecated_alias(
-            ADOT_GENAI_INSTRUMENTATION,
-            AWS_AGENTIC_INSTRUMENTATION,
-            "auto",
-        )
+        mode_variable = ADOT_GENAI_INSTRUMENTATION
+        raw_mode = os.environ.get(mode_variable)
+        if raw_mode is None:
+            mode_variable = AWS_AGENTIC_INSTRUMENTATION
+            raw_mode = os.environ.get(mode_variable, "auto")
         mode = raw_mode.lower()
         if mode not in ("auto", "enabled", "disabled"):
             _logger.warning(
                 "Unknown %s=%r — falling back to 'auto'. Valid values: auto, enabled, disabled.",
-                ADOT_GENAI_INSTRUMENTATION,
+                mode_variable,
                 raw_mode,
             )
             mode = "auto"
@@ -292,7 +290,7 @@ class AwsOpenTelemetryDistro(OpenTelemetryDistro):
         if mode == "enabled":
             return False
         if mode == "disabled":
-            _logger.debug("Skipping %s: ADOT_GENAI_INSTRUMENTATION=disabled", entry_point.name)
+            _logger.debug("Skipping %s: %s=disabled", entry_point.name, mode_variable)
             return True
 
         # mode == "auto": skip the native side if a same-library third-party is registered.

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/mcp/_wrappers.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/mcp/_wrappers.py
@@ -8,7 +8,7 @@ from contextvars import Token
 from typing import Any, Callable, Coroutine, Dict, Optional, Tuple
 from urllib.parse import urlparse
 
-from amazon.opentelemetry.distro._utils import is_agent_observability_enabled
+from amazon.opentelemetry.distro._utils import get_env, is_agent_observability_enabled
 from amazon.opentelemetry.distro.instrumentation.common.instrumentation_utils import to_tool_attribute_value
 from opentelemetry import context, trace
 from opentelemetry.instrumentation.utils import suppress_http_instrumentation
@@ -60,9 +60,11 @@ class McpWrapper:
     def __init__(self, tracer: trace.Tracer, **kwargs: Any) -> None:
         self._tracer = tracer
         self._propagators = kwargs.get("propagators") or get_global_textmap()
-        suppress_http_instrumentation = os.environ.get(ADOT_INSTRUMENTATION_MCP_SUPPRESS_HTTP_INSTRUMENTATION)
-        if suppress_http_instrumentation is None:
-            suppress_http_instrumentation = os.environ.get(OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION, "true")
+        suppress_http_instrumentation = get_env(
+            ADOT_INSTRUMENTATION_MCP_SUPPRESS_HTTP_INSTRUMENTATION,
+            OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION,
+            "true",
+        )
         self._should_suppress_http_spans = suppress_http_instrumentation.lower() == "true"
         self._agent_observability_enabled = is_agent_observability_enabled()
 

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/mcp/_wrappers.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/mcp/_wrappers.py
@@ -8,7 +8,7 @@ from contextvars import Token
 from typing import Any, Callable, Coroutine, Dict, Optional, Tuple
 from urllib.parse import urlparse
 
-from amazon.opentelemetry.distro._utils import is_agent_observability_enabled
+from amazon.opentelemetry.distro._utils import get_env_with_deprecated_alias, is_agent_observability_enabled
 from amazon.opentelemetry.distro.instrumentation.common.instrumentation_utils import to_tool_attribute_value
 from opentelemetry import context, trace
 from opentelemetry.instrumentation.utils import suppress_http_instrumentation
@@ -38,6 +38,8 @@ from opentelemetry.trace import SpanKind, Status, StatusCode
 
 _LOG = logging.getLogger(__name__)
 
+ADOT_INSTRUMENTATION_MCP_SUPPRESS_HTTP_INSTRUMENTATION = "ADOT_INSTRUMENTATION_MCP_SUPPRESS_HTTP_INSTRUMENTATION"
+# Deprecated: use ADOT_INSTRUMENTATION_MCP_SUPPRESS_HTTP_INSTRUMENTATION.
 OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION = "OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION"
 
 # Context key for storing client transport metadata alongside the session span.
@@ -59,7 +61,12 @@ class McpWrapper:
         self._tracer = tracer
         self._propagators = kwargs.get("propagators") or get_global_textmap()
         self._should_suppress_http_spans = (
-            os.environ.get(OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION, "true").lower() == "true"
+            get_env_with_deprecated_alias(
+                ADOT_INSTRUMENTATION_MCP_SUPPRESS_HTTP_INSTRUMENTATION,
+                OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION,
+                "true",
+            ).lower()
+            == "true"
         )
         self._agent_observability_enabled = is_agent_observability_enabled()
 

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/mcp/_wrappers.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/mcp/_wrappers.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-import os
 from contextlib import asynccontextmanager
 from contextvars import Token
 from typing import Any, Callable, Coroutine, Dict, Optional, Tuple

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/mcp/_wrappers.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/mcp/_wrappers.py
@@ -60,12 +60,14 @@ class McpWrapper:
     def __init__(self, tracer: trace.Tracer, **kwargs: Any) -> None:
         self._tracer = tracer
         self._propagators = kwargs.get("propagators") or get_global_textmap()
-        suppress_http_instrumentation = get_env(
-            ADOT_INSTRUMENTATION_MCP_SUPPRESS_HTTP_INSTRUMENTATION,
-            OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION,
-            "true",
+        self._should_suppress_http_spans = (
+            get_env(
+                ADOT_INSTRUMENTATION_MCP_SUPPRESS_HTTP_INSTRUMENTATION,
+                OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION,
+                "true",
+            ).lower()
+            == "true"
         )
-        self._should_suppress_http_spans = suppress_http_instrumentation.lower() == "true"
         self._agent_observability_enabled = is_agent_observability_enabled()
 
     def _should_suppress_mcp_span(self, message: Any) -> bool:

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/mcp/_wrappers.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/mcp/_wrappers.py
@@ -8,7 +8,7 @@ from contextvars import Token
 from typing import Any, Callable, Coroutine, Dict, Optional, Tuple
 from urllib.parse import urlparse
 
-from amazon.opentelemetry.distro._utils import get_env_with_deprecated_alias, is_agent_observability_enabled
+from amazon.opentelemetry.distro._utils import is_agent_observability_enabled
 from amazon.opentelemetry.distro.instrumentation.common.instrumentation_utils import to_tool_attribute_value
 from opentelemetry import context, trace
 from opentelemetry.instrumentation.utils import suppress_http_instrumentation
@@ -60,14 +60,10 @@ class McpWrapper:
     def __init__(self, tracer: trace.Tracer, **kwargs: Any) -> None:
         self._tracer = tracer
         self._propagators = kwargs.get("propagators") or get_global_textmap()
-        self._should_suppress_http_spans = (
-            get_env_with_deprecated_alias(
-                ADOT_INSTRUMENTATION_MCP_SUPPRESS_HTTP_INSTRUMENTATION,
-                OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION,
-                "true",
-            ).lower()
-            == "true"
-        )
+        suppress_http_instrumentation = os.environ.get(ADOT_INSTRUMENTATION_MCP_SUPPRESS_HTTP_INSTRUMENTATION)
+        if suppress_http_instrumentation is None:
+            suppress_http_instrumentation = os.environ.get(OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION, "true")
+        self._should_suppress_http_spans = suppress_http_instrumentation.lower() == "true"
         self._agent_observability_enabled = is_agent_observability_enabled()
 
     def _should_suppress_mcp_span(self, message: Any) -> bool:

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/openai_agents/__init__.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/openai_agents/__init__.py
@@ -13,8 +13,7 @@ from opentelemetry import trace
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor  # type: ignore
 from opentelemetry.instrumentation.utils import suppress_http_instrumentation
 
-# Opt-in control for replacing the OpenAI Agents SDK trace processors with the
-# ADOT processor, preventing export to the OpenAI trace backend.
+# Disables exporting traces to the OpenAI backend when set to true.
 ADOT_INSTRUMENTATION_OPENAI_AGENTS_DISABLE_TRACE_EXPORT = "ADOT_INSTRUMENTATION_OPENAI_AGENTS_DISABLE_TRACE_EXPORT"
 
 

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/openai_agents/__init__.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/openai_agents/__init__.py
@@ -80,10 +80,11 @@ class OpenAIAgentsInstrumentor(BaseInstrumentor):  # type: ignore
         # disables http spans created from spans sent OpenAI's tracing backend
         try_wrap("agents.tracing.processors", "BackendSpanExporter.export", _suppress_http_instrumentation)
 
-        disable_openai_trace_export = (
-            kwargs.get("disable_openai_trace_export")
-            or os.environ.get(ADOT_INSTRUMENTATION_OPENAI_AGENTS_DISABLE_TRACE_EXPORT, "false").lower() == "true"
-        )
+        disable_openai_trace_export = kwargs.get("disable_openai_trace_export")
+        if disable_openai_trace_export is None:
+            disable_openai_trace_export = (
+                os.environ.get(ADOT_INSTRUMENTATION_OPENAI_AGENTS_DISABLE_TRACE_EXPORT, "false").lower() == "true"
+            )
         if disable_openai_trace_export:
             trace_provider = get_trace_provider()
             multi_processor = getattr(trace_provider, "_multi_processor", None)

--- a/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/openai_agents/__init__.py
+++ b/aws-opentelemetry-distro/src/amazon/opentelemetry/distro/instrumentation/openai_agents/__init__.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import sys
 from typing import Any, Collection
 
@@ -11,6 +12,10 @@ from amazon.opentelemetry.distro.version import __version__
 from opentelemetry import trace
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor  # type: ignore
 from opentelemetry.instrumentation.utils import suppress_http_instrumentation
+
+# Opt-in control for replacing the OpenAI Agents SDK trace processors with the
+# ADOT processor, preventing export to the OpenAI trace backend.
+ADOT_INSTRUMENTATION_OPENAI_AGENTS_DISABLE_TRACE_EXPORT = "ADOT_INSTRUMENTATION_OPENAI_AGENTS_DISABLE_TRACE_EXPORT"
 
 
 class OpenAIAgentsInstrumentor(BaseInstrumentor):  # type: ignore
@@ -76,7 +81,11 @@ class OpenAIAgentsInstrumentor(BaseInstrumentor):  # type: ignore
         # disables http spans created from spans sent OpenAI's tracing backend
         try_wrap("agents.tracing.processors", "BackendSpanExporter.export", _suppress_http_instrumentation)
 
-        if kwargs.get("disable_openai_trace_export"):
+        disable_openai_trace_export = (
+            kwargs.get("disable_openai_trace_export")
+            or os.environ.get(ADOT_INSTRUMENTATION_OPENAI_AGENTS_DISABLE_TRACE_EXPORT, "false").lower() == "true"
+        )
+        if disable_openai_trace_export:
             trace_provider = get_trace_provider()
             multi_processor = getattr(trace_provider, "_multi_processor", None)
             self._previous_processors = tuple(getattr(multi_processor, "_processors", ()))

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/mcp/test_mcp_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/mcp/test_mcp_instrumentor.py
@@ -17,7 +17,10 @@ from unittest import TestCase
 from collector import OTLPServer, Telemetry
 
 from amazon.opentelemetry.distro.instrumentation.mcp import McpInstrumentor
-from amazon.opentelemetry.distro.instrumentation.mcp._wrappers import OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION
+from amazon.opentelemetry.distro.instrumentation.mcp._wrappers import (
+    ADOT_INSTRUMENTATION_MCP_SUPPRESS_HTTP_INSTRUMENTATION,
+    OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION,
+)
 from opentelemetry.baggage.propagation import W3CBaggagePropagator
 
 try:
@@ -492,19 +495,21 @@ class TestMcpInstrumentorInProcess(McpInstrumentorTestBase):
         self.assertEqual(format(server_span.context.trace_id, "032x"), expected_trace_id)
 
     def test_http_span_suppression(self):
-        for suppress_value, expect_post_spans in [("false", True), ("true", False), (None, False)]:
-            label = f"suppress={suppress_value}" if suppress_value else "suppress=default"
+        cases = [
+            ({ADOT_INSTRUMENTATION_MCP_SUPPRESS_HTTP_INSTRUMENTATION: "false"}, True, "adot=false"),
+            ({ADOT_INSTRUMENTATION_MCP_SUPPRESS_HTTP_INSTRUMENTATION: "true"}, False, "adot=true"),
+            ({OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION: "false"}, True, "deprecated=false"),
+            ({}, False, "default"),
+        ]
+        for patch_env, expect_post_spans, label in cases:
             with self.subTest(label):
                 self.instrumentor.uninstrument()
                 self.span_exporter.clear()
 
-                patch_env = {}
-                if suppress_value is not None:
-                    patch_env[OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION] = suppress_value
-
-                with unittest.mock.patch.dict(os.environ, patch_env):
-                    if suppress_value is None:
-                        os.environ.pop(OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION, None)
+                with unittest.mock.patch.dict(os.environ, {}, clear=False):
+                    os.environ.pop(ADOT_INSTRUMENTATION_MCP_SUPPRESS_HTTP_INSTRUMENTATION, None)
+                    os.environ.pop(OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION, None)
+                    os.environ.update(patch_env)
 
                     self.instrumentor.instrument(tracer_provider=self.tracer_provider, propagators=self.propagator)
                     self.server = self._create_server()
@@ -596,13 +601,16 @@ class TestMcpInstrumentorInProcess(McpInstrumentorTestBase):
         self.assertEqual(client_trace_id, server_trace_id, "Server span should be on same trace as client")
 
     def test_prepare_headers_skips_inject_when_not_suppressed(self):
-        """When ``OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION=false``, the httpx client
+        """When ``ADOT_INSTRUMENTATION_MCP_SUPPRESS_HTTP_INSTRUMENTATION=false``, the httpx client
         instrumentation handles header injection itself, so ``wrap_prepare_headers``
         should NOT inject (to avoid duplicate traceparent writes)."""
         self.instrumentor.uninstrument()
         self.span_exporter.clear()
 
-        with unittest.mock.patch.dict(os.environ, {OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION: "false"}):
+        with unittest.mock.patch.dict(
+            os.environ,
+            {ADOT_INSTRUMENTATION_MCP_SUPPRESS_HTTP_INSTRUMENTATION: "false"},
+        ):
             self.instrumentor.instrument(tracer_provider=self.tracer_provider, propagators=self.propagator)
             self.server = self._create_server()
 

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/mcp/test_mcp_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/mcp/test_mcp_instrumentor.py
@@ -496,13 +496,13 @@ class TestMcpInstrumentorInProcess(McpInstrumentorTestBase):
 
     def test_http_span_suppression(self):
         cases = [
-            ({ADOT_INSTRUMENTATION_MCP_SUPPRESS_HTTP_INSTRUMENTATION: "false"}, True, "adot=false"),
-            ({ADOT_INSTRUMENTATION_MCP_SUPPRESS_HTTP_INSTRUMENTATION: "true"}, False, "adot=true"),
-            ({OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION: "false"}, True, "deprecated=false"),
+            ({ADOT_INSTRUMENTATION_MCP_SUPPRESS_HTTP_INSTRUMENTATION: "false"}, True, "adot-false"),
+            ({ADOT_INSTRUMENTATION_MCP_SUPPRESS_HTTP_INSTRUMENTATION: "true"}, False, "adot-true"),
+            ({OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION: "false"}, True, "deprecated-false"),
             ({}, False, "default"),
         ]
-        for patch_env, expect_post_spans, label in cases:
-            with self.subTest(label):
+        for patch_env, expect_post_spans, mode in cases:
+            with self.subTest(mode=mode):
                 self.instrumentor.uninstrument()
                 self.span_exporter.clear()
 

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/openai_agents/test_openai_agents_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/openai_agents/test_openai_agents_instrumentor.py
@@ -3,10 +3,11 @@
 
 import asyncio
 import json
+import os
 import unittest
 from importlib.metadata import entry_points
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import litellm
 from agents import Agent, ModelSettings, OpenAIChatCompletionsModel, RunConfig, Runner, function_tool, tracing
@@ -18,7 +19,10 @@ from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
 from openai import NOT_GIVEN, Omit
 from pydantic import BaseModel
 
-from amazon.opentelemetry.distro.instrumentation.openai_agents import OpenAIAgentsInstrumentor
+from amazon.opentelemetry.distro.instrumentation.openai_agents import (
+    ADOT_INSTRUMENTATION_OPENAI_AGENTS_DISABLE_TRACE_EXPORT,
+    OpenAIAgentsInstrumentor,
+)
 from amazon.opentelemetry.distro.instrumentation.openai_agents._gen_ai_context_capture import GenAICapturingContext
 from amazon.opentelemetry.distro.instrumentation.openai_agents._processor import (
     GEN_AI_REQUEST_REASONING_LEVEL,
@@ -166,6 +170,17 @@ class TestOpenAIAgentsInstrumentor(unittest.TestCase):
         current = tracing.get_trace_provider()._multi_processor._processors  # pylint: disable=protected-access
         self.assertEqual(current, (existing_processor,))
         self.assertIsNone(self.instrumentor._processor)  # pylint: disable=protected-access
+
+    def test_disable_openai_trace_export_with_env_var(self):
+        existing_processor = MagicMock()
+        tracing.set_trace_processors([existing_processor])
+
+        with patch.dict(os.environ, {ADOT_INSTRUMENTATION_OPENAI_AGENTS_DISABLE_TRACE_EXPORT: "TrUe"}):
+            self.instrumentor.instrument(skip_dep_check=True)
+
+        processor = self.instrumentor._processor  # pylint: disable=protected-access
+        current = tracing.get_trace_provider()._multi_processor._processors  # pylint: disable=protected-access
+        self.assertEqual(current, (processor,))
 
     def test_openai_trace_export_produces_no_http_spans(self):
         exporter = InMemorySpanExporter()

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/openai_agents/test_openai_agents_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/openai_agents/test_openai_agents_instrumentor.py
@@ -158,29 +158,26 @@ class TestOpenAIAgentsInstrumentor(unittest.TestCase):
         self.assertIs(litellm.acompletion, original_acompletion)
 
     def test_disable_openai_trace_export_restores_previous_processors(self):
-        existing_processor = MagicMock()
-        tracing.set_trace_processors([existing_processor])
+        cases = [
+            ("kwarg", {"disable_openai_trace_export": True}, {}),
+            ("environment", {}, {ADOT_INSTRUMENTATION_OPENAI_AGENTS_DISABLE_TRACE_EXPORT: "TrUe"}),
+        ]
+        for mode, instrument_kwargs, environment in cases:
+            with self.subTest(mode=mode), patch.dict(os.environ, {}, clear=False):
+                os.environ.pop(ADOT_INSTRUMENTATION_OPENAI_AGENTS_DISABLE_TRACE_EXPORT, None)
+                os.environ.update(environment)
+                existing_processor = MagicMock()
+                tracing.set_trace_processors([existing_processor])
 
-        self.instrumentor.instrument(disable_openai_trace_export=True, skip_dep_check=True)
-        processor = self.instrumentor._processor  # pylint: disable=protected-access
-        current = tracing.get_trace_provider()._multi_processor._processors  # pylint: disable=protected-access
-        self.assertEqual(current, (processor,))
+                self.instrumentor.instrument(skip_dep_check=True, **instrument_kwargs)
+                processor = self.instrumentor._processor  # pylint: disable=protected-access
+                current = tracing.get_trace_provider()._multi_processor._processors  # pylint: disable=protected-access
+                self.assertEqual(current, (processor,))
 
-        self.instrumentor.uninstrument()
-        current = tracing.get_trace_provider()._multi_processor._processors  # pylint: disable=protected-access
-        self.assertEqual(current, (existing_processor,))
-        self.assertIsNone(self.instrumentor._processor)  # pylint: disable=protected-access
-
-    def test_disable_openai_trace_export_with_env_var(self):
-        existing_processor = MagicMock()
-        tracing.set_trace_processors([existing_processor])
-
-        with patch.dict(os.environ, {ADOT_INSTRUMENTATION_OPENAI_AGENTS_DISABLE_TRACE_EXPORT: "TrUe"}):
-            self.instrumentor.instrument(skip_dep_check=True)
-
-        processor = self.instrumentor._processor  # pylint: disable=protected-access
-        current = tracing.get_trace_provider()._multi_processor._processors  # pylint: disable=protected-access
-        self.assertEqual(current, (processor,))
+                self.instrumentor.uninstrument()
+                current = tracing.get_trace_provider()._multi_processor._processors  # pylint: disable=protected-access
+                self.assertEqual(current, (existing_processor,))
+                self.assertIsNone(self.instrumentor._processor)  # pylint: disable=protected-access
 
     def test_openai_trace_export_produces_no_http_spans(self):
         exporter = InMemorySpanExporter()

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/openai_agents/test_openai_agents_instrumentor.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/openai_agents/test_openai_agents_instrumentor.py
@@ -159,10 +159,16 @@ class TestOpenAIAgentsInstrumentor(unittest.TestCase):
 
     def test_disable_openai_trace_export_restores_previous_processors(self):
         cases = [
-            ("kwarg", {"disable_openai_trace_export": True}, {}),
-            ("environment", {}, {ADOT_INSTRUMENTATION_OPENAI_AGENTS_DISABLE_TRACE_EXPORT: "TrUe"}),
+            ("kwarg", {"disable_openai_trace_export": True}, {}, True),
+            ("environment", {}, {ADOT_INSTRUMENTATION_OPENAI_AGENTS_DISABLE_TRACE_EXPORT: "TrUe"}, True),
+            (
+                "kwarg_false_overrides_environment",
+                {"disable_openai_trace_export": False},
+                {ADOT_INSTRUMENTATION_OPENAI_AGENTS_DISABLE_TRACE_EXPORT: "true"},
+                False,
+            ),
         ]
-        for mode, instrument_kwargs, environment in cases:
+        for mode, instrument_kwargs, environment, export_disabled in cases:
             with self.subTest(mode=mode), patch.dict(os.environ, {}, clear=False):
                 os.environ.pop(ADOT_INSTRUMENTATION_OPENAI_AGENTS_DISABLE_TRACE_EXPORT, None)
                 os.environ.update(environment)
@@ -172,7 +178,8 @@ class TestOpenAIAgentsInstrumentor(unittest.TestCase):
                 self.instrumentor.instrument(skip_dep_check=True, **instrument_kwargs)
                 processor = self.instrumentor._processor  # pylint: disable=protected-access
                 current = tracing.get_trace_provider()._multi_processor._processors  # pylint: disable=protected-access
-                self.assertEqual(current, (processor,))
+                expected = (processor,) if export_disabled else (existing_processor, processor)
+                self.assertEqual(current, expected)
 
                 self.instrumentor.uninstrument()
                 current = tracing.get_trace_provider()._multi_processor._processors  # pylint: disable=protected-access

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelemetry_distro.py
@@ -11,7 +11,6 @@ from unittest.mock import MagicMock, patch
 from amazon.opentelemetry.distro.aws_opentelemetry_configurator import APPLICATION_SIGNALS_ENABLED_CONFIG
 from amazon.opentelemetry.distro.aws_opentelemetry_distro import (
     ADOT_GENAI_INSTRUMENTATION,
-    ADOT_INSTRUMENTATION_OPENAI_AGENTS_DISABLE_TRACE_EXPORT,
     AWS_AGENTIC_INSTRUMENTATION,
     AwsOpenTelemetryDistro,
 )
@@ -64,7 +63,6 @@ class TestAwsOpenTelemetryDistro(TestCase):
             OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,
             ADOT_GENAI_INSTRUMENTATION,
             AWS_AGENTIC_INSTRUMENTATION,
-            ADOT_INSTRUMENTATION_OPENAI_AGENTS_DISABLE_TRACE_EXPORT,
             "CREWAI_DISABLE_TELEMETRY",
         ]
 
@@ -640,14 +638,6 @@ class TestAwsOpenTelemetryDistro(TestCase):
         third_party = [self._make_ep("openai_agents", "openinference-instrumentation-openai-agents")]
         mock_super = self._load_instrumentor_with_agent(ep, third_party_eps=third_party)
         mock_super.assert_not_called()
-
-    def test_openai_agents_trace_export_can_be_disabled(self):
-        ep = self._make_ep("aws_openai_agents", "aws-opentelemetry-distro")
-        os.environ[ADOT_INSTRUMENTATION_OPENAI_AGENTS_DISABLE_TRACE_EXPORT] = "TrUe"
-
-        mock_super = self._load_instrumentor_with_agent(ep)
-
-        mock_super.assert_called_once_with(ep, disable_openai_trace_export=True)
 
     def _configure_with_agent_observability(self, region="us-west-2"):
         with patch("amazon.opentelemetry.distro.aws_opentelemetry_distro.OpenTelemetryDistro._configure"), patch(

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelemetry_distro.py
@@ -518,18 +518,16 @@ class TestAwsOpenTelemetryDistro(TestCase):
         self,
         ep,
         third_party_eps=None,
-        mode=None,
-        mode_variable=ADOT_GENAI_INSTRUMENTATION,
+        environment=None,
     ):
         """Helper to test load_instrumentor with agent observability enabled.
 
-        mode: None (unset → auto), "auto", "enabled", or "disabled".
+        environment: Environment variable values to set for the test.
         """
         distro = AwsOpenTelemetryDistro()
         os.environ.pop(ADOT_GENAI_INSTRUMENTATION, None)
         os.environ.pop(AWS_AGENTIC_INSTRUMENTATION, None)
-        if mode is not None:
-            os.environ[mode_variable] = mode
+        os.environ.update(environment or {})
         with patch(
             "amazon.opentelemetry.distro.aws_opentelemetry_distro.is_agent_observability_enabled", return_value=True
         ), patch(
@@ -566,13 +564,20 @@ class TestAwsOpenTelemetryDistro(TestCase):
         """
         ep = self._make_ep("aws_langchain", "aws-opentelemetry-distro")
         third_party = [self._make_ep("langchain", "openinference-instrumentation-langchain")]
-        for mode_variable in (ADOT_GENAI_INSTRUMENTATION, AWS_AGENTIC_INSTRUMENTATION):
-            with self.subTest(mode_variable=mode_variable):
+        environments = [
+            {ADOT_GENAI_INSTRUMENTATION: "enabled"},
+            {AWS_AGENTIC_INSTRUMENTATION: "enabled"},
+            {
+                ADOT_GENAI_INSTRUMENTATION: "enabled",
+                AWS_AGENTIC_INSTRUMENTATION: "disabled",
+            },
+        ]
+        for environment in environments:
+            with self.subTest(environment=environment):
                 mock_super = self._load_instrumentor_with_agent(
                     ep,
                     third_party_eps=third_party,
-                    mode="enabled",
-                    mode_variable=mode_variable,
+                    environment=environment,
                 )
                 mock_super.assert_called_once_with(ep)
 
@@ -580,7 +585,11 @@ class TestAwsOpenTelemetryDistro(TestCase):
         """Third-party langchain still loads under mode=enabled — only the aws_* side is governed."""
         ep = self._make_ep("langchain", "openinference-instrumentation-langchain")
         third_party = [self._make_ep("langchain", "openinference-instrumentation-langchain")]
-        mock_super = self._load_instrumentor_with_agent(ep, third_party_eps=third_party, mode="enabled")
+        mock_super = self._load_instrumentor_with_agent(
+            ep,
+            third_party_eps=third_party,
+            environment={ADOT_GENAI_INSTRUMENTATION: "enabled"},
+        )
         mock_super.assert_called_once_with(ep)
 
     def test_skip_native_when_mode_disabled(self):
@@ -588,8 +597,13 @@ class TestAwsOpenTelemetryDistro(TestCase):
         AWS_AGENTIC_INSTRUMENTATION is disabled.
         """
         ep = self._make_ep("aws_langchain", "aws-opentelemetry-distro")
-        for mode_variable in (ADOT_GENAI_INSTRUMENTATION, AWS_AGENTIC_INSTRUMENTATION):
-            with self.subTest(mode_variable=mode_variable):
+        environments = [
+            {ADOT_GENAI_INSTRUMENTATION: "disabled"},
+            {AWS_AGENTIC_INSTRUMENTATION: "disabled"},
+        ]
+        for environment in environments:
+            mode_variable = next(iter(environment))
+            with self.subTest(environment=environment):
                 with self.assertLogs(
                     "amazon.opentelemetry.distro.aws_opentelemetry_distro",
                     level="DEBUG",
@@ -597,8 +611,7 @@ class TestAwsOpenTelemetryDistro(TestCase):
                     mock_super = self._load_instrumentor_with_agent(
                         ep,
                         third_party_eps=[],
-                        mode="disabled",
-                        mode_variable=mode_variable,
+                        environment=environment,
                     )
                 mock_super.assert_not_called()
                 self.assertTrue(any(f"{mode_variable}=disabled" in line for line in logs.output))
@@ -609,13 +622,16 @@ class TestAwsOpenTelemetryDistro(TestCase):
         """
         ep = self._make_ep("langchain", "openinference-instrumentation-langchain")
         third_party = [self._make_ep("langchain", "openinference-instrumentation-langchain")]
-        for mode_variable in (ADOT_GENAI_INSTRUMENTATION, AWS_AGENTIC_INSTRUMENTATION):
-            with self.subTest(mode_variable=mode_variable):
+        environments = [
+            {ADOT_GENAI_INSTRUMENTATION: "disabled"},
+            {AWS_AGENTIC_INSTRUMENTATION: "disabled"},
+        ]
+        for environment in environments:
+            with self.subTest(environment=environment):
                 mock_super = self._load_instrumentor_with_agent(
                     ep,
                     third_party_eps=third_party,
-                    mode="disabled",
-                    mode_variable=mode_variable,
+                    environment=environment,
                 )
                 mock_super.assert_called_once_with(ep)
 
@@ -623,16 +639,20 @@ class TestAwsOpenTelemetryDistro(TestCase):
         """An unrecognized value should warn (with the raw casing) and behave like auto."""
         ep = self._make_ep("aws_langchain", "aws-opentelemetry-distro")
         third_party = [self._make_ep("langchain", "openinference-instrumentation-langchain")]
-        for mode_variable in (ADOT_GENAI_INSTRUMENTATION, AWS_AGENTIC_INSTRUMENTATION):
-            with self.subTest(mode_variable=mode_variable), self.assertLogs(
+        environments = [
+            {ADOT_GENAI_INSTRUMENTATION: "BoGuS"},
+            {AWS_AGENTIC_INSTRUMENTATION: "BoGuS"},
+        ]
+        for environment in environments:
+            mode_variable = next(iter(environment))
+            with self.subTest(environment=environment), self.assertLogs(
                 "amazon.opentelemetry.distro.aws_opentelemetry_distro",
                 level="WARNING",
             ) as logs:
                 mock_super = self._load_instrumentor_with_agent(
                     ep,
                     third_party_eps=third_party,
-                    mode="BoGuS",
-                    mode_variable=mode_variable,
+                    environment=environment,
                 )
             mock_super.assert_not_called()
             self.assertTrue(
@@ -646,15 +666,27 @@ class TestAwsOpenTelemetryDistro(TestCase):
         third_party = [self._make_ep("langchain", "openinference-instrumentation-langchain")]
 
         # ENABLED — load aws_* even with same-library third-party present
-        mock_super = self._load_instrumentor_with_agent(ep, third_party_eps=third_party, mode="ENABLED")
+        mock_super = self._load_instrumentor_with_agent(
+            ep,
+            third_party_eps=third_party,
+            environment={ADOT_GENAI_INSTRUMENTATION: "ENABLED"},
+        )
         mock_super.assert_called_once_with(ep)
 
         # Disabled — skip aws_*
-        mock_super = self._load_instrumentor_with_agent(ep, third_party_eps=[], mode="Disabled")
+        mock_super = self._load_instrumentor_with_agent(
+            ep,
+            third_party_eps=[],
+            environment={ADOT_GENAI_INSTRUMENTATION: "Disabled"},
+        )
         mock_super.assert_not_called()
 
         # Auto — same as unset, skip native because third-party covers it
-        mock_super = self._load_instrumentor_with_agent(ep, third_party_eps=third_party, mode="Auto")
+        mock_super = self._load_instrumentor_with_agent(
+            ep,
+            third_party_eps=third_party,
+            environment={ADOT_GENAI_INSTRUMENTATION: "Auto"},
+        )
         mock_super.assert_not_called()
 
     def test_load_regular_instrumentor(self):

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelemetry_distro.py
@@ -564,8 +564,15 @@ class TestAwsOpenTelemetryDistro(TestCase):
         """aws_langchain should load when ADOT_GENAI_INSTRUMENTATION=enabled even if third-party registered."""
         ep = self._make_ep("aws_langchain", "aws-opentelemetry-distro")
         third_party = [self._make_ep("langchain", "openinference-instrumentation-langchain")]
-        mock_super = self._load_instrumentor_with_agent(ep, third_party_eps=third_party, mode="enabled")
-        mock_super.assert_called_once_with(ep)
+        for mode_variable in (ADOT_GENAI_INSTRUMENTATION, AWS_AGENTIC_INSTRUMENTATION):
+            with self.subTest(mode_variable=mode_variable):
+                mock_super = self._load_instrumentor_with_agent(
+                    ep,
+                    third_party_eps=third_party,
+                    mode="enabled",
+                    mode_variable=mode_variable,
+                )
+                mock_super.assert_called_once_with(ep)
 
     def test_load_third_party_when_mode_enabled(self):
         """Third-party langchain still loads under mode=enabled — only the aws_* side is governed."""
@@ -612,19 +619,6 @@ class TestAwsOpenTelemetryDistro(TestCase):
         # Auto — same as unset, skip native because third-party covers it
         mock_super = self._load_instrumentor_with_agent(ep, third_party_eps=third_party, mode="Auto")
         mock_super.assert_not_called()
-
-    def test_deprecated_agentic_instrumentation_name_still_works(self):
-        ep = self._make_ep("aws_langchain", "aws-opentelemetry-distro")
-        third_party = [self._make_ep("langchain", "openinference-instrumentation-langchain")]
-
-        mock_super = self._load_instrumentor_with_agent(
-            ep,
-            third_party_eps=third_party,
-            mode="enabled",
-            mode_variable=AWS_AGENTIC_INSTRUMENTATION,
-        )
-
-        mock_super.assert_called_once_with(ep)
 
     def test_load_regular_instrumentor(self):
         """Regular instrumentors should always be loaded."""

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelemetry_distro.py
@@ -590,13 +590,18 @@ class TestAwsOpenTelemetryDistro(TestCase):
         ep = self._make_ep("aws_langchain", "aws-opentelemetry-distro")
         for mode_variable in (ADOT_GENAI_INSTRUMENTATION, AWS_AGENTIC_INSTRUMENTATION):
             with self.subTest(mode_variable=mode_variable):
-                mock_super = self._load_instrumentor_with_agent(
-                    ep,
-                    third_party_eps=[],
-                    mode="disabled",
-                    mode_variable=mode_variable,
-                )
+                with self.assertLogs(
+                    "amazon.opentelemetry.distro.aws_opentelemetry_distro",
+                    level="DEBUG",
+                ) as logs:
+                    mock_super = self._load_instrumentor_with_agent(
+                        ep,
+                        third_party_eps=[],
+                        mode="disabled",
+                        mode_variable=mode_variable,
+                    )
                 mock_super.assert_not_called()
+                self.assertTrue(any(f"{mode_variable}=disabled" in line for line in logs.output))
 
     def test_load_third_party_when_mode_disabled(self):
         """Third-party langchain should load when ADOT_GENAI_INSTRUMENTATION or
@@ -618,10 +623,22 @@ class TestAwsOpenTelemetryDistro(TestCase):
         """An unrecognized value should warn (with the raw casing) and behave like auto."""
         ep = self._make_ep("aws_langchain", "aws-opentelemetry-distro")
         third_party = [self._make_ep("langchain", "openinference-instrumentation-langchain")]
-        with self.assertLogs("amazon.opentelemetry.distro.aws_opentelemetry_distro", level="WARNING") as cm:
-            mock_super = self._load_instrumentor_with_agent(ep, third_party_eps=third_party, mode="BoGuS")
-        mock_super.assert_not_called()
-        self.assertTrue(any("'BoGuS'" in line for line in cm.output), cm.output)
+        for mode_variable in (ADOT_GENAI_INSTRUMENTATION, AWS_AGENTIC_INSTRUMENTATION):
+            with self.subTest(mode_variable=mode_variable), self.assertLogs(
+                "amazon.opentelemetry.distro.aws_opentelemetry_distro",
+                level="WARNING",
+            ) as logs:
+                mock_super = self._load_instrumentor_with_agent(
+                    ep,
+                    third_party_eps=third_party,
+                    mode="BoGuS",
+                    mode_variable=mode_variable,
+                )
+            mock_super.assert_not_called()
+            self.assertTrue(
+                any(mode_variable in line and "'BoGuS'" in line for line in logs.output),
+                logs.output,
+            )
 
     def test_mode_value_is_case_insensitive(self):
         """Values like ENABLED / Disabled / Auto should be accepted."""

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelemetry_distro.py
@@ -9,7 +9,12 @@ from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 from amazon.opentelemetry.distro.aws_opentelemetry_configurator import APPLICATION_SIGNALS_ENABLED_CONFIG
-from amazon.opentelemetry.distro.aws_opentelemetry_distro import AwsOpenTelemetryDistro
+from amazon.opentelemetry.distro.aws_opentelemetry_distro import (
+    ADOT_GENAI_INSTRUMENTATION,
+    ADOT_INSTRUMENTATION_OPENAI_AGENTS_DISABLE_TRACE_EXPORT,
+    AWS_AGENTIC_INSTRUMENTATION,
+    AwsOpenTelemetryDistro,
+)
 from opentelemetry import propagate
 from opentelemetry.distro import OpenTelemetryDistro
 from opentelemetry.environment_variables import (
@@ -57,7 +62,9 @@ class TestAwsOpenTelemetryDistro(TestCase):
             "DJANGO_SETTINGS_MODULE",
             OTEL_EXPORTER_OTLP_ENDPOINT,
             OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,
-            "AWS_AGENTIC_INSTRUMENTATION",
+            ADOT_GENAI_INSTRUMENTATION,
+            AWS_AGENTIC_INSTRUMENTATION,
+            ADOT_INSTRUMENTATION_OPENAI_AGENTS_DISABLE_TRACE_EXPORT,
             "CREWAI_DISABLE_TELEMETRY",
         ]
 
@@ -509,15 +516,22 @@ class TestAwsOpenTelemetryDistro(TestCase):
             ep.dist = None
         return ep
 
-    def _load_instrumentor_with_agent(self, ep, third_party_eps=None, mode=None):
+    def _load_instrumentor_with_agent(
+        self,
+        ep,
+        third_party_eps=None,
+        mode=None,
+        mode_variable=ADOT_GENAI_INSTRUMENTATION,
+    ):
         """Helper to test load_instrumentor with agent observability enabled.
 
         mode: None (unset → auto), "auto", "enabled", or "disabled".
         """
         distro = AwsOpenTelemetryDistro()
-        os.environ.pop("AWS_AGENTIC_INSTRUMENTATION", None)
+        os.environ.pop(ADOT_GENAI_INSTRUMENTATION, None)
+        os.environ.pop(AWS_AGENTIC_INSTRUMENTATION, None)
         if mode is not None:
-            os.environ["AWS_AGENTIC_INSTRUMENTATION"] = mode
+            os.environ[mode_variable] = mode
         with patch(
             "amazon.opentelemetry.distro.aws_opentelemetry_distro.is_agent_observability_enabled", return_value=True
         ), patch(
@@ -549,7 +563,7 @@ class TestAwsOpenTelemetryDistro(TestCase):
         mock_super.assert_called_once_with(ep)
 
     def test_load_native_when_mode_enabled(self):
-        """aws_langchain should load when AWS_AGENTIC_INSTRUMENTATION=enabled even if third-party registered."""
+        """aws_langchain should load when ADOT_GENAI_INSTRUMENTATION=enabled even if third-party registered."""
         ep = self._make_ep("aws_langchain", "aws-opentelemetry-distro")
         third_party = [self._make_ep("langchain", "openinference-instrumentation-langchain")]
         mock_super = self._load_instrumentor_with_agent(ep, third_party_eps=third_party, mode="enabled")
@@ -563,13 +577,13 @@ class TestAwsOpenTelemetryDistro(TestCase):
         mock_super.assert_called_once_with(ep)
 
     def test_skip_native_when_mode_disabled(self):
-        """aws_langchain should be skipped when AWS_AGENTIC_INSTRUMENTATION=disabled, even with no third-party."""
+        """aws_langchain should be skipped when ADOT_GENAI_INSTRUMENTATION=disabled, even with no third-party."""
         ep = self._make_ep("aws_langchain", "aws-opentelemetry-distro")
         mock_super = self._load_instrumentor_with_agent(ep, third_party_eps=[], mode="disabled")
         mock_super.assert_not_called()
 
     def test_load_third_party_when_mode_disabled(self):
-        """Third-party langchain should load when AWS_AGENTIC_INSTRUMENTATION=disabled."""
+        """Third-party langchain should load when ADOT_GENAI_INSTRUMENTATION=disabled."""
         ep = self._make_ep("langchain", "openinference-instrumentation-langchain")
         third_party = [self._make_ep("langchain", "openinference-instrumentation-langchain")]
         mock_super = self._load_instrumentor_with_agent(ep, third_party_eps=third_party, mode="disabled")
@@ -601,6 +615,19 @@ class TestAwsOpenTelemetryDistro(TestCase):
         mock_super = self._load_instrumentor_with_agent(ep, third_party_eps=third_party, mode="Auto")
         mock_super.assert_not_called()
 
+    def test_deprecated_agentic_instrumentation_name_still_works(self):
+        ep = self._make_ep("aws_langchain", "aws-opentelemetry-distro")
+        third_party = [self._make_ep("langchain", "openinference-instrumentation-langchain")]
+
+        mock_super = self._load_instrumentor_with_agent(
+            ep,
+            third_party_eps=third_party,
+            mode="enabled",
+            mode_variable=AWS_AGENTIC_INSTRUMENTATION,
+        )
+
+        mock_super.assert_called_once_with(ep)
+
     def test_load_regular_instrumentor(self):
         """Regular instrumentors should always be loaded."""
         ep = self._make_ep("flask", "opentelemetry-instrumentation-flask")
@@ -613,6 +640,14 @@ class TestAwsOpenTelemetryDistro(TestCase):
         third_party = [self._make_ep("openai_agents", "openinference-instrumentation-openai-agents")]
         mock_super = self._load_instrumentor_with_agent(ep, third_party_eps=third_party)
         mock_super.assert_not_called()
+
+    def test_openai_agents_trace_export_can_be_disabled(self):
+        ep = self._make_ep("aws_openai_agents", "aws-opentelemetry-distro")
+        os.environ[ADOT_INSTRUMENTATION_OPENAI_AGENTS_DISABLE_TRACE_EXPORT] = "TrUe"
+
+        mock_super = self._load_instrumentor_with_agent(ep)
+
+        mock_super.assert_called_once_with(ep, disable_openai_trace_export=True)
 
     def _configure_with_agent_observability(self, region="us-west-2"):
         with patch("amazon.opentelemetry.distro.aws_opentelemetry_distro.OpenTelemetryDistro._configure"), patch(

--- a/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelemetry_distro.py
+++ b/aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelemetry_distro.py
@@ -561,7 +561,9 @@ class TestAwsOpenTelemetryDistro(TestCase):
         mock_super.assert_called_once_with(ep)
 
     def test_load_native_when_mode_enabled(self):
-        """aws_langchain should load when ADOT_GENAI_INSTRUMENTATION=enabled even if third-party registered."""
+        """aws_langchain should load when ADOT_GENAI_INSTRUMENTATION or
+        AWS_AGENTIC_INSTRUMENTATION is enabled, even if a third party is registered.
+        """
         ep = self._make_ep("aws_langchain", "aws-opentelemetry-distro")
         third_party = [self._make_ep("langchain", "openinference-instrumentation-langchain")]
         for mode_variable in (ADOT_GENAI_INSTRUMENTATION, AWS_AGENTIC_INSTRUMENTATION):
@@ -582,17 +584,35 @@ class TestAwsOpenTelemetryDistro(TestCase):
         mock_super.assert_called_once_with(ep)
 
     def test_skip_native_when_mode_disabled(self):
-        """aws_langchain should be skipped when ADOT_GENAI_INSTRUMENTATION=disabled, even with no third-party."""
+        """aws_langchain should be skipped when ADOT_GENAI_INSTRUMENTATION or
+        AWS_AGENTIC_INSTRUMENTATION is disabled.
+        """
         ep = self._make_ep("aws_langchain", "aws-opentelemetry-distro")
-        mock_super = self._load_instrumentor_with_agent(ep, third_party_eps=[], mode="disabled")
-        mock_super.assert_not_called()
+        for mode_variable in (ADOT_GENAI_INSTRUMENTATION, AWS_AGENTIC_INSTRUMENTATION):
+            with self.subTest(mode_variable=mode_variable):
+                mock_super = self._load_instrumentor_with_agent(
+                    ep,
+                    third_party_eps=[],
+                    mode="disabled",
+                    mode_variable=mode_variable,
+                )
+                mock_super.assert_not_called()
 
     def test_load_third_party_when_mode_disabled(self):
-        """Third-party langchain should load when ADOT_GENAI_INSTRUMENTATION=disabled."""
+        """Third-party langchain should load when ADOT_GENAI_INSTRUMENTATION or
+        AWS_AGENTIC_INSTRUMENTATION is disabled.
+        """
         ep = self._make_ep("langchain", "openinference-instrumentation-langchain")
         third_party = [self._make_ep("langchain", "openinference-instrumentation-langchain")]
-        mock_super = self._load_instrumentor_with_agent(ep, third_party_eps=third_party, mode="disabled")
-        mock_super.assert_called_once_with(ep)
+        for mode_variable in (ADOT_GENAI_INSTRUMENTATION, AWS_AGENTIC_INSTRUMENTATION):
+            with self.subTest(mode_variable=mode_variable):
+                mock_super = self._load_instrumentor_with_agent(
+                    ep,
+                    third_party_eps=third_party,
+                    mode="disabled",
+                    mode_variable=mode_variable,
+                )
+                mock_super.assert_called_once_with(ep)
 
     def test_unknown_mode_falls_back_to_auto(self):
         """An unrecognized value should warn (with the raw casing) and behave like auto."""


### PR DESCRIPTION
## Summary

- add `AWS_GENAI_INSTRUMENTATION` and retain `AWS_AGENTIC_INSTRUMENTATION` as a legacy fallback
- add `AWS_INSTRUMENTATION_MCP_SUPPRESS_HTTP_INSTRUMENTATION` and retain `OTEL_MCP_SUPPRESS_HTTP_INSTRUMENTATION` as a legacy fallback
- add the opt-in `AWS_INSTRUMENTATION_OPENAI_AGENTS_DISABLE_OPENAI_EXPORT` control
- rename the unreleased span attribute redaction control to `AWS_REDACT_SPAN_ATTRIBUTES`
- preserve all existing defaults and give the new AWS names precedence over legacy fallback names

## Testing

- `PYTHONPATH=aws-opentelemetry-distro/src python -m pytest -q aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelemetry_distro.py`
- `PYTHONPATH=aws-opentelemetry-distro/src python -m pytest -q aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/mcp/test_mcp_instrumentor.py::TestMcpInstrumentorInProcess::test_http_span_suppression aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/mcp/test_mcp_instrumentor.py::TestMcpInstrumentorInProcess::test_prepare_headers_skips_inject_when_not_suppressed`
- `PYTHONPATH=aws-opentelemetry-distro/src python -m pytest -q aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/instrumentation/openai_agents/test_openai_agents_instrumentor.py::TestOpenAIAgentsInstrumentor::test_disable_openai_trace_export_restores_previous_processors`
- `PYTHONPATH=aws-opentelemetry-distro/src python -m pytest -q aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_attribute_redacting_span_processor.py`
- `PYTHONPATH=aws-opentelemetry-distro/src python -m pytest -q aws-opentelemetry-distro/tests/amazon/opentelemetry/distro/test_aws_opentelementry_configurator.py::TestAwsOpenTelemetryConfigurator::test_customize_span_processors_with_agent_observability`
- targeted Black, isort, Flake8, and `git diff --check`
